### PR TITLE
Add migration analyzer for MySQL 8.0.x to 8.4.x upgrade support

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -3,9 +3,11 @@ from .tunnel_engine import TunnelEngine
 from .db_connector import MySQLConnector, test_mysql_connection
 from .github_issue_reporter import GitHubIssueReporter, get_reporter_from_config
 from .github_app_auth import GitHubAppAuth, get_github_app_auth, is_github_app_configured
+from .migration_analyzer import MigrationAnalyzer, AnalysisResult, OrphanRecord, CleanupAction, ActionType
 
 __all__ = [
     'ConfigManager', 'TunnelEngine', 'MySQLConnector', 'test_mysql_connection',
     'GitHubIssueReporter', 'get_reporter_from_config',
-    'GitHubAppAuth', 'get_github_app_auth', 'is_github_app_configured'
+    'GitHubAppAuth', 'get_github_app_auth', 'is_github_app_configured',
+    'MigrationAnalyzer', 'AnalysisResult', 'OrphanRecord', 'CleanupAction', 'ActionType'
 ]

--- a/src/core/migration_analyzer.py
+++ b/src/core/migration_analyzer.py
@@ -1,0 +1,585 @@
+"""
+MySQL 마이그레이션 분석기
+- 고아 레코드(orphan rows) 탐지
+- FK 관계 분석 및 정리
+- MySQL 8.0.x → 8.4.x 호환성 검사
+- dry-run 지원
+"""
+from typing import List, Dict, Set, Tuple, Optional, Callable, Any
+from dataclasses import dataclass, field
+from enum import Enum
+from src.core.db_connector import MySQLConnector
+
+
+class IssueType(Enum):
+    """문제 유형"""
+    ORPHAN_ROW = "orphan_row"  # 부모 없는 자식 레코드
+    DEPRECATED_FUNCTION = "deprecated_function"  # deprecated 함수 사용
+    CHARSET_ISSUE = "charset_issue"  # utf8mb3 → utf8mb4 필요
+    RESERVED_KEYWORD = "reserved_keyword"  # 예약어 충돌
+    SQL_MODE_ISSUE = "sql_mode_issue"  # deprecated SQL 모드
+
+
+class ActionType(Enum):
+    """조치 유형"""
+    DELETE = "delete"  # 삭제
+    UPDATE = "update"  # 업데이트
+    SET_NULL = "set_null"  # NULL로 설정
+    MANUAL = "manual"  # 수동 처리 필요
+
+
+@dataclass
+class OrphanRecord:
+    """고아 레코드 정보"""
+    child_table: str
+    child_column: str
+    parent_table: str
+    parent_column: str
+    orphan_count: int
+    sample_values: List[Any] = field(default_factory=list)
+
+
+@dataclass
+class ForeignKeyInfo:
+    """FK 관계 정보"""
+    constraint_name: str
+    child_table: str
+    child_column: str
+    parent_table: str
+    parent_column: str
+    on_delete: str
+    on_update: str
+
+
+@dataclass
+class CompatibilityIssue:
+    """호환성 문제"""
+    issue_type: IssueType
+    severity: str  # "error", "warning", "info"
+    location: str  # 테이블명 또는 위치
+    description: str
+    suggestion: str
+
+
+@dataclass
+class CleanupAction:
+    """정리 작업"""
+    action_type: ActionType
+    table: str
+    description: str
+    sql: str
+    affected_rows: int
+    dry_run: bool = True
+
+
+@dataclass
+class AnalysisResult:
+    """분석 결과"""
+    schema: str
+    analyzed_at: str
+    total_tables: int
+    total_fk_relations: int
+    orphan_records: List[OrphanRecord] = field(default_factory=list)
+    compatibility_issues: List[CompatibilityIssue] = field(default_factory=list)
+    cleanup_actions: List[CleanupAction] = field(default_factory=list)
+    fk_tree: Dict[str, List[str]] = field(default_factory=dict)
+
+
+class MigrationAnalyzer:
+    """마이그레이션 분석기"""
+
+    # MySQL 8.4에서 제거된/deprecated된 함수들
+    DEPRECATED_FUNCTIONS = [
+        'PASSWORD', 'ENCODE', 'DECODE', 'DES_ENCRYPT', 'DES_DECRYPT',
+        'ENCRYPT', 'OLD_PASSWORD', 'MASTER_POS_WAIT'
+    ]
+
+    # MySQL 8.4에서 새로운 예약어들
+    NEW_RESERVED_KEYWORDS = [
+        'CUME_DIST', 'DENSE_RANK', 'EMPTY', 'EXCEPT', 'FIRST_VALUE',
+        'GROUPING', 'GROUPS', 'JSON_TABLE', 'LAG', 'LAST_VALUE', 'LATERAL',
+        'LEAD', 'NTH_VALUE', 'NTILE', 'OF', 'OVER', 'PERCENT_RANK',
+        'RANK', 'RECURSIVE', 'ROW_NUMBER', 'SYSTEM', 'WINDOW'
+    ]
+
+    def __init__(self, connector: MySQLConnector):
+        self.connector = connector
+        self._progress_callback: Optional[Callable[[str], None]] = None
+
+    def set_progress_callback(self, callback: Callable[[str], None]):
+        """진행 상황 콜백 설정"""
+        self._progress_callback = callback
+
+    def _log(self, message: str):
+        """진행 상황 로깅"""
+        if self._progress_callback:
+            self._progress_callback(message)
+
+    def get_foreign_keys(self, schema: str) -> List[ForeignKeyInfo]:
+        """스키마의 모든 FK 관계 조회"""
+        query = """
+        SELECT
+            tc.CONSTRAINT_NAME,
+            kcu.TABLE_NAME as CHILD_TABLE,
+            kcu.COLUMN_NAME as CHILD_COLUMN,
+            kcu.REFERENCED_TABLE_NAME as PARENT_TABLE,
+            kcu.REFERENCED_COLUMN_NAME as PARENT_COLUMN,
+            rc.DELETE_RULE,
+            rc.UPDATE_RULE
+        FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
+        JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
+            ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+            AND tc.TABLE_SCHEMA = kcu.TABLE_SCHEMA
+        JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
+            ON tc.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
+            AND tc.TABLE_SCHEMA = rc.CONSTRAINT_SCHEMA
+        WHERE tc.TABLE_SCHEMA = %s
+            AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY'
+        ORDER BY kcu.TABLE_NAME, kcu.COLUMN_NAME
+        """
+        rows = self.connector.execute(query, (schema,))
+
+        fk_list = []
+        for row in rows:
+            fk_list.append(ForeignKeyInfo(
+                constraint_name=row['CONSTRAINT_NAME'],
+                child_table=row['CHILD_TABLE'],
+                child_column=row['CHILD_COLUMN'],
+                parent_table=row['PARENT_TABLE'],
+                parent_column=row['PARENT_COLUMN'],
+                on_delete=row['DELETE_RULE'],
+                on_update=row['UPDATE_RULE']
+            ))
+
+        return fk_list
+
+    def build_fk_tree(self, schema: str) -> Dict[str, List[str]]:
+        """FK 관계 트리 구성 (부모 → 자식 목록)"""
+        fk_list = self.get_foreign_keys(schema)
+
+        tree = {}
+        for fk in fk_list:
+            if fk.parent_table not in tree:
+                tree[fk.parent_table] = []
+            if fk.child_table not in tree[fk.parent_table]:
+                tree[fk.parent_table].append(fk.child_table)
+
+        return tree
+
+    def find_orphan_records(
+        self,
+        schema: str,
+        sample_limit: int = 5
+    ) -> List[OrphanRecord]:
+        """고아 레코드 탐지 (부모 없는 자식 레코드)"""
+        self._log("🔍 고아 레코드 탐지 중...")
+
+        fk_list = self.get_foreign_keys(schema)
+        orphans = []
+
+        for i, fk in enumerate(fk_list, 1):
+            self._log(f"  검사 중: {fk.child_table}.{fk.child_column} → {fk.parent_table}.{fk.parent_column} ({i}/{len(fk_list)})")
+
+            # 고아 레코드 수 조회
+            count_query = f"""
+            SELECT COUNT(*) as cnt
+            FROM `{schema}`.`{fk.child_table}` c
+            LEFT JOIN `{schema}`.`{fk.parent_table}` p
+                ON c.`{fk.child_column}` = p.`{fk.parent_column}`
+            WHERE c.`{fk.child_column}` IS NOT NULL
+                AND p.`{fk.parent_column}` IS NULL
+            """
+            result = self.connector.execute(count_query)
+            orphan_count = result[0]['cnt'] if result else 0
+
+            if orphan_count > 0:
+                # 샘플 값 조회
+                sample_query = f"""
+                SELECT DISTINCT c.`{fk.child_column}` as orphan_value
+                FROM `{schema}`.`{fk.child_table}` c
+                LEFT JOIN `{schema}`.`{fk.parent_table}` p
+                    ON c.`{fk.child_column}` = p.`{fk.parent_column}`
+                WHERE c.`{fk.child_column}` IS NOT NULL
+                    AND p.`{fk.parent_column}` IS NULL
+                LIMIT {sample_limit}
+                """
+                samples = self.connector.execute(sample_query)
+                sample_values = [s['orphan_value'] for s in samples]
+
+                orphans.append(OrphanRecord(
+                    child_table=fk.child_table,
+                    child_column=fk.child_column,
+                    parent_table=fk.parent_table,
+                    parent_column=fk.parent_column,
+                    orphan_count=orphan_count,
+                    sample_values=sample_values
+                ))
+
+                self._log(f"    ⚠️ 고아 레코드 발견: {orphan_count}개")
+
+        return orphans
+
+    def check_charset_issues(self, schema: str) -> List[CompatibilityIssue]:
+        """utf8mb3 사용 테이블/컬럼 확인"""
+        self._log("🔍 문자셋 이슈 확인 중...")
+
+        issues = []
+
+        # 테이블 레벨 charset 확인
+        table_query = """
+        SELECT TABLE_NAME, TABLE_COLLATION
+        FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = %s
+            AND TABLE_TYPE = 'BASE TABLE'
+            AND (TABLE_COLLATION LIKE 'utf8_%%' OR TABLE_COLLATION LIKE 'utf8mb3_%%')
+        """
+        tables = self.connector.execute(table_query, (schema,))
+
+        for t in tables:
+            issues.append(CompatibilityIssue(
+                issue_type=IssueType.CHARSET_ISSUE,
+                severity="warning",
+                location=f"{schema}.{t['TABLE_NAME']}",
+                description=f"테이블이 utf8mb3 collation 사용 중: {t['TABLE_COLLATION']}",
+                suggestion="ALTER TABLE ... CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+            ))
+
+        # 컬럼 레벨 charset 확인
+        column_query = """
+        SELECT TABLE_NAME, COLUMN_NAME, CHARACTER_SET_NAME, COLLATION_NAME
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = %s
+            AND CHARACTER_SET_NAME IN ('utf8', 'utf8mb3')
+        """
+        columns = self.connector.execute(column_query, (schema,))
+
+        for c in columns:
+            issues.append(CompatibilityIssue(
+                issue_type=IssueType.CHARSET_ISSUE,
+                severity="warning",
+                location=f"{schema}.{c['TABLE_NAME']}.{c['COLUMN_NAME']}",
+                description=f"컬럼이 utf8mb3 사용 중: {c['CHARACTER_SET_NAME']}",
+                suggestion="ALTER TABLE ... MODIFY COLUMN ... CHARACTER SET utf8mb4"
+            ))
+
+        if issues:
+            self._log(f"  ⚠️ 문자셋 이슈 {len(issues)}개 발견")
+        else:
+            self._log("  ✅ 문자셋 이슈 없음")
+
+        return issues
+
+    def check_reserved_keywords(self, schema: str) -> List[CompatibilityIssue]:
+        """예약어와 충돌하는 컬럼/테이블명 확인"""
+        self._log("🔍 예약어 충돌 확인 중...")
+
+        issues = []
+        keywords_upper = set(k.upper() for k in self.NEW_RESERVED_KEYWORDS)
+
+        # 테이블명 확인
+        tables = self.connector.get_tables(schema)
+        for table in tables:
+            if table.upper() in keywords_upper:
+                issues.append(CompatibilityIssue(
+                    issue_type=IssueType.RESERVED_KEYWORD,
+                    severity="error",
+                    location=f"{schema}.{table}",
+                    description=f"테이블명 '{table}'이 MySQL 8.4 예약어와 충돌",
+                    suggestion=f"테이블명을 백틱으로 감싸거나 이름 변경 필요"
+                ))
+
+        # 컬럼명 확인
+        column_query = """
+        SELECT TABLE_NAME, COLUMN_NAME
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = %s
+        """
+        columns = self.connector.execute(column_query, (schema,))
+
+        for c in columns:
+            if c['COLUMN_NAME'].upper() in keywords_upper:
+                issues.append(CompatibilityIssue(
+                    issue_type=IssueType.RESERVED_KEYWORD,
+                    severity="warning",
+                    location=f"{schema}.{c['TABLE_NAME']}.{c['COLUMN_NAME']}",
+                    description=f"컬럼명 '{c['COLUMN_NAME']}'이 MySQL 8.4 예약어와 충돌",
+                    suggestion="컬럼 참조 시 백틱(`) 사용 필요"
+                ))
+
+        if issues:
+            self._log(f"  ⚠️ 예약어 충돌 {len(issues)}개 발견")
+        else:
+            self._log("  ✅ 예약어 충돌 없음")
+
+        return issues
+
+    def check_deprecated_in_routines(self, schema: str) -> List[CompatibilityIssue]:
+        """저장 프로시저/함수에서 deprecated 함수 사용 확인"""
+        self._log("🔍 저장 프로시저/함수 검사 중...")
+
+        issues = []
+
+        # 저장 프로시저와 함수 조회
+        routine_query = """
+        SELECT ROUTINE_NAME, ROUTINE_TYPE, ROUTINE_DEFINITION
+        FROM INFORMATION_SCHEMA.ROUTINES
+        WHERE ROUTINE_SCHEMA = %s
+            AND ROUTINE_DEFINITION IS NOT NULL
+        """
+        routines = self.connector.execute(routine_query, (schema,))
+
+        for routine in routines:
+            definition = routine['ROUTINE_DEFINITION'].upper() if routine['ROUTINE_DEFINITION'] else ""
+
+            for func in self.DEPRECATED_FUNCTIONS:
+                if func in definition:
+                    issues.append(CompatibilityIssue(
+                        issue_type=IssueType.DEPRECATED_FUNCTION,
+                        severity="error",
+                        location=f"{routine['ROUTINE_TYPE']} {schema}.{routine['ROUTINE_NAME']}",
+                        description=f"deprecated 함수 '{func}' 사용 중",
+                        suggestion=f"'{func}' 함수를 대체 함수로 변경 필요"
+                    ))
+
+        if issues:
+            self._log(f"  ⚠️ deprecated 함수 사용 {len(issues)}개 발견")
+        else:
+            self._log("  ✅ deprecated 함수 없음")
+
+        return issues
+
+    def check_sql_modes(self) -> List[CompatibilityIssue]:
+        """현재 SQL 모드 확인"""
+        self._log("🔍 SQL 모드 확인 중...")
+
+        issues = []
+
+        # deprecated SQL 모드들
+        deprecated_modes = [
+            'NO_AUTO_CREATE_USER',  # 8.0에서 제거됨
+            'NO_FIELD_OPTIONS',
+            'NO_KEY_OPTIONS',
+            'NO_TABLE_OPTIONS',
+        ]
+
+        result = self.connector.execute("SELECT @@sql_mode as sql_mode")
+        if result:
+            current_modes = result[0]['sql_mode'].split(',')
+
+            for mode in current_modes:
+                mode = mode.strip()
+                if mode in deprecated_modes:
+                    issues.append(CompatibilityIssue(
+                        issue_type=IssueType.SQL_MODE_ISSUE,
+                        severity="warning",
+                        location="@@sql_mode",
+                        description=f"deprecated SQL 모드 '{mode}' 사용 중",
+                        suggestion=f"sql_mode에서 '{mode}' 제거 필요"
+                    ))
+
+        if issues:
+            self._log(f"  ⚠️ deprecated SQL 모드 {len(issues)}개 발견")
+        else:
+            self._log("  ✅ SQL 모드 정상")
+
+        return issues
+
+    def generate_cleanup_sql(
+        self,
+        orphan: OrphanRecord,
+        action: ActionType,
+        schema: str,
+        dry_run: bool = True
+    ) -> CleanupAction:
+        """고아 레코드 정리 SQL 생성"""
+        if action == ActionType.DELETE:
+            sql = f"""DELETE FROM `{schema}`.`{orphan.child_table}`
+WHERE `{orphan.child_column}` NOT IN (
+    SELECT `{orphan.parent_column}` FROM `{schema}`.`{orphan.parent_table}`
+)
+AND `{orphan.child_column}` IS NOT NULL"""
+            description = f"{orphan.child_table}에서 고아 레코드 {orphan.orphan_count}개 삭제"
+
+        elif action == ActionType.SET_NULL:
+            sql = f"""UPDATE `{schema}`.`{orphan.child_table}`
+SET `{orphan.child_column}` = NULL
+WHERE `{orphan.child_column}` NOT IN (
+    SELECT `{orphan.parent_column}` FROM `{schema}`.`{orphan.parent_table}`
+)
+AND `{orphan.child_column}` IS NOT NULL"""
+            description = f"{orphan.child_table}.{orphan.child_column}을 NULL로 설정 ({orphan.orphan_count}개)"
+
+        else:
+            sql = f"-- 수동 처리 필요: {orphan.child_table}.{orphan.child_column}"
+            description = f"{orphan.child_table} 수동 검토 필요"
+
+        return CleanupAction(
+            action_type=action,
+            table=orphan.child_table,
+            description=description,
+            sql=sql,
+            affected_rows=orphan.orphan_count,
+            dry_run=dry_run
+        )
+
+    def execute_cleanup(
+        self,
+        action: CleanupAction,
+        dry_run: bool = True
+    ) -> Tuple[bool, str, int]:
+        """
+        정리 작업 실행
+
+        Args:
+            action: 실행할 정리 작업
+            dry_run: True면 실제 실행하지 않고 영향받는 행 수만 반환
+
+        Returns:
+            (성공여부, 메시지, 영향받은 행 수)
+        """
+        if dry_run:
+            # dry-run: 실제 실행하지 않고 영향받는 행 수 확인
+            self._log(f"🔍 [DRY-RUN] 영향 분석: {action.table}")
+
+            if action.action_type == ActionType.MANUAL:
+                return True, "수동 처리 필요", 0
+
+            # COUNT 쿼리로 변환하여 영향받는 행 수 확인
+            # DELETE/UPDATE의 WHERE 절 추출
+            sql_upper = action.sql.upper()
+            if 'WHERE' in sql_upper:
+                where_idx = action.sql.upper().find('WHERE')
+                where_clause = action.sql[where_idx:]
+
+                # 테이블명 추출
+                if action.action_type == ActionType.DELETE:
+                    # DELETE FROM `schema`.`table` WHERE ...
+                    count_sql = f"SELECT COUNT(*) as cnt FROM {action.sql.split('FROM')[1].split('WHERE')[0].strip()} {where_clause}"
+                else:
+                    # UPDATE `schema`.`table` SET ... WHERE ...
+                    count_sql = f"SELECT COUNT(*) as cnt FROM {action.sql.split('UPDATE')[1].split('SET')[0].strip()} {where_clause}"
+
+                result = self.connector.execute(count_sql)
+                affected = result[0]['cnt'] if result else 0
+
+                return True, f"[DRY-RUN] {affected}개 행이 영향받음", affected
+
+            return True, "[DRY-RUN] 영향 분석 완료", action.affected_rows
+
+        else:
+            # 실제 실행
+            self._log(f"🔧 실행 중: {action.table}")
+
+            try:
+                with self.connector.connection.cursor() as cursor:
+                    cursor.execute(action.sql)
+                    affected = cursor.rowcount
+                    self.connector.connection.commit()
+
+                return True, f"✅ {affected}개 행 처리됨", affected
+
+            except Exception as e:
+                self.connector.connection.rollback()
+                return False, f"❌ 오류: {str(e)}", 0
+
+    def analyze_schema(
+        self,
+        schema: str,
+        check_orphans: bool = True,
+        check_charset: bool = True,
+        check_keywords: bool = True,
+        check_routines: bool = True,
+        check_sql_mode: bool = True
+    ) -> AnalysisResult:
+        """
+        스키마 전체 분석
+
+        Args:
+            schema: 분석할 스키마명
+            check_orphans: 고아 레코드 검사 여부
+            check_charset: 문자셋 이슈 검사 여부
+            check_keywords: 예약어 충돌 검사 여부
+            check_routines: 저장 프로시저/함수 검사 여부
+            check_sql_mode: SQL 모드 검사 여부
+
+        Returns:
+            AnalysisResult
+        """
+        from datetime import datetime
+
+        self._log(f"📊 스키마 '{schema}' 분석 시작...")
+
+        # 기본 정보 수집
+        tables = self.connector.get_tables(schema)
+        fk_list = self.get_foreign_keys(schema)
+        fk_tree = self.build_fk_tree(schema)
+
+        self._log(f"  테이블 수: {len(tables)}, FK 관계: {len(fk_list)}")
+
+        result = AnalysisResult(
+            schema=schema,
+            analyzed_at=datetime.now().isoformat(),
+            total_tables=len(tables),
+            total_fk_relations=len(fk_list),
+            fk_tree=fk_tree
+        )
+
+        # 고아 레코드 검사
+        if check_orphans and fk_list:
+            result.orphan_records = self.find_orphan_records(schema)
+
+        # 호환성 검사들
+        if check_charset:
+            result.compatibility_issues.extend(self.check_charset_issues(schema))
+
+        if check_keywords:
+            result.compatibility_issues.extend(self.check_reserved_keywords(schema))
+
+        if check_routines:
+            result.compatibility_issues.extend(self.check_deprecated_in_routines(schema))
+
+        if check_sql_mode:
+            result.compatibility_issues.extend(self.check_sql_modes())
+
+        # 정리 작업 생성 (고아 레코드에 대해)
+        for orphan in result.orphan_records:
+            # 기본적으로 DELETE 작업 생성 (dry-run)
+            cleanup = self.generate_cleanup_sql(orphan, ActionType.DELETE, schema, dry_run=True)
+            result.cleanup_actions.append(cleanup)
+
+        self._log(f"✅ 분석 완료")
+        self._log(f"  - 고아 레코드: {len(result.orphan_records)}개 FK 관계에서 발견")
+        self._log(f"  - 호환성 이슈: {len(result.compatibility_issues)}개")
+
+        return result
+
+    def get_fk_visualization(self, schema: str) -> str:
+        """FK 관계를 트리 형태로 시각화"""
+        fk_tree = self.build_fk_tree(schema)
+
+        if not fk_tree:
+            return "FK 관계가 없습니다."
+
+        lines = ["FK 관계 트리:", ""]
+
+        # 루트 테이블 찾기 (다른 테이블의 자식이 아닌 테이블)
+        all_children = set()
+        for children in fk_tree.values():
+            all_children.update(children)
+
+        root_tables = set(fk_tree.keys()) - all_children
+
+        def print_tree(table: str, prefix: str = "", is_last: bool = True):
+            connector = "└── " if is_last else "├── "
+            lines.append(f"{prefix}{connector}{table}")
+
+            if table in fk_tree:
+                children = fk_tree[table]
+                child_prefix = prefix + ("    " if is_last else "│   ")
+                for i, child in enumerate(children):
+                    print_tree(child, child_prefix, i == len(children) - 1)
+
+        for i, root in enumerate(sorted(root_tables)):
+            print_tree(root, "", i == len(root_tables) - 1)
+
+        return "\n".join(lines)

--- a/src/ui/dialogs/__init__.py
+++ b/src/ui/dialogs/__init__.py
@@ -1,5 +1,9 @@
 from .tunnel_config import TunnelConfigDialog
 from .settings import SettingsDialog, CloseConfirmDialog
 from .db_dialogs import MySQLShellWizard
+from .migration_dialogs import MigrationAnalyzerDialog, MigrationWizard
 
-__all__ = ['TunnelConfigDialog', 'SettingsDialog', 'CloseConfirmDialog', 'MySQLShellWizard']
+__all__ = [
+    'TunnelConfigDialog', 'SettingsDialog', 'CloseConfirmDialog', 'MySQLShellWizard',
+    'MigrationAnalyzerDialog', 'MigrationWizard'
+]

--- a/src/ui/dialogs/migration_dialogs.py
+++ b/src/ui/dialogs/migration_dialogs.py
@@ -1,0 +1,741 @@
+"""
+마이그레이션 분석 다이얼로그
+- 스키마 분석 (고아 레코드, 호환성 이슈)
+- FK 관계 시각화
+- dry-run 및 실제 정리 작업
+"""
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QFormLayout,
+    QLabel, QLineEdit, QSpinBox, QPushButton, QComboBox,
+    QCheckBox, QListWidget, QListWidgetItem, QGroupBox,
+    QMessageBox, QProgressBar, QApplication,
+    QRadioButton, QButtonGroup, QWidget, QTabWidget,
+    QTextEdit, QTreeWidget, QTreeWidgetItem, QSplitter,
+    QTableWidget, QTableWidgetItem, QHeaderView, QFrame
+)
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QFont, QColor
+from typing import List, Optional, Dict
+from datetime import datetime
+
+from src.core.db_connector import MySQLConnector
+from src.core.migration_analyzer import (
+    MigrationAnalyzer, AnalysisResult, OrphanRecord,
+    CompatibilityIssue, CleanupAction, ActionType, IssueType
+)
+from src.ui.workers.migration_worker import MigrationAnalyzerWorker, CleanupWorker
+
+
+class MigrationAnalyzerDialog(QDialog):
+    """마이그레이션 분석 다이얼로그"""
+
+    def __init__(self, parent=None, connector: MySQLConnector = None, config_manager=None):
+        super().__init__(parent)
+        self.setWindowTitle("🔄 마이그레이션 분석기")
+        self.resize(1000, 700)
+
+        self.connector = connector
+        self.config_manager = config_manager
+        self.analysis_result: Optional[AnalysisResult] = None
+        self.worker: Optional[MigrationAnalyzerWorker] = None
+        self.cleanup_worker: Optional[CleanupWorker] = None
+
+        self.init_ui()
+        self.load_schemas()
+
+    def init_ui(self):
+        layout = QVBoxLayout(self)
+
+        # --- 상단: 스키마 선택 및 분석 옵션 ---
+        top_group = QGroupBox("분석 설정")
+        top_layout = QVBoxLayout(top_group)
+
+        # 스키마 선택
+        schema_layout = QHBoxLayout()
+        schema_layout.addWidget(QLabel("스키마:"))
+        self.combo_schema = QComboBox()
+        self.combo_schema.setMinimumWidth(200)
+        schema_layout.addWidget(self.combo_schema)
+        schema_layout.addStretch()
+        top_layout.addLayout(schema_layout)
+
+        # 분석 옵션 체크박스들
+        options_layout = QHBoxLayout()
+
+        self.chk_orphans = QCheckBox("고아 레코드 검사")
+        self.chk_orphans.setChecked(True)
+        self.chk_orphans.setToolTip("FK 관계에서 부모가 없는 자식 레코드 탐지")
+
+        self.chk_charset = QCheckBox("문자셋 이슈")
+        self.chk_charset.setChecked(True)
+        self.chk_charset.setToolTip("utf8mb3 사용 테이블/컬럼 확인")
+
+        self.chk_keywords = QCheckBox("예약어 충돌")
+        self.chk_keywords.setChecked(True)
+        self.chk_keywords.setToolTip("MySQL 8.4 새 예약어와 충돌하는 이름 확인")
+
+        self.chk_routines = QCheckBox("저장 프로시저/함수")
+        self.chk_routines.setChecked(True)
+        self.chk_routines.setToolTip("deprecated 함수 사용 여부 확인")
+
+        self.chk_sql_mode = QCheckBox("SQL 모드")
+        self.chk_sql_mode.setChecked(True)
+        self.chk_sql_mode.setToolTip("deprecated SQL 모드 사용 여부 확인")
+
+        options_layout.addWidget(self.chk_orphans)
+        options_layout.addWidget(self.chk_charset)
+        options_layout.addWidget(self.chk_keywords)
+        options_layout.addWidget(self.chk_routines)
+        options_layout.addWidget(self.chk_sql_mode)
+        options_layout.addStretch()
+
+        top_layout.addLayout(options_layout)
+
+        # 분석 버튼
+        btn_layout = QHBoxLayout()
+        self.btn_analyze = QPushButton("🔍 분석 시작")
+        self.btn_analyze.setStyleSheet("""
+            QPushButton {
+                background-color: #3498db; color: white; font-weight: bold;
+                padding: 8px 20px; border-radius: 4px; border: none;
+                font-size: 14px;
+            }
+            QPushButton:hover { background-color: #2980b9; }
+            QPushButton:disabled { background-color: #bdc3c7; }
+        """)
+        self.btn_analyze.clicked.connect(self.start_analysis)
+        btn_layout.addWidget(self.btn_analyze)
+        btn_layout.addStretch()
+        top_layout.addLayout(btn_layout)
+
+        layout.addWidget(top_group)
+
+        # --- 진행 상황 ---
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setVisible(False)
+        layout.addWidget(self.progress_bar)
+
+        # --- 탭 위젯: 결과 표시 ---
+        self.tab_widget = QTabWidget()
+
+        # 탭 1: 개요
+        self.tab_overview = QWidget()
+        self.init_overview_tab()
+        self.tab_widget.addTab(self.tab_overview, "📊 개요")
+
+        # 탭 2: 고아 레코드
+        self.tab_orphans = QWidget()
+        self.init_orphans_tab()
+        self.tab_widget.addTab(self.tab_orphans, "🔗 고아 레코드")
+
+        # 탭 3: 호환성 이슈
+        self.tab_compatibility = QWidget()
+        self.init_compatibility_tab()
+        self.tab_widget.addTab(self.tab_compatibility, "⚠️ 호환성")
+
+        # 탭 4: FK 트리
+        self.tab_fk_tree = QWidget()
+        self.init_fk_tree_tab()
+        self.tab_widget.addTab(self.tab_fk_tree, "🌳 FK 관계")
+
+        # 탭 5: 로그
+        self.tab_log = QWidget()
+        self.init_log_tab()
+        self.tab_widget.addTab(self.tab_log, "📝 로그")
+
+        layout.addWidget(self.tab_widget)
+
+        # --- 하단 버튼 ---
+        bottom_layout = QHBoxLayout()
+
+        self.btn_close = QPushButton("닫기")
+        self.btn_close.setStyleSheet("""
+            QPushButton {
+                background-color: #ecf0f1; color: #2c3e50;
+                padding: 8px 20px; border-radius: 4px; border: 1px solid #bdc3c7;
+            }
+            QPushButton:hover { background-color: #d5dbdb; }
+        """)
+        self.btn_close.clicked.connect(self.close)
+
+        bottom_layout.addStretch()
+        bottom_layout.addWidget(self.btn_close)
+
+        layout.addLayout(bottom_layout)
+
+    def init_overview_tab(self):
+        """개요 탭 초기화"""
+        layout = QVBoxLayout(self.tab_overview)
+
+        # 요약 정보
+        self.lbl_summary = QLabel("분석을 시작하세요.")
+        self.lbl_summary.setWordWrap(True)
+        self.lbl_summary.setStyleSheet("""
+            QLabel {
+                background-color: #f8f9fa;
+                padding: 15px;
+                border-radius: 8px;
+                font-size: 13px;
+            }
+        """)
+        layout.addWidget(self.lbl_summary)
+
+        # 통계 테이블
+        self.table_stats = QTableWidget()
+        self.table_stats.setColumnCount(2)
+        self.table_stats.setHorizontalHeaderLabels(["항목", "값"])
+        self.table_stats.horizontalHeader().setStretchLastSection(True)
+        self.table_stats.verticalHeader().setVisible(False)
+        layout.addWidget(self.table_stats)
+
+    def init_orphans_tab(self):
+        """고아 레코드 탭 초기화"""
+        layout = QVBoxLayout(self.tab_orphans)
+
+        # 고아 레코드 테이블
+        self.table_orphans = QTableWidget()
+        self.table_orphans.setColumnCount(6)
+        self.table_orphans.setHorizontalHeaderLabels([
+            "자식 테이블", "자식 컬럼", "부모 테이블", "부모 컬럼", "고아 수", "샘플 값"
+        ])
+        self.table_orphans.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        self.table_orphans.horizontalHeader().setStretchLastSection(True)
+        self.table_orphans.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.table_orphans.itemSelectionChanged.connect(self.on_orphan_selected)
+        layout.addWidget(self.table_orphans)
+
+        # 정리 옵션
+        cleanup_group = QGroupBox("정리 작업")
+        cleanup_layout = QVBoxLayout(cleanup_group)
+
+        # 조치 선택
+        action_layout = QHBoxLayout()
+        action_layout.addWidget(QLabel("조치:"))
+
+        self.btn_group_action = QButtonGroup(self)
+        self.radio_delete = QRadioButton("삭제 (DELETE)")
+        self.radio_delete.setChecked(True)
+        self.radio_set_null = QRadioButton("NULL로 설정 (SET NULL)")
+
+        self.btn_group_action.addButton(self.radio_delete)
+        self.btn_group_action.addButton(self.radio_set_null)
+
+        action_layout.addWidget(self.radio_delete)
+        action_layout.addWidget(self.radio_set_null)
+        action_layout.addStretch()
+        cleanup_layout.addLayout(action_layout)
+
+        # SQL 미리보기
+        self.txt_cleanup_sql = QTextEdit()
+        self.txt_cleanup_sql.setReadOnly(True)
+        self.txt_cleanup_sql.setMaximumHeight(100)
+        self.txt_cleanup_sql.setPlaceholderText("정리할 레코드를 선택하면 SQL이 표시됩니다...")
+        self.txt_cleanup_sql.setStyleSheet("""
+            QTextEdit {
+                font-family: 'Consolas', 'Monaco', monospace;
+                background-color: #2d2d2d;
+                color: #f8f8f2;
+                border-radius: 4px;
+            }
+        """)
+        cleanup_layout.addWidget(self.txt_cleanup_sql)
+
+        # 버튼들
+        btn_layout = QHBoxLayout()
+
+        self.btn_dry_run = QPushButton("🔍 Dry-Run (미리보기)")
+        self.btn_dry_run.setStyleSheet("""
+            QPushButton {
+                background-color: #f39c12; color: white; font-weight: bold;
+                padding: 8px 16px; border-radius: 4px; border: none;
+            }
+            QPushButton:hover { background-color: #e67e22; }
+            QPushButton:disabled { background-color: #bdc3c7; }
+        """)
+        self.btn_dry_run.clicked.connect(lambda: self.execute_cleanup(dry_run=True))
+        self.btn_dry_run.setEnabled(False)
+
+        self.btn_execute = QPushButton("⚡ 실행")
+        self.btn_execute.setStyleSheet("""
+            QPushButton {
+                background-color: #e74c3c; color: white; font-weight: bold;
+                padding: 8px 16px; border-radius: 4px; border: none;
+            }
+            QPushButton:hover { background-color: #c0392b; }
+            QPushButton:disabled { background-color: #bdc3c7; }
+        """)
+        self.btn_execute.clicked.connect(lambda: self.execute_cleanup(dry_run=False))
+        self.btn_execute.setEnabled(False)
+
+        self.btn_select_all = QPushButton("전체 선택")
+        self.btn_select_all.clicked.connect(self.select_all_orphans)
+
+        btn_layout.addWidget(self.btn_select_all)
+        btn_layout.addStretch()
+        btn_layout.addWidget(self.btn_dry_run)
+        btn_layout.addWidget(self.btn_execute)
+
+        cleanup_layout.addLayout(btn_layout)
+        layout.addWidget(cleanup_group)
+
+    def init_compatibility_tab(self):
+        """호환성 이슈 탭 초기화"""
+        layout = QVBoxLayout(self.tab_compatibility)
+
+        # 필터
+        filter_layout = QHBoxLayout()
+        filter_layout.addWidget(QLabel("필터:"))
+
+        self.chk_filter_error = QCheckBox("Error")
+        self.chk_filter_error.setChecked(True)
+        self.chk_filter_error.stateChanged.connect(self.filter_compatibility_issues)
+
+        self.chk_filter_warning = QCheckBox("Warning")
+        self.chk_filter_warning.setChecked(True)
+        self.chk_filter_warning.stateChanged.connect(self.filter_compatibility_issues)
+
+        self.chk_filter_info = QCheckBox("Info")
+        self.chk_filter_info.setChecked(True)
+        self.chk_filter_info.stateChanged.connect(self.filter_compatibility_issues)
+
+        filter_layout.addWidget(self.chk_filter_error)
+        filter_layout.addWidget(self.chk_filter_warning)
+        filter_layout.addWidget(self.chk_filter_info)
+        filter_layout.addStretch()
+        layout.addLayout(filter_layout)
+
+        # 이슈 테이블
+        self.table_issues = QTableWidget()
+        self.table_issues.setColumnCount(5)
+        self.table_issues.setHorizontalHeaderLabels([
+            "심각도", "유형", "위치", "설명", "권장 조치"
+        ])
+        self.table_issues.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        self.table_issues.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.table_issues)
+
+    def init_fk_tree_tab(self):
+        """FK 관계 트리 탭 초기화"""
+        layout = QVBoxLayout(self.tab_fk_tree)
+
+        # 트리 위젯
+        self.tree_fk = QTreeWidget()
+        self.tree_fk.setHeaderLabels(["테이블 (부모 → 자식)"])
+        self.tree_fk.setAlternatingRowColors(True)
+        layout.addWidget(self.tree_fk)
+
+        # 텍스트 뷰 (ASCII 트리)
+        self.txt_fk_tree = QTextEdit()
+        self.txt_fk_tree.setReadOnly(True)
+        self.txt_fk_tree.setStyleSheet("""
+            QTextEdit {
+                font-family: 'Consolas', 'Monaco', monospace;
+                font-size: 12px;
+            }
+        """)
+        layout.addWidget(self.txt_fk_tree)
+
+    def init_log_tab(self):
+        """로그 탭 초기화"""
+        layout = QVBoxLayout(self.tab_log)
+
+        self.txt_log = QTextEdit()
+        self.txt_log.setReadOnly(True)
+        self.txt_log.setStyleSheet("""
+            QTextEdit {
+                font-family: 'Consolas', 'Monaco', monospace;
+                font-size: 11px;
+            }
+        """)
+        layout.addWidget(self.txt_log)
+
+        # 로그 저장 버튼
+        btn_layout = QHBoxLayout()
+        btn_save_log = QPushButton("로그 저장")
+        btn_save_log.clicked.connect(self.save_log)
+        btn_layout.addStretch()
+        btn_layout.addWidget(btn_save_log)
+        layout.addLayout(btn_layout)
+
+    def load_schemas(self):
+        """스키마 목록 로드"""
+        if not self.connector:
+            return
+
+        schemas = self.connector.get_schemas()
+        self.combo_schema.clear()
+        for schema in schemas:
+            self.combo_schema.addItem(schema)
+
+    def add_log(self, message: str):
+        """로그 추가"""
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        self.txt_log.append(f"[{timestamp}] {message}")
+
+    def save_log(self):
+        """로그 저장"""
+        from PyQt6.QtWidgets import QFileDialog
+
+        filename, _ = QFileDialog.getSaveFileName(
+            self, "로그 저장", f"migration_log_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt",
+            "Text Files (*.txt)"
+        )
+        if filename:
+            with open(filename, 'w', encoding='utf-8') as f:
+                f.write(self.txt_log.toPlainText())
+            QMessageBox.information(self, "저장 완료", f"로그가 저장되었습니다:\n{filename}")
+
+    def set_ui_enabled(self, enabled: bool):
+        """UI 활성화/비활성화"""
+        self.btn_analyze.setEnabled(enabled)
+        self.combo_schema.setEnabled(enabled)
+        self.chk_orphans.setEnabled(enabled)
+        self.chk_charset.setEnabled(enabled)
+        self.chk_keywords.setEnabled(enabled)
+        self.chk_routines.setEnabled(enabled)
+        self.chk_sql_mode.setEnabled(enabled)
+
+    def start_analysis(self):
+        """분석 시작"""
+        schema = self.combo_schema.currentText()
+        if not schema:
+            QMessageBox.warning(self, "오류", "스키마를 선택하세요.")
+            return
+
+        self.set_ui_enabled(False)
+        self.progress_bar.setVisible(True)
+        self.progress_bar.setRange(0, 0)  # 무한 프로그레스
+
+        self.add_log(f"📊 스키마 '{schema}' 분석 시작...")
+
+        # 워커 생성 및 시작
+        self.worker = MigrationAnalyzerWorker(
+            connector=self.connector,
+            schema=schema,
+            check_orphans=self.chk_orphans.isChecked(),
+            check_charset=self.chk_charset.isChecked(),
+            check_keywords=self.chk_keywords.isChecked(),
+            check_routines=self.chk_routines.isChecked(),
+            check_sql_mode=self.chk_sql_mode.isChecked()
+        )
+
+        self.worker.progress.connect(self.add_log)
+        self.worker.analysis_complete.connect(self.on_analysis_complete)
+        self.worker.finished.connect(self.on_analysis_finished)
+        self.worker.start()
+
+    def on_analysis_complete(self, result: AnalysisResult):
+        """분석 완료 시"""
+        self.analysis_result = result
+        self.update_overview(result)
+        self.update_orphans_table(result.orphan_records)
+        self.update_compatibility_table(result.compatibility_issues)
+        self.update_fk_tree(result.fk_tree, result.schema)
+
+    def on_analysis_finished(self, success: bool, message: str):
+        """분석 종료 시"""
+        self.set_ui_enabled(True)
+        self.progress_bar.setVisible(False)
+
+        if success:
+            self.add_log(f"✅ {message}")
+        else:
+            self.add_log(f"❌ {message}")
+            QMessageBox.critical(self, "분석 오류", message)
+
+    def update_overview(self, result: AnalysisResult):
+        """개요 탭 업데이트"""
+        # 요약 텍스트
+        orphan_count = sum(o.orphan_count for o in result.orphan_records)
+        error_count = sum(1 for i in result.compatibility_issues if i.severity == "error")
+        warning_count = sum(1 for i in result.compatibility_issues if i.severity == "warning")
+
+        summary = f"""
+<h3>📊 분석 결과: {result.schema}</h3>
+<p><b>분석 시각:</b> {result.analyzed_at}</p>
+<p><b>테이블 수:</b> {result.total_tables}개</p>
+<p><b>FK 관계:</b> {result.total_fk_relations}개</p>
+<hr>
+<p><b>🔗 고아 레코드:</b> {len(result.orphan_records)}개 FK 관계에서 총 {orphan_count:,}개 발견</p>
+<p><b>❌ 오류:</b> {error_count}개</p>
+<p><b>⚠️ 경고:</b> {warning_count}개</p>
+"""
+        self.lbl_summary.setText(summary)
+
+        # 통계 테이블
+        stats = [
+            ("스키마", result.schema),
+            ("분석 시각", result.analyzed_at),
+            ("테이블 수", str(result.total_tables)),
+            ("FK 관계 수", str(result.total_fk_relations)),
+            ("고아 레코드 FK 관계", str(len(result.orphan_records))),
+            ("총 고아 레코드 수", f"{orphan_count:,}"),
+            ("호환성 오류", str(error_count)),
+            ("호환성 경고", str(warning_count)),
+        ]
+
+        self.table_stats.setRowCount(len(stats))
+        for i, (key, value) in enumerate(stats):
+            self.table_stats.setItem(i, 0, QTableWidgetItem(key))
+            self.table_stats.setItem(i, 1, QTableWidgetItem(value))
+
+    def update_orphans_table(self, orphans: List[OrphanRecord]):
+        """고아 레코드 테이블 업데이트"""
+        self.table_orphans.setRowCount(len(orphans))
+
+        for i, orphan in enumerate(orphans):
+            self.table_orphans.setItem(i, 0, QTableWidgetItem(orphan.child_table))
+            self.table_orphans.setItem(i, 1, QTableWidgetItem(orphan.child_column))
+            self.table_orphans.setItem(i, 2, QTableWidgetItem(orphan.parent_table))
+            self.table_orphans.setItem(i, 3, QTableWidgetItem(orphan.parent_column))
+
+            count_item = QTableWidgetItem(f"{orphan.orphan_count:,}")
+            count_item.setTextAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+            if orphan.orphan_count > 1000:
+                count_item.setForeground(QColor("#e74c3c"))
+            elif orphan.orphan_count > 100:
+                count_item.setForeground(QColor("#f39c12"))
+            self.table_orphans.setItem(i, 4, count_item)
+
+            samples = ", ".join(str(v) for v in orphan.sample_values[:3])
+            if len(orphan.sample_values) > 3:
+                samples += "..."
+            self.table_orphans.setItem(i, 5, QTableWidgetItem(samples))
+
+        self.btn_dry_run.setEnabled(len(orphans) > 0)
+        self.btn_execute.setEnabled(len(orphans) > 0)
+
+    def update_compatibility_table(self, issues: List[CompatibilityIssue]):
+        """호환성 이슈 테이블 업데이트"""
+        self._all_issues = issues  # 필터링용 저장
+        self.filter_compatibility_issues()
+
+    def filter_compatibility_issues(self):
+        """호환성 이슈 필터링"""
+        if not hasattr(self, '_all_issues'):
+            return
+
+        show_error = self.chk_filter_error.isChecked()
+        show_warning = self.chk_filter_warning.isChecked()
+        show_info = self.chk_filter_info.isChecked()
+
+        filtered = []
+        for issue in self._all_issues:
+            if issue.severity == "error" and show_error:
+                filtered.append(issue)
+            elif issue.severity == "warning" and show_warning:
+                filtered.append(issue)
+            elif issue.severity == "info" and show_info:
+                filtered.append(issue)
+
+        self.table_issues.setRowCount(len(filtered))
+
+        severity_icons = {
+            "error": "❌",
+            "warning": "⚠️",
+            "info": "ℹ️"
+        }
+
+        type_names = {
+            IssueType.ORPHAN_ROW: "고아 레코드",
+            IssueType.DEPRECATED_FUNCTION: "deprecated 함수",
+            IssueType.CHARSET_ISSUE: "문자셋",
+            IssueType.RESERVED_KEYWORD: "예약어",
+            IssueType.SQL_MODE_ISSUE: "SQL 모드"
+        }
+
+        for i, issue in enumerate(filtered):
+            severity_item = QTableWidgetItem(f"{severity_icons.get(issue.severity, '')} {issue.severity.upper()}")
+            if issue.severity == "error":
+                severity_item.setForeground(QColor("#e74c3c"))
+            elif issue.severity == "warning":
+                severity_item.setForeground(QColor("#f39c12"))
+
+            self.table_issues.setItem(i, 0, severity_item)
+            self.table_issues.setItem(i, 1, QTableWidgetItem(type_names.get(issue.issue_type, str(issue.issue_type))))
+            self.table_issues.setItem(i, 2, QTableWidgetItem(issue.location))
+            self.table_issues.setItem(i, 3, QTableWidgetItem(issue.description))
+            self.table_issues.setItem(i, 4, QTableWidgetItem(issue.suggestion))
+
+    def update_fk_tree(self, fk_tree: Dict[str, List[str]], schema: str):
+        """FK 트리 업데이트"""
+        self.tree_fk.clear()
+
+        if not fk_tree:
+            self.txt_fk_tree.setText("FK 관계가 없습니다.")
+            return
+
+        # 루트 테이블 찾기
+        all_children = set()
+        for children in fk_tree.values():
+            all_children.update(children)
+
+        root_tables = set(fk_tree.keys()) - all_children
+
+        def add_tree_items(parent_item, table: str):
+            if table in fk_tree:
+                for child in fk_tree[table]:
+                    child_item = QTreeWidgetItem(parent_item, [f"└── {child}"])
+                    add_tree_items(child_item, child)
+
+        for root in sorted(root_tables):
+            root_item = QTreeWidgetItem(self.tree_fk, [f"📁 {root}"])
+            add_tree_items(root_item, root)
+
+        self.tree_fk.expandAll()
+
+        # ASCII 트리 텍스트
+        analyzer = MigrationAnalyzer(self.connector)
+        tree_text = analyzer.get_fk_visualization(schema)
+        self.txt_fk_tree.setText(tree_text)
+
+    def on_orphan_selected(self):
+        """고아 레코드 선택 시"""
+        selected_rows = self.table_orphans.selectionModel().selectedRows()
+
+        if not selected_rows or not self.analysis_result:
+            self.txt_cleanup_sql.clear()
+            return
+
+        # 선택된 고아 레코드들에 대한 SQL 생성
+        sql_parts = []
+        schema = self.analysis_result.schema
+        action = ActionType.DELETE if self.radio_delete.isChecked() else ActionType.SET_NULL
+
+        analyzer = MigrationAnalyzer(self.connector)
+
+        for row_index in selected_rows:
+            row = row_index.row()
+            if row < len(self.analysis_result.orphan_records):
+                orphan = self.analysis_result.orphan_records[row]
+                cleanup = analyzer.generate_cleanup_sql(orphan, action, schema, dry_run=True)
+                sql_parts.append(f"-- {cleanup.description}\n{cleanup.sql};")
+
+        self.txt_cleanup_sql.setText("\n\n".join(sql_parts))
+
+    def select_all_orphans(self):
+        """모든 고아 레코드 선택"""
+        self.table_orphans.selectAll()
+
+    def execute_cleanup(self, dry_run: bool = True):
+        """정리 작업 실행"""
+        if not self.analysis_result:
+            return
+
+        selected_rows = self.table_orphans.selectionModel().selectedRows()
+        if not selected_rows:
+            QMessageBox.warning(self, "선택 필요", "정리할 고아 레코드를 선택하세요.")
+            return
+
+        # 실제 실행 시 확인
+        if not dry_run:
+            reply = QMessageBox.warning(
+                self,
+                "실행 확인",
+                f"선택된 {len(selected_rows)}개 항목에 대해 정리 작업을 실행합니다.\n\n"
+                "이 작업은 되돌릴 수 없습니다. 계속하시겠습니까?",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No
+            )
+            if reply != QMessageBox.StandardButton.Yes:
+                return
+
+        # 정리 작업 목록 생성
+        schema = self.analysis_result.schema
+        action = ActionType.DELETE if self.radio_delete.isChecked() else ActionType.SET_NULL
+        analyzer = MigrationAnalyzer(self.connector)
+
+        actions = []
+        for row_index in selected_rows:
+            row = row_index.row()
+            if row < len(self.analysis_result.orphan_records):
+                orphan = self.analysis_result.orphan_records[row]
+                cleanup = analyzer.generate_cleanup_sql(orphan, action, schema, dry_run=dry_run)
+                actions.append(cleanup)
+
+        # UI 비활성화
+        self.btn_dry_run.setEnabled(False)
+        self.btn_execute.setEnabled(False)
+        self.progress_bar.setVisible(True)
+        self.progress_bar.setRange(0, 0)
+
+        mode = "DRY-RUN" if dry_run else "실행"
+        self.add_log(f"🔧 [{mode}] 정리 작업 시작 ({len(actions)}개)")
+
+        # 워커 실행
+        self.cleanup_worker = CleanupWorker(
+            connector=self.connector,
+            schema=schema,
+            actions=actions,
+            dry_run=dry_run
+        )
+
+        self.cleanup_worker.progress.connect(self.add_log)
+        self.cleanup_worker.action_complete.connect(self.on_action_complete)
+        self.cleanup_worker.finished.connect(self.on_cleanup_finished)
+        self.cleanup_worker.start()
+
+    def on_action_complete(self, table: str, success: bool, message: str, affected: int):
+        """개별 정리 작업 완료 시"""
+        status = "✅" if success else "❌"
+        self.add_log(f"  {status} {table}: {message}")
+
+    def on_cleanup_finished(self, success: bool, message: str, results: dict):
+        """정리 작업 완료 시"""
+        self.btn_dry_run.setEnabled(True)
+        self.btn_execute.setEnabled(True)
+        self.progress_bar.setVisible(False)
+
+        self.add_log(message)
+
+        # 결과 요약
+        total_affected = sum(r.get('affected_rows', 0) for r in results.values())
+        success_count = sum(1 for r in results.values() if r.get('success'))
+        fail_count = len(results) - success_count
+
+        QMessageBox.information(
+            self,
+            "작업 완료",
+            f"정리 작업이 완료되었습니다.\n\n"
+            f"성공: {success_count}개\n"
+            f"실패: {fail_count}개\n"
+            f"영향받은 행: {total_affected:,}개"
+        )
+
+
+class MigrationWizard:
+    """마이그레이션 분석 위저드"""
+
+    @staticmethod
+    def start(parent=None, tunnel_engine=None, config_manager=None) -> bool:
+        """
+        마이그레이션 분석 시작
+
+        Args:
+            parent: 부모 위젯
+            tunnel_engine: TunnelEngine 인스턴스
+            config_manager: ConfigManager 인스턴스
+
+        Returns:
+            성공 여부
+        """
+        from src.ui.dialogs.db_dialogs import DBConnectionDialog
+
+        # 1단계: DB 연결
+        conn_dialog = DBConnectionDialog(parent, tunnel_engine, config_manager)
+        if conn_dialog.exec() != QDialog.DialogCode.Accepted:
+            return False
+
+        connector = conn_dialog.connector
+        if not connector:
+            return False
+
+        # 2단계: 마이그레이션 분석 다이얼로그
+        try:
+            analyzer_dialog = MigrationAnalyzerDialog(parent, connector, config_manager)
+            analyzer_dialog.exec()
+            return True
+        finally:
+            # 연결 종료
+            if connector:
+                connector.disconnect()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -8,6 +8,7 @@ from PyQt6.QtGui import QAction, QIcon
 from src.ui.dialogs.tunnel_config import TunnelConfigDialog
 from src.ui.dialogs.settings import CloseConfirmDialog, SettingsDialog
 from src.ui.dialogs.db_dialogs import MySQLShellWizard
