### PR TITLE
chore: pyproject.toml 메타데이터 보완 (#43)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,17 @@ description = "SSH Tunnel and MySQL Database Manager"
 readme = "README.md"
 requires-python = ">=3.9"
 license = {text = "MIT"}
-authors = []
+authors = [{name = "sanghyun-io"}]
+keywords = ["ssh", "mysql", "tunnel", "database", "migration", "PyQt6"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: Microsoft :: Windows",
+    "Topic :: Database",
+]
 dependencies = [
     "PyQt6>=6.4.0",
     "sshtunnel>=0.4.0",
@@ -29,6 +39,11 @@ dev = [
     "pytest-mock>=3.0.0",
     "pytest-cov>=4.0.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/sanghyun-io/tunnelforge"
+Repository = "https://github.com/sanghyun-io/tunnelforge"
+Issues = "https://github.com/sanghyun-io/tunnelforge/issues"
 
 [project.scripts]
 tunnelforge = "main:main"


### PR DESCRIPTION
## Summary

- `authors` 필드에 `sanghyun-io` 추가
- `keywords` 필드 추가: ssh, mysql, tunnel, database, migration, PyQt6
- `classifiers` 필드 추가: Python 3.9~3.12, Windows OS, Database 토픽
- `[project.urls]` 섹션 추가: Homepage, Repository, Issues URL

## Test plan

- [x] `python -m py_compile main.py` 구문 검사 통과

Closes #43

Generated with [Claude Code](https://claude.com/claude-code)