### PR TITLE
Fix: 연결 테스트 시 전원이 켜지는 버그 및 자동 재연결 수정

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tunnelforge"
-version = "1.14.1"
+version = "1.14.4"
 description = "SSH Tunnel and MySQL Database Manager"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/core/tunnel_monitor.py
+++ b/src/core/tunnel_monitor.py
@@ -457,7 +457,27 @@ class TunnelMonitor:
                 return
 
             try:
-                success, msg = self.tunnel_engine.start_tunnel(tunnel_id)
+                # start_tunnel은 config dict를 요구함. stop_tunnel이 tunnel_configs를
+                # 삭제하므로, 반드시 stop 호출 전에 config를 조회/보관한다.
+                config = self.tunnel_engine.tunnel_configs.get(tunnel_id)
+                if not config:
+                    with self._lock:
+                        status.state = TunnelState.ERROR
+                        status.error_message = "재연결 실패: 터널 설정을 찾을 수 없음"
+                        self._add_event(
+                            tunnel_id, "error", status.error_message
+                        )
+                        self._notify_callbacks(tunnel_id, status)
+                    return
+
+                # 끊긴 stale server 객체와 tunnel_configs 엔트리를 정리하여
+                # 포트 충돌 및 객체 누수를 방지한다.
+                self.tunnel_engine.stop_tunnel(tunnel_id)
+
+                # 자동 재연결은 포트 재사용 상황이라 포트 충돌 체크를 건너뛴다.
+                success, msg = self.tunnel_engine.start_tunnel(
+                    config, check_port=False
+                )
 
                 with self._lock:
                     if success:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -377,22 +377,21 @@ class TunnelManagerUI(QMainWindow):
             )
             return
 
-        # 터널 시작 시도
+        # 임시 터널로 연결 테스트 (실제 터널은 시작하지 않음)
         self.statusBar().showMessage(f"연결 테스트 중: {tunnel_name}...")
         QApplication.processEvents()
 
-        success, msg = self.engine.start_tunnel(tunnel)
+        success, msg = self.engine.test_connection(tunnel)
         if success:
             QMessageBox.information(
                 self, "연결 테스트",
-                f"✅ '{tunnel_name}' 터널 연결 성공!\n\n로컬 포트: {tunnel.get('local_port')}"
+                f"✅ '{tunnel_name}' 터널 연결 테스트 성공!\n\n{msg}"
             )
-            self.refresh_table()
             self.statusBar().showMessage(f"연결 성공: {tunnel_name}")
         else:
             QMessageBox.warning(
                 self, "연결 테스트",
-                f"❌ '{tunnel_name}' 터널 연결 실패\n\n원인: {msg}"
+                f"❌ '{tunnel_name}' 터널 연결 실패\n\n{msg}"
             )
             self.statusBar().showMessage(f"연결 실패: {tunnel_name}")
 

--- a/src/version.py
+++ b/src/version.py
@@ -4,7 +4,7 @@
 모든 버전 참조는 이 파일을 사용해야 합니다.
 """
 
-__version__ = "1.14.3"
+__version__ = "1.14.4"
 __app_name__ = "TunnelForge"
 
 # GitHub 저장소 정보 (업데이트 확인용)


### PR DESCRIPTION
## Summary

SSH 터널 연결 상태 관련 두 가지 버그를 수정합니다.

### 1. 연결 테스트 시 실제 터널이 시작되는 버그
컨텍스트 메뉴의 `🔍 연결 테스트`가 `engine.start_tunnel()`을 호출하여 실제 터널을 활성화하고 전원 버튼이 "중지"로 전환되던 문제. 이미 존재하는 비파괴 API `engine.test_connection()`을 사용하도록 교체하여 임시 터널로만 검증하고 즉시 종료합니다.

- `src/ui/main_window.py` `_on_tree_test_connection`
- `engine.start_tunnel` → `engine.test_connection`
- 성공 시 `refresh_table()` 호출 제거 (상태 불변)

### 2. 자동 재연결이 항상 실패하던 버그
절전/sleep 또는 장시간 유지 후 SSH 터널이 끊겼을 때 `TunnelMonitor._attempt_reconnect`가 `start_tunnel(tunnel_id)`로 문자열을 넘겨 매번 TypeError로 실패하여, 사용자에게는 "켜놓은 게 꺼진 걸로 보임" 증상이 발생했습니다.

- `src/core/tunnel_monitor.py` `_attempt_reconnect` 내부 reconnect 스레드
- `tunnel_configs`에서 config dict를 조회하여 `start_tunnel(config, check_port=False)`로 호출
- 재연결 직전 `stop_tunnel(tunnel_id)`로 stale server 정리 (포트 충돌·객체 누수 방지)
- config 미조회 시 ERROR 상태로 전환

## Versioning

`version:patch` — breaking change 없음, 사용자 가시 동작 변화는 버그 회복. (1.14.3 → 1.14.4)

## Test plan

- [ ] 터널이 꺼진 상태에서 `🔍 연결 테스트` 실행 → 성공/실패 결과 박스는 표시되지만 전원 버튼이 "시작"으로 유지되는지
- [ ] 터널이 켜진 상태에서 `🔍 연결 테스트` 실행 → "이미 연결되어 있습니다" 메시지 (기존 동작 유지)
- [ ] 직접 연결 모드에서 `🔍 연결 테스트` → 기존 동작 유지 (이번 수정 미영향)
- [ ] SSH 터널 연결 후 랩탑 sleep / Wi-Fi toggle / VPN 재연결 → 5초 내 disconnected 감지, backoff(1s, 2s, 5s…)로 자동 재연결 성공하여 🟢 상태 복귀
- [ ] 재연결 성공 후 로컬 포트로 실제 DB 쿼리가 정상 동작 (stale server가 덮이지 않음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)