### PR TITLE
Fix: 셀 편집 커밋 시 Production 환경 가드 적용

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tunnelforge"
-version = "1.15.2"
+version = "1.15.3"
 description = "SSH Tunnel and MySQL Database Manager"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ui/dialogs/sql_editor_dialog.py
+++ b/src/ui/dialogs/sql_editor_dialog.py
@@ -2777,6 +2777,32 @@ class SQLEditorDialog(QDialog):
         if pending_count == 0 and cell_edit_count == 0:
             return
 
+        # Production 환경 가드 (셀 편집에 한함 — pending_queries는 실행 시점에 이미 통과)
+        if table_edits:
+            from src.core.production_guard import ProductionGuard
+            guard = ProductionGuard(self)
+
+            # 관여 스키마별로 그룹화
+            schemas_with_tables = {}
+            for tbl_widget, ctx in table_edits:
+                schema_key = ctx['schema'] or (self.db_combo.currentText() or '')
+                schemas_with_tables.setdefault(schema_key, []).append(
+                    (ctx['table'], len(ctx['pending_edits']))
+                )
+
+            for schema, tables_info in schemas_with_tables.items():
+                details = '<br>'.join(
+                    f'• <code>{t}</code>: {n}개 셀 변경'
+                    for t, n in tables_info
+                )
+                if not guard.confirm_dangerous_operation(
+                    self.config,
+                    "셀 편집 커밋 (UPDATE)",
+                    schema or '(기본 스키마)',
+                    f"대상 테이블:<br>{details}"
+                ):
+                    return  # 사용자 취소 — 커밋 중단
+
         try:
             # 셀 편집이 있으면 같은 트랜잭션에서 UPDATE 실행
             if table_edits:

--- a/src/version.py
+++ b/src/version.py
@@ -4,7 +4,7 @@
 모든 버전 참조는 이 파일을 사용해야 합니다.
 """
 
-__version__ = "1.15.2"
+__version__ = "1.15.3"
 __app_name__ = "TunnelForge"
 
 # GitHub 저장소 정보 (업데이트 확인용)


### PR DESCRIPTION
## Summary
v1.15.1에 통합한 셀 편집 → 하단 "✅ 커밋" 경로가 `ProductionGuard` 체크를 우회하는 결함 수정. PROD 테이블을 셀 편집으로 경고 없이 UPDATE 할 수 있던 허점 차단.

## 문제
기존 `_execute_sql`은 DML 쿼리를 실행하기 전에 `ProductionGuard.confirm_dangerous_query`를 통과시킨다. 하지만 셀 편집은 사용자가 UPDATE 텍스트를 직접 작성하지 않기 때문에 이 경로를 거치지 않았고, 커밋 단계인 `_do_commit`에서도 별도 가드가 없어 PROD 테이블도 경고 0회로 반영되는 상황이었음.

## 변경 (`src/ui/dialogs/sql_editor_dialog.py` `_do_commit`)
셀 편집(`table_edits`)이 있을 때:
1. 관여 스키마별로 그룹화
2. 각 스키마마다 `ProductionGuard.confirm_dangerous_operation(self.config, ...)` 호출
   - PROD → `SchemaConfirmDialog` (스키마명 직접 입력 필요)
   - STAGING → Yes/No 확인 (기본값 No)
   - DEV/미설정 → 바로 진행
3. 하나라도 취소되면 커밋 전체 중단

`pending_queries`(사용자가 직접 작성해 이미 실행된 DML)는 실행 시점에 이미 가드를 통과했으므로 중복 확인 생략.

## Test plan
- [ ] PROD 터널의 테이블을 셀 편집 후 커밋 → 스키마명 입력 다이얼로그 뜨고, 틀리게 입력하면 진행 불가
- [ ] STAGING 터널 → Yes/No 다이얼로그, 기본값 No
- [ ] DEV/미설정 → 확인 없이 바로 커밋
- [ ] 두 스키마에 걸친 셀 편집 커밋 → 스키마별로 각각 다이얼로그 (하나 취소하면 전체 중단)
- [ ] DML 쿼리만 있고 셀 편집 없는 커밋 → 가드 호출 없음 (기존 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)