### PR TITLE
fix: 스키마 비교 기능 오류 수정

### DIFF
--- a/src/ui/dialogs/diff_dialog.py
+++ b/src/ui/dialogs/diff_dialog.py
@@ -263,18 +263,9 @@ class SchemaDiffDialog(QDialog):
                 return
 
             # 스키마 목록 조회
-            query = """
-                SELECT SCHEMA_NAME
-                FROM INFORMATION_SCHEMA.SCHEMATA
-                WHERE SCHEMA_NAME NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')
-                ORDER BY SCHEMA_NAME
-            """
-            success, result = connector.execute_query(query)
-
-            if success:
-                for row in result:
-                    schema_name = row[0] if isinstance(row, tuple) else row['SCHEMA_NAME']
-                    schema_combo.addItem(schema_name)
+            schemas = connector.get_schemas(use_cache=False)
+            for schema_name in schemas:
+                schema_combo.addItem(schema_name)
 
             connector.disconnect()
 


### PR DESCRIPTION
## Summary
- `SchemaExtractor`와 `SchemaDiffDialog`에서 존재하지 않는 `execute_query()` 호출 → `MySQLConnector`의 실제 API인 `execute()`와 `get_schemas()`로 변경
- DictCursor 전용이므로 불필요한 `isinstance(row, tuple)` 분기 제거
- 2파일 수정, 100줄 삭제 / 65줄 추가 (코드 간결화)

Closes #6

## Test plan
- [ ] 정상 연결된 터널에서 스키마 비교 다이얼로그 열기
- [ ] 소스/타겟 터널 선택 시 스키마 목록이 정상 로드되는지 확인
- [ ] 비교 시작 후 테이블/컬럼/인덱스/FK 차이가 정상 표시되는지 확인
- [ ] 동기화 스크립트 생성이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)