+from src.ui.dialogs.migration_dialogs import MigrationWizard
 
 
 class TunnelManagerUI(QMainWindow):
@@ -72,6 +73,17 @@ class TunnelManagerUI(QMainWindow):
         """)
         btn_mysqlsh_import.clicked.connect(self.open_mysqlsh_import)
 
+        # [Migration Analyzer] 버튼 - 마이그레이션 분석
+        btn_migration = QPushButton("🔄 Migration")
+        btn_migration.setStyleSheet("""
+            QPushButton {
+                background-color: #9b59b6; color: white; font-weight: bold;
+                padding: 6px 16px; border-radius: 4px; border: none;
+            }
+            QPushButton:hover { background-color: #8e44ad; }
+        """)
+        btn_migration.clicked.connect(self.open_migration_analyzer)
+
         # [새로고침] 버튼 - Secondary 스타일
         btn_refresh = QPushButton("🔄 설정 로드")
         btn_refresh.setStyleSheet("""
@@ -99,6 +111,7 @@ class TunnelManagerUI(QMainWindow):
         header_layout.addWidget(btn_add)
         header_layout.addWidget(btn_mysqlsh_export)
         header_layout.addWidget(btn_mysqlsh_import)
+        header_layout.addWidget(btn_migration)
         header_layout.addWidget(btn_refresh)
         header_layout.addWidget(btn_settings)
         layout.addLayout(header_layout)
@@ -318,6 +331,14 @@ class TunnelManagerUI(QMainWindow):
             config_manager=self.config_mgr
         )
         wizard.start_import()
