### PR TITLE
fix: version-gate 중복 bump 버그 수정

### DIFF
--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -84,18 +84,20 @@ jobs:
             echo "needs_rebump=true" >> "$GITHUB_OUTPUT"
           fi
 
-          # PR 커밋 히스토리 체크 (페이지네이션 적용)
+          # PR 커밋 히스토리 체크 (페이지네이션 적용, 최신 bump만 검증)
           BUMP_MSGS=$(gh api --paginate \
             "repos/${{ github.repository }}/pulls/${PR_NUMBER}/commits" \
             --jq '.[].commit.message' | grep "^chore: bump version" || true)
           if [ -n "$BUMP_MSGS" ]; then
-            if echo "$BUMP_MSGS" | grep -q "\[$BUMP_TYPE\]" || \
-               ! echo "$BUMP_MSGS" | grep -qE "\[(patch|minor|major)\]"; then
-              echo "PR에 이미 bump 커밋 존재 (타입 일치 또는 레거시). 체크 통과."
+            # 최신 bump 커밋만 확인 (API는 시간순 반환, tail -1 = 가장 최근)
+            LATEST_BUMP=$(echo "$BUMP_MSGS" | tail -1)
+            if echo "$LATEST_BUMP" | grep -q "\[$BUMP_TYPE\]" || \
+               ! echo "$LATEST_BUMP" | grep -qE "\[(patch|minor|major)\]"; then
+              echo "PR의 최신 bump 커밋이 현재 라벨과 일치 (또는 레거시). 체크 통과."
               echo "bump_type=" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            echo "기존 bump 커밋이 현재 라벨과 불일치. 재bump 필요."
+            echo "최신 bump 커밋이 현재 라벨과 불일치. 재bump 필요."
             echo "needs_rebump=true" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary
- **가드 1 강화**: PR 커밋 히스토리 전체에서 bump 커밋을 검색하여, HEAD 위에 새 커밋이 쌓여도 중복 bump 방지
- **가드 2 수정**: 깨진 `--dry-run` 비교를 `origin/main` base 버전 비교로 교체하여 안전망 역할 수행

## Test plan
- [ ] 테스트 PR 생성 후 `version:patch` 라벨 부착 → 첫 bump 정상 실행 확인
- [ ] 추가 커밋 push → 워크플로 로그에서 "PR에 이미 bump 커밋 존재" 메시지와 함께 스킵 확인
- [ ] PR 머지 → `create-release-tag.yml` 정상 트리거 확인

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)