### PR TITLE
Feat: 연결된 터널 더블클릭 시 SQL 에디터 열기

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tunnelforge"
-version = "1.15.1"
+version = "1.15.2"
 description = "SSH Tunnel and MySQL Database Manager"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ui/widgets/tunnel_tree.py
+++ b/src/ui/widgets/tunnel_tree.py
@@ -361,9 +361,14 @@ class TunnelTreeWidget(QTreeWidget):
             # 그룹 더블클릭: 접기/펼치기
             item.setExpanded(not item.isExpanded())
         elif item_type == self.ITEM_TYPE_TUNNEL:
-            # 터널 더블클릭: 수정 다이얼로그
+            # 터널 더블클릭: 연결 상태에 따라 분기
+            # - 🟢 (연결됨) → SQL 에디터 열기
+            # - 그 외 → 수정 다이얼로그 (기존 동작)
             tunnel_data = item_data.get('data', {})
-            self.tunnel_edit_requested.emit(tunnel_data)
+            if item.text(0) == "🟢":
+                self.tunnel_sql_editor.emit(tunnel_data)
+            else:
+                self.tunnel_edit_requested.emit(tunnel_data)
 
     def _on_item_expanded(self, item):
         """아이템 확장됨"""

--- a/src/version.py
+++ b/src/version.py
@@ -4,7 +4,7 @@
 모든 버전 참조는 이 파일을 사용해야 합니다.
 """
 
-__version__ = "1.15.1"
+__version__ = "1.15.2"
 __app_name__ = "TunnelForge"
 
 # GitHub 저장소 정보 (업데이트 확인용)


### PR DESCRIPTION
## Summary
터널 트리에서 터널 아이템을 더블클릭했을 때의 동작을 **연결 상태에 따라 분기**:

| 상태 | 동작 |
|---|---|
| 🟢 연결됨 | **SQL 에디터 열기** (신규) |
| 그 외 | 수정 다이얼로그 (기존 유지) |

## 변경 (`src/ui/widgets/tunnel_tree.py`)
`_on_item_double_clicked`에서 아이템의 상태 아이콘(`item.text(0)`)이 `🟢`인 경우 기존 `tunnel_sql_editor` 시그널을 emit하도록 분기 추가. 이 시그널은 우클릭 메뉴의 "📝 SQL 에디터" 항목에서 이미 emit되어 `_on_tree_sql_editor`가 처리 중이므로 신규 핸들러 없이 바로 재사용.

## 설계 근거
- DB 클라이언트 표준 UX (DBeaver/TablePlus 등) — 연결된 세션 더블클릭 = 쿼리 편집기
- DB 정보 미등록 등의 검증은 기존 `_on_tree_sql_editor` 경로에서 이미 처리되므로 중복 로직 불필요
- 연결되지 않은 터널은 기존 수정 다이얼로그 유지 → 기존 사용자 습관 보존

## Test plan
- [ ] 🟢 연결 상태 터널 더블클릭 → SQL 에디터 창이 해당 터널 컨텍스트로 열림
- [ ] ⚪ 미연결 터널 더블클릭 → 수정 다이얼로그 열림 (기존 동작)
- [ ] 그룹 더블클릭 → 접기/펼치기 (기존 동작)
- [ ] 우클릭 메뉴의 "📝 SQL 에디터" 항목은 기존처럼 정상 동작 (연결 여부 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)