+
+    def open_migration_analyzer(self):
+        """마이그레이션 분석기 열기"""
+        MigrationWizard.start(
+            parent=self,
+            tunnel_engine=self.engine,
+            config_manager=self.config_mgr
+        )
 
     # --- 기존 터널링 로직 ---
     def start_tunnel(self, tunnel_config):

--- a/src/ui/workers/__init__.py
+++ b/src/ui/workers/__init__.py
@@ -1,3 +1,4 @@
 from .mysql_worker import MySQLShellWorker
+from .migration_worker import MigrationAnalyzerWorker, CleanupWorker
 
-__all__ = ['MySQLShellWorker']
+__all__ = ['MySQLShellWorker', 'MigrationAnalyzerWorker', 'CleanupWorker']

--- a/src/ui/workers/migration_worker.py
+++ b/src/ui/workers/migration_worker.py
@@ -1,0 +1,111 @@
+"""마이그레이션 분석 작업 스레드"""
+from PyQt6.QtCore import QThread, pyqtSignal
+
+from src.core.db_connector import MySQLConnector
+from src.core.migration_analyzer import (
+    MigrationAnalyzer, AnalysisResult, CleanupAction, ActionType
+)
+
+
+class MigrationAnalyzerWorker(QThread):
+    """마이그레이션 분석 작업 스레드"""
+    progress = pyqtSignal(str)  # 진행 메시지
+    analysis_complete = pyqtSignal(object)  # AnalysisResult
+    finished = pyqtSignal(bool, str)  # success, message
+
+    def __init__(
+        self,
+        connector: MySQLConnector,
+        schema: str,
+        check_orphans: bool = True,
+        check_charset: bool = True,
+        check_keywords: bool = True,
+        check_routines: bool = True,
+        check_sql_mode: bool = True
+    ):
+        super().__init__()
+        self.connector = connector
+        self.schema = schema
+        self.check_orphans = check_orphans
+        self.check_charset = check_charset
+        self.check_keywords = check_keywords
+        self.check_routines = check_routines
+        self.check_sql_mode = check_sql_mode
+
+    def run(self):
+        try:
+            analyzer = MigrationAnalyzer(self.connector)
+            analyzer.set_progress_callback(lambda msg: self.progress.emit(msg))
+
+            result = analyzer.analyze_schema(
+                self.schema,
+                check_orphans=self.check_orphans,
+                check_charset=self.check_charset,
+                check_keywords=self.check_keywords,
+                check_routines=self.check_routines,
+                check_sql_mode=self.check_sql_mode
+            )
+
+            self.analysis_complete.emit(result)
+            self.finished.emit(True, "분석 완료")
+
+        except Exception as e:
+            self.finished.emit(False, f"분석 오류: {str(e)}")
+
+
+class CleanupWorker(QThread):
+    """정리 작업 실행 스레드"""
+    progress = pyqtSignal(str)  # 진행 메시지
+    action_complete = pyqtSignal(str, bool, str, int)  # table, success, message, affected_rows
+    finished = pyqtSignal(bool, str, dict)  # success, message, results
+
+    def __init__(
+        self,
+        connector: MySQLConnector,
+        schema: str,
+        actions: list,  # List[CleanupAction]
+        dry_run: bool = True
+    ):
+        super().__init__()
+        self.connector = connector
+        self.schema = schema
+        self.actions = actions
+        self.dry_run = dry_run
+
+    def run(self):
+        try:
+            analyzer = MigrationAnalyzer(self.connector)
+            analyzer.set_progress_callback(lambda msg: self.progress.emit(msg))
+
+            results = {}
+            total_affected = 0
+            all_success = True
+
+            mode = "[DRY-RUN]" if self.dry_run else "[실행]"
+            self.progress.emit(f"🔧 {mode} 정리 작업 시작 ({len(self.actions)}개)")
+
+            for i, action in enumerate(self.actions, 1):
+                self.progress.emit(f"  {mode} 처리 중: {action.table} ({i}/{len(self.actions)})")
+
+                success, msg, affected = analyzer.execute_cleanup(action, dry_run=self.dry_run)
+
+                results[action.table] = {
+                    'success': success,
+                    'message': msg,
+                    'affected_rows': affected,
+                    'action_type': action.action_type.value
+                }
+
+                self.action_complete.emit(action.table, success, msg, affected)
+
+                if success:
+                    total_affected += affected
+                else:
+                    all_success = False
+
+            summary = f"✅ {mode} 완료: {total_affected}개 행 {'영향받음' if self.dry_run else '처리됨'}"
+            self.progress.emit(summary)
+            self.finished.emit(all_success, summary, results)
+
+        except Exception as e:
+            self.finished.emit(False, f"정리 작업 오류: {str(e)}", {})


### PR DESCRIPTION
Features:
- Orphan record detection (FK relations with missing parent records)
- Charset issues check (utf8mb3 to utf8mb4 migration needs)
- Reserved keyword conflicts detection for MySQL 8.4
- Deprecated functions usage in stored procedures/functions
- SQL mode compatibility check
- FK relationship tree visualization
- Dry-run mode for safe preview before cleanup
- Cleanup actions: DELETE or SET NULL for orphan records

New files:
- src/core/migration_analyzer.py: Core analysis logic
- src/ui/workers/migration_worker.py: QThread workers
- src/ui/dialogs/migration_dialogs.py: Analysis UI dialogs

UI:
- Added "Migration" button to main window header