### PR TITLE
[codex] Harden Rust Core DB workflows

### DIFF
--- a/migration_core/src/lib.rs
+++ b/migration_core/src/lib.rs
@@ -657,15 +657,10 @@ impl CoreService {
                     "message": format!("unknown connection_id: {connection_id}")
                 })];
             };
-            return match execute_query_adapter(adapter, sql) {
-                Ok(rows) => vec![json!({
-                    "event": "result",
-                    "request_id": request.request_id,
-                    "command": "query.execute",
-                    "success": true,
-                    "rows": rows,
-                    "rows_affected": 0
-                })],
+            let params = query_params(&request.payload);
+            let bound_sql = bind_query_params(sql, &params);
+            return match execute_query_adapter(adapter, &bound_sql) {
+                Ok(rows) => query_result_events(request, rows),
                 Err(err) => vec![json!({
                     "event": "error",
                     "request_id": request.request_id,
@@ -1036,15 +1031,10 @@ fn query_execute(request: &Request) -> Vec<Value> {
         }
     };
 
-    match execute_query_live(&endpoint, sql) {
-        Ok(rows) => vec![json!({
-            "event": "result",
-            "request_id": request.request_id,
-            "command": "query.execute",
-            "success": true,
-            "rows": rows,
-            "rows_affected": 0
-        })],
+    let params = query_params(&request.payload);
+    let bound_sql = bind_query_params(sql, &params);
+    match execute_query_live(&endpoint, &bound_sql) {
+        Ok(rows) => query_result_events(request, rows),
         Err(err) => vec![json!({
             "event": "error",
             "request_id": request.request_id,
@@ -1053,12 +1043,61 @@ fn query_execute(request: &Request) -> Vec<Value> {
     }
 }
 
+fn query_result_events(request: &Request, rows: Vec<Value>) -> Vec<Value> {
+    let stream_rows = request
+        .payload
+        .get("stream_rows")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !stream_rows {
+        return vec![json!({
+            "event": "result",
+            "request_id": request.request_id,
+            "command": "query.execute",
+            "success": true,
+            "rows": rows,
+            "rows_affected": 0
+        })];
+    }
+
+    let batch_size = request
+        .payload
+        .get("row_batch_size")
+        .and_then(Value::as_u64)
+        .unwrap_or(500)
+        .max(1) as usize;
+    let total = rows.len();
+    let mut events = Vec::new();
+    for (index, chunk) in rows.chunks(batch_size).enumerate() {
+        events.push(json!({
+            "event": "row_batch",
+            "request_id": request.request_id,
+            "command": "query.execute",
+            "batch_index": index,
+            "rows": chunk,
+            "total": total
+        }));
+    }
+    events.push(json!({
+        "event": "result",
+        "request_id": request.request_id,
+        "command": "query.execute",
+        "success": true,
+        "rows": [],
+        "rows_streamed": total,
+        "rows_affected": 0
+    }));
+    events
+}
+
 fn query_cancel(request: &Request) -> Vec<Value> {
     vec![json!({
         "event": "result",
         "request_id": request.request_id,
         "command": "query.cancel",
         "success": true,
+        "cancelled": false,
+        "message": "No asynchronous query is registered for this JSONL worker",
         "job_id": request.payload.get("job_id").cloned().unwrap_or(Value::Null)
     })]
 }
@@ -1069,6 +1108,8 @@ fn job_cancel(request: &Request) -> Vec<Value> {
         "request_id": request.request_id,
         "command": "job.cancel",
         "success": true,
+        "cancelled": false,
+        "message": "UI workers cancel long-running Rust jobs by terminating the isolated core process",
         "job_id": request.payload.get("job_id").cloned().unwrap_or(Value::Null)
     })]
 }
@@ -1372,6 +1413,43 @@ fn request_endpoint(request: &Request) -> Result<Endpoint, String> {
         }
     }
     endpoint_from_value(&request.payload)
+}
+
+fn query_params(payload: &Value) -> Vec<Value> {
+    payload
+        .get("params")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn bind_query_params(sql: &str, params: &[Value]) -> String {
+    if params.is_empty() {
+        return sql.to_string();
+    }
+    let mut rendered = sql.to_string();
+    for (index, value) in params.iter().enumerate() {
+        let literal = sql_json_literal(value);
+        rendered = rendered.replacen("%s", &literal, 1);
+        rendered = rendered.replace(&format!("${}", index + 1), &literal);
+    }
+    rendered
+}
+
+fn sql_json_literal(value: &Value) -> String {
+    match value {
+        Value::Null => "NULL".to_string(),
+        Value::Bool(item) => {
+            if *item {
+                "TRUE".to_string()
+            } else {
+                "FALSE".to_string()
+            }
+        }
+        Value::Number(item) => item.to_string(),
+        Value::String(item) => format!("'{}'", item.replace('\\', "\\\\").replace('\'', "''")),
+        other => format!("'{}'", other.to_string().replace('\\', "\\\\").replace('\'', "''")),
+    }
 }
 
 fn connection_id(endpoint: &Endpoint) -> String {
@@ -2353,6 +2431,7 @@ fn migrate_streaming<F: FnMut(Value)>(request: &Request, mut emit: F) {
                     "request_id": request.request_id,
                     "command": "migrate",
                     "success": result.success,
+                    "cancelled": !result.success && options.cancel_after_chunks.is_some() && result.issues.is_empty(),
                     "rows_copied": result.rows_copied,
                     "chunks_copied": result.chunks_copied,
                     "state": result.state,
@@ -2410,6 +2489,7 @@ fn migrate_streaming<F: FnMut(Value)>(request: &Request, mut emit: F) {
         "request_id": request.request_id,
         "command": "migrate",
         "success": result.success,
+        "cancelled": !result.success && options.cancel_after_chunks.is_some() && result.issues.is_empty(),
         "rows_copied": result.rows_copied,
         "chunks_copied": result.chunks_copied,
         "state": result.state,
@@ -4783,6 +4863,34 @@ mod tests {
 
         assert_eq!(result["command"], "query.execute");
         assert_eq!(result["rows"][0]["name"], "alpha");
+    }
+
+    #[test]
+    fn query_param_binding_is_owned_by_core_protocol() {
+        let sql = bind_query_params(
+            "SELECT * FROM users WHERE id = %s AND name = $2",
+            &[json!(7), json!("O'Reilly")],
+        );
+
+        assert_eq!(sql, "SELECT * FROM users WHERE id = 7 AND name = 'O''Reilly'");
+    }
+
+    #[test]
+    fn query_result_streams_row_batches_when_requested() {
+        let events = query_result_events(
+            &Request {
+                command: "query.execute".to_string(),
+                request_id: Some("query-1".to_string()),
+                payload: json!({"stream_rows": true, "row_batch_size": 1}),
+            },
+            vec![json!({"id": 1}), json!({"id": 2})],
+        );
+
+        assert_eq!(events[0]["event"], "row_batch");
+        assert_eq!(events[0]["rows"][0]["id"], 1);
+        assert_eq!(events[1]["event"], "row_batch");
+        assert_eq!(events[2]["event"], "result");
+        assert_eq!(events[2]["rows_streamed"], 2);
     }
 
     #[test]

--- a/scripts/rust-core-regression-gate.ps1
+++ b/scripts/rust-core-regression-gate.ps1
@@ -1,0 +1,80 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path -Parent $PSScriptRoot
+$paths = @(
+    "src/core",
+    "src/exporters",
+    "src/ui",
+    "src/ui/workers",
+    "migration_core/src"
+)
+
+$legacyPattern = "pymysql|psycopg|mysqlsh|MySQLShell|MySQL Shell|mysql_shell|mysqlsh_exporter|mysql_worker|check_mysqlsh|migration-core|migration_core_executable"
+$engineLockedPattern = "from src\.core\.db_connector import MySQLConnector"
+$allowedEngineLocked = @(
+    "src/core/db_connector.py",
+    "src/core/migration_analyzer.py",
+    "src/core/migration_auto_recommend.py",
+    "src/core/migration_fix_wizard.py",
+    "src/core/migration_preflight.py",
+    "src/core/migration_validator.py",
+    "src/exporters/rust_dump_exporter.py",
+    "src/ui/dialogs/db_dialogs.py",
+    "src/ui/dialogs/diff_dialog.py",
+    "src/ui/dialogs/fix_wizard_dialog.py",
+    "src/ui/dialogs/migration_dialogs.py",
+    "src/ui/dialogs/oneclick_migration_dialog.py",
+    "src/ui/workers/fix_wizard_worker.py",
+    "src/ui/workers/metadata_worker.py",
+    "src/ui/workers/migration_worker.py"
+)
+
+Push-Location $root
+try {
+    $legacyHits = & rg -n $legacyPattern @paths
+    if ($LASTEXITCODE -eq 0) {
+        Write-Error "Rust Core regression gate failed: legacy DB/export helper reference found.`n$legacyHits"
+    }
+    if ($LASTEXITCODE -gt 1) {
+        exit $LASTEXITCODE
+    }
+
+    $engineHits = & rg -n $engineLockedPattern src/core src/ui
+    if ($LASTEXITCODE -eq 0) {
+        $unexpected = @()
+        foreach ($line in $engineHits) {
+            $file = ($line -split ":", 2)[0].Replace("\", "/")
+            if ($allowedEngineLocked -notcontains $file) {
+                $unexpected += $line
+            }
+        }
+        if ($unexpected.Count -gt 0) {
+            Write-Error "Rust Core regression gate failed: product path imports MySQLConnector directly.`n$($unexpected -join "`n")"
+        }
+    } elseif ($LASTEXITCODE -gt 1) {
+        exit $LASTEXITCODE
+    }
+
+    if ($env:RUST_CORE_REQUIRE_PERF_EVIDENCE -eq "1") {
+        $perfFiles = @(
+            "migration_core/target/perf_pg_mysql_1m_migrate.jsonl",
+            "migration_core/target/perf_pg_mysql_1m_verify.jsonl",
+            "migration_core/target/perf_stress_10m_resume.jsonl",
+            "migration_core/target/perf_stress_10m_verify.jsonl"
+        )
+        foreach ($file in $perfFiles) {
+            if (-not (Test-Path $file)) {
+                Write-Error "Rust Core performance gate failed: missing evidence file $file"
+            }
+            $result = Get-Content $file | Where-Object { $_ -match '"event"\s*:\s*"result"' } | Select-Object -Last 1 | ConvertFrom-Json
+            if (-not $result.success) {
+                Write-Error "Rust Core performance gate failed: $file did not finish successfully"
+            }
+        }
+    }
+
+    Write-Output "Rust Core regression gate passed."
+} finally {
+    Pop-Location
+}

--- a/src/core/db_core_service.py
+++ b/src/core/db_core_service.py
@@ -14,6 +14,27 @@ class DbCoreServiceError(RuntimeError):
     """Raised when the Rust DB core service cannot complete a request."""
 
 
+SUPPORTED_DB_ENGINES = {"mysql", "postgresql"}
+
+
+def normalize_db_engine(engine: Optional[str], port: Optional[int] = None) -> str:
+    """Return the Rust core engine id used by DB-facing product paths."""
+    value = str(engine or "").strip().lower()
+    if value in ("postgres", "postgresql", "pg"):
+        return "postgresql"
+    if value in ("mysql", "mariadb"):
+        return "mysql"
+    if int(port or 0) == 5432:
+        return "postgresql"
+    return "mysql"
+
+
+def default_database_for_engine(engine: str, database: Optional[str] = None) -> str:
+    if database:
+        return database
+    return "postgres" if normalize_db_engine(engine) == "postgresql" else ""
+
+
 @dataclass(frozen=True)
 class DbEndpoint:
     engine: str
@@ -162,21 +183,58 @@ class DbCoreFacade:
         differences = result.get("differences")
         return [item for item in differences if isinstance(item, dict)] if isinstance(differences, list) else []
 
-    def execute_query(self, endpoint: DbEndpoint, sql: str) -> List[Dict[str, Any]]:
+    def execute_query(
+        self,
+        endpoint: DbEndpoint,
+        sql: str,
+        params: Optional[Sequence[Any]] = None,
+    ) -> List[Dict[str, Any]]:
         result = self.client.request(
             "query.execute",
-            {"connection": endpoint.to_payload(), "sql": sql},
+            {"connection": endpoint.to_payload(), "sql": sql, "params": list(params or [])},
         )
         rows = result.get("rows")
         return [row for row in rows if isinstance(row, dict)] if isinstance(rows, list) else []
 
-    def execute_on_connection(self, connection_id: str, sql: str) -> List[Dict[str, Any]]:
+    def execute_on_connection(
+        self,
+        connection_id: str,
+        sql: str,
+        params: Optional[Sequence[Any]] = None,
+    ) -> List[Dict[str, Any]]:
         result = self.client.request(
             "query.execute",
-            {"connection_id": connection_id, "sql": sql},
+            {"connection_id": connection_id, "sql": sql, "params": list(params or [])},
         )
         rows = result.get("rows")
         return [row for row in rows if isinstance(row, dict)] if isinstance(rows, list) else []
+
+    def execute_on_connection_streaming(
+        self,
+        connection_id: str,
+        sql: str,
+        params: Optional[Sequence[Any]] = None,
+        row_batch_size: int = 500,
+        on_batch: Optional[Callable[[List[Dict[str, Any]]], None]] = None,
+    ) -> Dict[str, Any]:
+        def handle_event(payload: Dict[str, Any]) -> None:
+            if payload.get("event") != "row_batch" or not on_batch:
+                return
+            rows = payload.get("rows")
+            if isinstance(rows, list):
+                on_batch([row for row in rows if isinstance(row, dict)])
+
+        return self.client.request(
+            "query.execute",
+            {
+                "connection_id": connection_id,
+                "sql": sql,
+                "params": list(params or []),
+                "stream_rows": True,
+                "row_batch_size": int(row_batch_size),
+            },
+            on_event=handle_event,
+        )
 
     def run_migration(
         self,
@@ -273,9 +331,123 @@ class RustDbConnector:
     def schema_exists(self, schema_name: Optional[str]) -> bool:
         if not schema_name:
             return True
-        schema = self.facade.inspect_schema(self.endpoint)
-        tables = schema.get("tables")
-        return isinstance(tables, list)
+        if not self.connection:
+            success, _ = self.connect()
+            if not success:
+                return False
+        try:
+            with self.connection.cursor() as cursor:
+                if self.endpoint.engine == "postgresql":
+                    cursor.execute(
+                        "SELECT 1 FROM information_schema.schemata WHERE schema_name = %s",
+                        (schema_name,),
+                    )
+                else:
+                    cursor.execute("SHOW DATABASES LIKE %s", (schema_name,))
+                return cursor.fetchone() is not None
+        except Exception:
+            return False
+
+    def get_schemas(self, use_cache: bool = True) -> List[str]:
+        if not self.connection:
+            success, _ = self.connect()
+            if not success:
+                return []
+        try:
+            with self.connection.cursor() as cursor:
+                if self.endpoint.engine == "postgresql":
+                    cursor.execute(
+                        "SELECT schema_name FROM information_schema.schemata "
+                        "WHERE schema_name <> 'information_schema' "
+                        "AND schema_name NOT LIKE 'pg_%' "
+                        "ORDER BY schema_name"
+                    )
+                    return [str(row.get("schema_name")) for row in cursor.fetchall()]
+                cursor.execute("SHOW DATABASES")
+                excluded = {"information_schema", "performance_schema", "mysql", "sys"}
+                return [
+                    str(row.get("Database"))
+                    for row in cursor.fetchall()
+                    if str(row.get("Database")) not in excluded
+                ]
+        except Exception:
+            return []
+
+    def get_tables(self, schema: Optional[str] = None, use_cache: bool = True) -> List[str]:
+        endpoint = self.endpoint
+        if schema:
+            endpoint = DbEndpoint(
+                engine=self.endpoint.engine,
+                host=self.endpoint.host,
+                port=self.endpoint.port,
+                user=self.endpoint.user,
+                password=self.endpoint.password,
+                database=self.endpoint.database if self.endpoint.engine == "postgresql" else schema,
+                schema=schema if self.endpoint.engine == "postgresql" else "",
+            )
+        return self.facade.list_tables(endpoint)
+
+    def get_db_version(self) -> str:
+        if not self.connection:
+            success, _ = self.connect()
+            if not success:
+                return ""
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute("SELECT VERSION() AS version" if self.endpoint.engine == "mysql" else "SELECT version() AS version")
+                row = cursor.fetchone() or {}
+                return str(row.get("version", ""))
+        except Exception:
+            return ""
+
+    def get_column_names(self, table: str, schema: Optional[str] = None) -> List[str]:
+        if not self.connection:
+            success, _ = self.connect()
+            if not success:
+                return []
+        try:
+            with self.connection.cursor() as cursor:
+                if self.endpoint.engine == "postgresql":
+                    cursor.execute(
+                        "SELECT column_name FROM information_schema.columns "
+                        "WHERE table_schema = %s AND table_name = %s "
+                        "ORDER BY ordinal_position",
+                        (schema or self.endpoint.schema or "public", table),
+                    )
+                else:
+                    cursor.execute(
+                        "SELECT COLUMN_NAME AS column_name FROM information_schema.columns "
+                        "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s "
+                        "ORDER BY ORDINAL_POSITION",
+                        (schema or self.endpoint.database, table),
+                    )
+                return [str(row.get("column_name")) for row in cursor.fetchall()]
+        except Exception:
+            return []
+
+
+def create_rust_db_connector(
+    engine: Optional[str],
+    host: str,
+    port: int,
+    user: str,
+    password: str,
+    database: Optional[str] = None,
+    schema: str = "",
+    facade: Optional[DbCoreFacade] = None,
+) -> RustDbConnector:
+    """Create an engine-aware Rust connector for UI/orchestration code."""
+    resolved_engine = normalize_db_engine(engine, port)
+    return RustDbConnector(
+        resolved_engine,
+        host,
+        int(port),
+        user,
+        password,
+        default_database_for_engine(resolved_engine, database),
+        schema,
+        facade=facade,
+    )
 
 
 class RustDbConnection:
@@ -287,6 +459,7 @@ class RustDbConnection:
         self.connection_id = connection_id
         self.open = True
         self._autocommit = True
+        self._in_transaction = False
 
     def cursor(self) -> "RustDbCursor":
         return RustDbCursor(self)
@@ -303,13 +476,38 @@ class RustDbConnection:
     def commit(self) -> None:
         if self.open:
             self.facade.execute_on_connection(self.connection_id, "COMMIT")
+            self._in_transaction = False
+            if not self._autocommit:
+                self._begin_transaction()
 
     def rollback(self) -> None:
         if self.open:
             self.facade.execute_on_connection(self.connection_id, "ROLLBACK")
+            self._in_transaction = False
+            if not self._autocommit:
+                self._begin_transaction()
 
     def autocommit(self, enabled: bool) -> None:
         self._autocommit = bool(enabled)
+        if not self.open:
+            return
+        if self.endpoint.engine == "mysql":
+            self.facade.execute_on_connection(
+                self.connection_id,
+                "SET autocommit = 1" if enabled else "SET autocommit = 0",
+            )
+            self._in_transaction = not enabled
+        elif enabled:
+            if self._in_transaction:
+                self.facade.execute_on_connection(self.connection_id, "COMMIT")
+            self._in_transaction = False
+        else:
+            self._begin_transaction()
+
+    def _begin_transaction(self) -> None:
+        if self.open and not self._in_transaction:
+            self.facade.execute_on_connection(self.connection_id, "BEGIN")
+            self._in_transaction = True
 
     def select_db(self, database: str) -> None:
         self.endpoint = DbEndpoint(
@@ -341,14 +539,14 @@ class RustDbCursor:
         return False
 
     def execute(self, query: str, params: Optional[Sequence[Any]] = None) -> int:
-        sql = bind_sql_params(query, params)
         self._rows = self.connection.facade.execute_on_connection(
             self.connection.connection_id,
-            sql,
+            query,
+            params=params,
         )
         if self._rows:
             self.description = [(column,) for column in self._rows[0].keys()]
-        elif query_returns_rows(sql):
+        elif query_returns_rows(query):
             self.description = []
         else:
             self.description = None

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -18,6 +18,7 @@ from typing import List, Dict, Any, Optional, Callable, Tuple
 
 from src.core.logger import get_logger
 from src.core.constants import DEFAULT_MYSQL_PORT, DEFAULT_LOCAL_HOST
+from src.core.db_core_service import create_rust_db_connector, normalize_db_engine
 
 logger = get_logger(__name__)
 
@@ -637,8 +638,6 @@ class BackupScheduler:
         Returns:
             (success, message)
         """
-        from src.core.db_connector import MySQLConnector
-
         logger.info(f"SQL 쿼리 실행 시작: {schedule.name}")
 
         try:
@@ -651,6 +650,8 @@ class BackupScheduler:
                     self._log_backup(schedule, False, error_msg)
                     return False, error_msg
 
+            config = getattr(self.tunnel_engine, 'tunnel_configs', {}).get(schedule.tunnel_id, {})
+
             # 연결 정보 가져오기
             conn_info = self.tunnel_engine.get_connection_info(schedule.tunnel_id)
             if not conn_info:
@@ -659,13 +660,28 @@ class BackupScheduler:
                 self._log_backup(schedule, False, error_msg)
                 return False, error_msg
 
+            if isinstance(conn_info, dict):
+                host = conn_info.get('host', DEFAULT_LOCAL_HOST)
+                port = int(conn_info.get('local_port') or conn_info.get('port') or DEFAULT_MYSQL_PORT)
+                user = conn_info.get('db_user') or conn_info.get('db_username') or config.get('db_username') or 'root'
+                password = conn_info.get('db_password') or config.get('db_password') or ''
+            else:
+                host, port = conn_info
+                port = int(port or DEFAULT_MYSQL_PORT)
+                user = config.get('db_user') or config.get('db_username') or 'root'
+                password = config.get('db_password') or ''
+
+            engine = normalize_db_engine(config.get('db_engine'), config.get('remote_port') or port)
+
             # DB 연결
-            connector = MySQLConnector(
-                host=conn_info.get('host', DEFAULT_LOCAL_HOST),
-                port=conn_info.get('local_port', DEFAULT_MYSQL_PORT),
-                user=conn_info.get('db_user', 'root'),
-                password=conn_info.get('db_password', ''),
-                database=schedule.schema if schedule.schema else None
+            connector = create_rust_db_connector(
+                engine,
+                host or DEFAULT_LOCAL_HOST,
+                port,
+                user,
+                password,
+                schedule.schema if schedule.schema else None,
+                schema=schedule.schema if engine == 'postgresql' else "",
             )
 
             success, msg = connector.connect()
@@ -788,13 +804,18 @@ class BackupScheduler:
 
             with connector.connection.cursor() as cursor:
                 # 타임아웃 설정 (MySQL 8.0+)
+                engine = getattr(getattr(connector, "connection", None), "endpoint", None)
+                engine_name = getattr(engine, "engine", "mysql")
                 if schedule.query_timeout > 0:
                     try:
-                        cursor.execute(
-                            f"SET SESSION MAX_EXECUTION_TIME = {schedule.query_timeout * 1000}"
-                        )
+                        if engine_name == "postgresql":
+                            cursor.execute(f"SET statement_timeout = {schedule.query_timeout * 1000}")
+                        else:
+                            cursor.execute(
+                                f"SET SESSION MAX_EXECUTION_TIME = {schedule.query_timeout * 1000}"
+                            )
                     except Exception:
-                        # MAX_EXECUTION_TIME 미지원 시 무시
+                        # 엔진별 statement timeout 미지원 시 무시
                         pass
 
                 # 쿼리 실행

--- a/src/core/tunnel_monitor.py
+++ b/src/core/tunnel_monitor.py
@@ -1,7 +1,7 @@
 """
 터널 상태 모니터링
 - 연결 상태 실시간 감시
-- Latency 측정 (MySQL ping 사용)
+- Latency 측정 (Rust DB Core health connection 사용)
 - 자동 재연결
 - 이벤트 히스토리
 """
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import Dict, List, Optional, Callable, Any
 from enum import Enum
 
-from src.core.db_connector import MySQLConnector
+from src.core.db_core_service import create_rust_db_connector, normalize_db_engine
 from src.core.logger import get_logger
 from src.core.constants import DEFAULT_MYSQL_PORT, DEFAULT_LOCAL_HOST
 
@@ -101,7 +101,7 @@ class TunnelMonitor:
         self._stop_event = threading.Event()
         self._lock = threading.RLock()  # RLock: 재진입 가능 (on_tunnel_connected 등 내부 중첩 호출 대응)
 
-        # Health check용 MySQL 연결 캐시 (터널별 1개씩 유지)
+        # Health check용 Rust DB Core 연결 캐시 (터널별 1개씩 유지)
         self._health_connections: Dict[str, Any] = {}
 
         # 설정에서 자동 재연결 설정 로드
@@ -313,11 +313,9 @@ class TunnelMonitor:
                         self._notify_callbacks(tunnel_id, status)
 
     def _measure_latency(self, tunnel_id: str) -> float:
-        """Latency 측정 (MySQL ping 사용)
+        """Latency 측정 (Rust DB Core 연결 사용)
 
-        MySQL ping을 사용하여 실제 DB 연결 응답 시간을 측정합니다.
-        TCP 소켓만 연결하면 MySQL handshake_error가 발생하므로,
-        정상적인 MySQL 프로토콜을 사용합니다.
+        MySQL/PostgreSQL 모두 실제 DB 프로토콜 연결을 통해 응답 시간을 측정합니다.
 
         Args:
             tunnel_id: 터널 ID
@@ -333,7 +331,8 @@ class TunnelMonitor:
             # DB 인증 정보 확인
             db_username = config.get('db_username', '')
             db_password = config.get('db_password', '')
-            db_name = config.get('db_name', '')
+            db_name = config.get('db_name') or config.get('default_database') or config.get('default_schema') or ''
+            db_engine = normalize_db_engine(config.get('db_engine'), config.get('remote_port'))
 
             # 인증 정보가 없으면 측정 불가
             if not db_username:
@@ -359,19 +358,19 @@ class TunnelMonitor:
             # 연결이 없거나 끊어진 경우 재연결
             if conn is None:
                 conn = self._create_health_connection(
-                    tunnel_id, host, port, db_username, db_password, db_name
+                    tunnel_id, db_engine, host, port, db_username, db_password, db_name
                 )
                 if conn is None:
                     return -1
 
-            # MySQL ping으로 latency 측정
+            # Rust Core connection ping으로 latency 측정
             start = time.time()
             try:
                 conn.ping(reconnect=False)
                 latency = (time.time() - start) * 1000
                 return latency
             except Exception as e:
-                logger.debug(f"MySQL ping 실패 ({tunnel_id}): {e}")
+                logger.debug(f"DB ping 실패 ({tunnel_id}): {e}")
                 # 연결 끊김 - 캐시에서 제거
                 self._cleanup_health_connection(tunnel_id)
                 return -1
@@ -381,10 +380,10 @@ class TunnelMonitor:
             return -1
 
     def _create_health_connection(
-        self, tunnel_id: str, host: str, port: int,
+        self, tunnel_id: str, engine: str, host: str, port: int,
         username: str, password: str, database: str
     ) -> Optional[Any]:
-        """Health check용 MySQL 연결 생성
+        """Health check용 DB 연결 생성
 
         Args:
             tunnel_id: 터널 ID
@@ -398,7 +397,14 @@ class TunnelMonitor:
             DB connection 또는 None
         """
         try:
-            connector = MySQLConnector(host, port, username, password, database if database else None)
+            connector = create_rust_db_connector(
+                engine,
+                host,
+                port,
+                username,
+                password,
+                database if database else None,
+            )
             success, message = connector.connect()
             if not success or connector.connection is None:
                 logger.debug(f"Health check 연결 생성 실패 ({tunnel_id}): {message}")

--- a/src/ui/dialogs/cross_engine_migration_dialog.py
+++ b/src/ui/dialogs/cross_engine_migration_dialog.py
@@ -47,6 +47,7 @@ class CrossEngineMigrationDialog(QDialog):
         self._last_checkpoint_path = None
         self._workflow_active = False
         self._current_command: Optional[str] = None
+        self._pending_after_inspect: Optional[str] = None
         self._execution_unlocked = False
         self.setWindowTitle("DB 전환")
         self.resize(900, 700)
@@ -93,11 +94,17 @@ class CrossEngineMigrationDialog(QDialog):
         option_layout.addStretch()
         layout.addWidget(option_group)
 
-        schema_group = QGroupBox("Normalized schema JSON")
+        schema_group = QGroupBox("스키마 검사 결과")
         schema_layout = QVBoxLayout(schema_group)
         load_layout = QHBoxLayout()
+        self.lbl_schema_status = QLabel("Source DB를 검사하면 Rust Core가 정규화한 스키마가 자동으로 채워집니다.")
+        schema_layout.addWidget(self.lbl_schema_status)
         self.btn_load_schema = QPushButton("JSON 불러오기")
+        self.btn_auto_inspect = QPushButton("Source 자동 검사")
         self.btn_load_schema.clicked.connect(self._load_schema_json)
+        self.btn_auto_inspect.clicked.connect(lambda: self._start_command("inspect"))
+        self.btn_auto_inspect.setToolTip("선택한 Source DB를 Rust Core schema.inspect로 검사합니다.")
+        load_layout.addWidget(self.btn_auto_inspect)
         load_layout.addWidget(self.btn_load_schema)
         load_layout.addStretch()
         schema_layout.addLayout(load_layout)
@@ -243,6 +250,13 @@ class CrossEngineMigrationDialog(QDialog):
             QMessageBox.warning(self, "작업 진행 중", "이미 실행 중인 작업이 있습니다.")
             return
 
+        if command not in ("inspect", "migrate") and self._schema_is_empty():
+            self._pending_after_inspect = command
+            self._workflow_active = workflow
+            self._append_log(f"[inspect] 스키마가 비어 있어 Source 자동 검사를 먼저 실행합니다.")
+            self._start_command("inspect", workflow=False)
+            return
+
         if command == "migrate":
             if not self._execution_unlocked:
                 QMessageBox.warning(
@@ -301,6 +315,8 @@ class CrossEngineMigrationDialog(QDialog):
         if schema is not None:
             self.txt_schema.setPlainText(json.dumps(schema, ensure_ascii=False, indent=2))
             self._set_execution_unlocked(False)
+            table_count = len(schema.get("tables", [])) if isinstance(schema.get("tables"), list) else 0
+            self.lbl_schema_status.setText(f"Rust Core 검사 완료: {table_count}개 테이블")
             self._append_log("스키마 검사 결과를 입력에 반영했습니다.")
         unsupported_objects = payload.get("unsupported_objects")
         if isinstance(unsupported_objects, list):
@@ -320,6 +336,11 @@ class CrossEngineMigrationDialog(QDialog):
             else:
                 self._append_log("차단 이슈가 있어 DB 변경 실행은 계속 잠겨 있습니다.")
         self._append_log(json.dumps(payload, ensure_ascii=False, indent=2))
+
+        if payload.get("command") == "inspect" and payload.get("success") and self._pending_after_inspect:
+            next_command = self._pending_after_inspect
+            self._pending_after_inspect = None
+            QTimer.singleShot(0, lambda: self._start_command(next_command, workflow=self._workflow_active))
 
     def _append_readiness_summary(self, payload: Dict):
         directions = payload.get("directions")
@@ -429,6 +450,7 @@ class CrossEngineMigrationDialog(QDialog):
     def _set_running(self, running: bool):
         for button in (
             self.btn_full_run,
+            self.btn_auto_inspect,
             self.btn_inspect,
             self.btn_preflight,
             self.btn_readiness,
@@ -459,6 +481,14 @@ class CrossEngineMigrationDialog(QDialog):
     def _lock_execution_due_to_input_change(self):
         if self._execution_unlocked:
             self._set_execution_unlocked(False)
+
+    def _schema_is_empty(self) -> bool:
+        try:
+            schema = json.loads(self.txt_schema.toPlainText() or "{}")
+        except json.JSONDecodeError:
+            return False
+        tables = schema.get("tables") if isinstance(schema, dict) else None
+        return not isinstance(tables, list) or len(tables) == 0
 
     def _connect_endpoint_lock_signals(self, form: "EndpointForm"):
         form.combo_tunnel.currentIndexChanged.connect(self._lock_execution_due_to_input_change)

--- a/src/ui/dialogs/sql_editor_dialog.py
+++ b/src/ui/dialogs/sql_editor_dialog.py
@@ -23,7 +23,22 @@ from PyQt6.QtGui import (
     QTextCursor, QKeySequence, QShortcut, QPen, QTextFormat
 )
 import re
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Tuple
+
+from src.core.db_core_service import create_rust_db_connector, normalize_db_engine
+
+
+def create_sql_editor_connector(engine, host, port, user, password, database=None):
+    db_engine = normalize_db_engine(engine, port)
+    return create_rust_db_connector(
+        db_engine,
+        host,
+        port,
+        user,
+        password,
+        database,
+        schema=database if db_engine == "postgresql" else "",
+    )
 
 
 # =====================================================================
@@ -696,8 +711,9 @@ class SQLQueryWorker(QThread):
     query_result = pyqtSignal(int, list, list, str, int, float)  # idx, columns, rows, error, affected, time
     finished = pyqtSignal(bool, str)
 
-    def __init__(self, host, port, user, password, database, queries):
+    def __init__(self, host, port, user, password, database, queries, engine="mysql"):
         super().__init__()
+        self.engine = normalize_db_engine(engine, port)
         self.host = host
         self.port = port
         self.user = user
@@ -706,11 +722,16 @@ class SQLQueryWorker(QThread):
         self.queries = queries  # List of query strings
 
     def run(self):
-        from src.core.db_connector import MySQLConnector
-
         connector = None
         try:
-            connector = MySQLConnector(self.host, self.port, self.user, self.password, self.database)
+            connector = create_sql_editor_connector(
+                self.engine,
+                self.host,
+                self.port,
+                self.user,
+                self.password,
+                self.database,
+            )
             success, msg = connector.connect()
 
             if not success:
@@ -733,6 +754,25 @@ class SQLQueryWorker(QThread):
 
                 start_time = time.time()
                 try:
+                    if query_returns_rows(query):
+                        rows = []
+
+                        def collect_batch(batch):
+                            rows.extend(batch)
+
+                        connector.connection.facade.execute_on_connection_streaming(
+                            connector.connection.connection_id,
+                            query,
+                            row_batch_size=500,
+                            on_batch=collect_batch,
+                        )
+                        columns = list(rows[0].keys()) if rows else []
+                        row_list = [[row.get(col) for col in columns] for row in rows]
+                        execution_time = time.time() - start_time
+                        self.query_result.emit(idx, columns, row_list, "", len(row_list), execution_time)
+                        success_count += 1
+                        continue
+
                     # 직접 커서 사용하여 실행
                     with connector.connection.cursor() as cursor:
                         cursor.execute(query)
@@ -795,8 +835,9 @@ class SQLTransactionWorker(QThread):
     ready_for_confirm = pyqtSignal()  # 커밋 대기 상태
     finished = pyqtSignal(bool, str)
 
-    def __init__(self, host, port, user, password, database, queries):
+    def __init__(self, host, port, user, password, database, queries, engine="mysql"):
         super().__init__()
+        self.engine = normalize_db_engine(engine, port)
         self.host = host
         self.port = port
         self.user = user
@@ -808,11 +849,16 @@ class SQLTransactionWorker(QThread):
         self.should_commit = None  # None: 대기 중, True: 커밋, False: 롤백
 
     def run(self):
-        from src.core.db_connector import MySQLConnector
-
         try:
             # autocommit=False로 연결
-            self.connector = MySQLConnector(self.host, self.port, self.user, self.password, self.database)
+            self.connector = create_sql_editor_connector(
+                self.engine,
+                self.host,
+                self.port,
+                self.user,
+                self.password,
+                self.database,
+            )
             success, msg = self.connector.connect()
 
             if not success:
@@ -1513,6 +1559,54 @@ class SQLEditorDialog(QDialog):
         self.setup_shortcuts()
         self.refresh_databases()
 
+    def _db_engine(self) -> str:
+        """Return the configured DB engine for Rust Core calls."""
+        return normalize_db_engine(self.config.get('db_engine'), self.config.get('remote_port'))
+
+    def _db_credentials(self) -> Tuple[str, str]:
+        tid = self.config.get('id')
+        return self.config_mgr.get_tunnel_credentials(tid)
+
+    def _resolve_db_target(
+        self,
+        allow_temp_tunnel: bool,
+        keep_temp_tunnel: bool = False,
+        log_temp_tunnel: bool = False,
+    ) -> Tuple[Optional[str], Optional[int], object, Optional[str]]:
+        tid = self.config.get('id')
+        if self.config.get('connection_mode') == 'direct':
+            return self.config['remote_host'], int(self.config['remote_port']), None, None
+        if self.engine.is_running(tid):
+            host, port = self.engine.get_connection_info(tid)
+            return host, int(port), None, None
+        if not allow_temp_tunnel:
+            return None, None, None, None
+
+        if log_temp_tunnel:
+            self.message_text.append("🔗 임시 터널 생성 중...")
+            QApplication.processEvents()
+        success, temp_server, error = self.engine.create_temp_tunnel(self.config)
+        if not success:
+            return None, None, None, f"터널 생성 실패: {error}"
+        host = '127.0.0.1'
+        port = int(self.engine.get_temp_tunnel_port(temp_server))
+        if keep_temp_tunnel:
+            self.temp_server = temp_server
+            temp_server = None
+        if log_temp_tunnel:
+            self.message_text.append(f"✅ 임시 터널: localhost:{port}")
+        return host, port, temp_server, None
+
+    def _create_db_connector(self, host, port, user, password, database=None):
+        return create_sql_editor_connector(
+            self._db_engine(),
+            host,
+            port,
+            user,
+            password,
+            database,
+        )
+
     def init_ui(self):
         layout = QVBoxLayout(self)
         layout.setSpacing(8)
@@ -2034,38 +2128,29 @@ class SQLEditorDialog(QDialog):
 
     def refresh_databases(self):
         """데이터베이스 목록 새로고침"""
-        from src.core.db_connector import MySQLConnector
-
-        tid = self.config.get('id')
-        db_user, db_password = self.config_mgr.get_tunnel_credentials(tid)
+        db_user, db_password = self._db_credentials()
 
         if not db_user:
             self.message_text.append("⚠️ DB 자격 증명이 설정되지 않았습니다.")
             return
 
-        is_direct = self.config.get('connection_mode') == 'direct'
         temp_server = None
 
         try:
             self.message_text.append("📋 데이터베이스 목록 조회 중...")
             QApplication.processEvents()
 
-            # 연결 정보 결정
-            if is_direct:
-                host = self.config['remote_host']
-                port = int(self.config['remote_port'])
-            elif self.engine.is_running(tid):
-                host, port = self.engine.get_connection_info(tid)
-            else:
-                # 임시 터널 생성
-                success, temp_server, error = self.engine.create_temp_tunnel(self.config)
-                if not success:
-                    self.message_text.append(f"❌ 터널 생성 실패: {error}")
-                    return
-                host = '127.0.0.1'
-                port = self.engine.get_temp_tunnel_port(temp_server)
-
-            connector = MySQLConnector(host, port, db_user, db_password)
+            host, port, temp_server, error = self._resolve_db_target(allow_temp_tunnel=True)
+            if error:
+                self.message_text.append(f"❌ {error}")
+                return
+            connector = self._create_db_connector(
+                host,
+                port,
+                db_user,
+                db_password,
+                self.config.get('default_database') if db_engine == 'postgresql' else None,
+            )
             try:
                 success, msg = connector.connect()
 
@@ -2109,37 +2194,30 @@ class SQLEditorDialog(QDialog):
         if self.db_connection and self.db_connection.open:
             return True, None
 
-        tid = self.config.get('id')
-        db_user, db_password = self.config_mgr.get_tunnel_credentials(tid)
+        db_user, db_password = self._db_credentials()
 
         if not db_user:
             return False, "DB 자격 증명이 설정되지 않았습니다."
 
-        is_direct = self.config.get('connection_mode') == 'direct'
-
         try:
-            # 연결 정보 결정
-            if is_direct:
-                host = self.config['remote_host']
-                port = int(self.config['remote_port'])
-            elif self.engine.is_running(tid):
-                host, port = self.engine.get_connection_info(tid)
-            else:
-                # 임시 터널 생성
-                self.message_text.append("🔗 임시 터널 생성 중...")
-                QApplication.processEvents()
-                success, self.temp_server, error = self.engine.create_temp_tunnel(self.config)
-                if not success:
-                    return False, f"터널 생성 실패: {error}"
-                host = '127.0.0.1'
-                port = self.engine.get_temp_tunnel_port(self.temp_server)
-                self.message_text.append(f"✅ 임시 터널: localhost:{port}")
+            host, port, _temp_server, error = self._resolve_db_target(
+                allow_temp_tunnel=True,
+                keep_temp_tunnel=True,
+                log_temp_tunnel=True,
+            )
+            if error:
+                return False, error
 
             database = self.db_combo.currentText().strip() or None
 
-            from src.core.db_connector import MySQLConnector
-
-            connector = MySQLConnector(host, port, db_user, db_password, database)
+            db_engine = self._db_engine()
+            connector = self._create_db_connector(
+                host,
+                port,
+                db_user,
+                db_password,
+                database,
+            )
             success, msg = connector.connect()
             if not success:
                 return False, msg
@@ -2147,9 +2225,14 @@ class SQLEditorDialog(QDialog):
             self._db_connector = connector
             self.db_connection.autocommit(False)
             # READ COMMITTED: 각 SELECT가 최신 커밋 데이터를 조회 (외부 변경 즉시 반영)
-            self.db_connection.cursor().execute(
-                "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED"
-            )
+            if db_engine == 'postgresql':
+                self.db_connection.cursor().execute(
+                    "SET TRANSACTION ISOLATION LEVEL READ COMMITTED"
+                )
+            else:
+                self.db_connection.cursor().execute(
+                    "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED"
+                )
             self.message_text.append(f"✅ DB 연결 성공 (트랜잭션 모드): {host}:{port}")
             self._update_tx_status()
             return True, None
@@ -2375,30 +2458,21 @@ class SQLEditorDialog(QDialog):
 
     def _execute_with_autocommit(self, queries, sql_text):
         """자동 커밋 모드로 실행 (기존 워커 사용)"""
-        tid = self.config.get('id')
-        db_user, db_password = self.config_mgr.get_tunnel_credentials(tid)
+        db_user, db_password = self._db_credentials()
 
         if not db_user:
             QMessageBox.warning(self, "경고", "DB 자격 증명이 설정되지 않았습니다.")
             return
 
-        is_direct = self.config.get('connection_mode') == 'direct'
-
         try:
-            if is_direct:
-                host = self.config['remote_host']
-                port = int(self.config['remote_port'])
-            elif self.engine.is_running(tid):
-                host, port = self.engine.get_connection_info(tid)
-            else:
-                self.message_text.append("🔗 임시 터널 생성 중...")
-                QApplication.processEvents()
-                success, self.temp_server, error = self.engine.create_temp_tunnel(self.config)
-                if not success:
-                    self.message_text.append(f"❌ 터널 생성 실패: {error}")
-                    return
-                host = '127.0.0.1'
-                port = self.engine.get_temp_tunnel_port(self.temp_server)
+            host, port, _temp_server, error = self._resolve_db_target(
+                allow_temp_tunnel=True,
+                keep_temp_tunnel=True,
+                log_temp_tunnel=True,
+            )
+            if error:
+                self.message_text.append(f"❌ {error}")
+                return
 
             database = self.db_combo.currentText().strip() or None
 
@@ -2410,7 +2484,15 @@ class SQLEditorDialog(QDialog):
             self.message_text.append(f"🚀 {len(queries)}개 쿼리 실행 (자동 커밋)")
             self.message_text.append(f"{'='*50}\n")
 
-            self.worker = SQLQueryWorker(host, port, db_user, db_password, database, queries)
+            self.worker = SQLQueryWorker(
+                host,
+                port,
+                db_user,
+                db_password,
+                database,
+                queries,
+                engine=self._db_engine(),
+            )
             self.worker.progress.connect(self._on_progress)
             self.worker.query_result.connect(self._on_query_result)
             self.worker.finished.connect(self._on_finished)
@@ -3435,7 +3517,6 @@ class SQLEditorDialog(QDialog):
 
     def _load_metadata(self, schema: str = None):
         """메타데이터 백그라운드 로드"""
-        from src.core.db_connector import MySQLConnector
         from src.ui.workers.validation_worker import MetadataLoadWorker
 
         # 기존 워커 취소
@@ -3444,22 +3525,14 @@ class SQLEditorDialog(QDialog):
             self.metadata_worker.wait()
 
         # 연결 확보
-        tid = self.config.get('id')
-        db_user, db_password = self.config_mgr.get_tunnel_credentials(tid)
+        db_user, db_password = self._db_credentials()
 
         if not db_user:
             return
 
-        is_direct = self.config.get('connection_mode') == 'direct'
-
         try:
-            if is_direct:
-                host = self.config['remote_host']
-                port = int(self.config['remote_port'])
-            elif self.engine.is_running(tid):
-                host, port = self.engine.get_connection_info(tid)
-            else:
-                # 터널 미실행 시 스킵
+            host, port, _temp_server, error = self._resolve_db_target(allow_temp_tunnel=False)
+            if error or not host or not port:
                 return
 
             target_schema = schema or self.db_combo.currentText().strip()
@@ -3474,7 +3547,13 @@ class SQLEditorDialog(QDialog):
                     pass
                 self._metadata_connector = None
 
-            connector = MySQLConnector(host, port, db_user, db_password, target_schema)
+            connector = self._create_db_connector(
+                host,
+                port,
+                db_user,
+                db_password,
+                target_schema,
+            )
             success, _ = connector.connect()
             if not success:
                 return

--- a/src/ui/dialogs/test_dialogs.py
+++ b/src/ui/dialogs/test_dialogs.py
@@ -6,6 +6,8 @@ from PyQt6.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel,
                              QGroupBox, QProgressBar, QMessageBox)
 from PyQt6.QtCore import Qt
 
+from src.core.db_core_service import create_rust_db_connector, normalize_db_engine
+
 
 class SQLExecutionDialog(QDialog):
     """SQL 파일 실행 다이얼로그"""
@@ -155,8 +157,6 @@ class SQLExecutionDialog(QDialog):
 
     def refresh_databases(self):
         """데이터베이스 목록 새로고침"""
-        from src.core.db_connector import MySQLConnector
-
         tid = self.config.get('id')
         db_user, db_password = self.config_mgr.get_tunnel_credentials(tid)
 
@@ -184,7 +184,15 @@ class SQLExecutionDialog(QDialog):
                 host = '127.0.0.1'
                 port = self.engine.get_temp_tunnel_port(temp_server)
 
-            connector = MySQLConnector(host, port, db_user, db_password)
+            db_engine = normalize_db_engine(self.config.get('db_engine'), self.config.get('remote_port'))
+            connector = create_rust_db_connector(
+                db_engine,
+                host,
+                port,
+                db_user,
+                db_password,
+                self.config.get('default_database') if db_engine == 'postgresql' else None,
+            )
             success, msg = connector.connect()
 
             if success:

--- a/src/ui/workers/cross_engine_migration_worker.py
+++ b/src/ui/workers/cross_engine_migration_worker.py
@@ -41,6 +41,7 @@ class CrossEngineMigrationWorker(QThread):
         self._popen_factory = popen_factory or subprocess.Popen
         self._process: Optional[subprocess.Popen] = None
         self._cancelled = False
+        self._last_checkpoint: Optional[Dict[str, Any]] = None
 
     def cancel(self):
         self._cancelled = True
@@ -85,10 +86,12 @@ class CrossEngineMigrationWorker(QThread):
                 elif event.event == "table_progress":
                     self.table_progress.emit(event.table or "", event.status or "")
                     if isinstance(event.payload.get("state"), dict):
+                        self._last_checkpoint = event.payload["state"]
                         self.checkpoint.emit(event.payload["state"])
                 elif event.event == "row_progress":
                     self.row_progress.emit(event.table or "", int(event.rows or 0), event.total)
                     if isinstance(event.payload.get("state"), dict):
+                        self._last_checkpoint = event.payload["state"]
                         self.checkpoint.emit(event.payload["state"])
                 elif event.event == "issue" and event.issue:
                     self.issue.emit(event.issue)
@@ -117,4 +120,6 @@ class CrossEngineMigrationWorker(QThread):
             if self._cancelled:
                 success = False
                 final_payload = {"cancelled": True}
+                if self._last_checkpoint:
+                    final_payload["state"] = self._last_checkpoint
             self.finished.emit(success, final_payload)

--- a/tests/test_cross_engine_migration_dialog.py
+++ b/tests/test_cross_engine_migration_dialog.py
@@ -147,6 +147,42 @@ def test_inspect_result_enables_report_and_updates_schema():
         dialog.close()
 
 
+def test_empty_schema_runs_inspect_before_requested_plan(monkeypatch):
+    dialog = make_dialog()
+    started = []
+    schema = {
+        "tables": [{"name": "users", "columns": [{"name": "id", "type": "int"}]}]
+    }
+
+    monkeypatch.setattr(
+        "src.ui.dialogs.cross_engine_migration_dialog.QTimer.singleShot",
+        lambda _msec, callback: callback(),
+    )
+    monkeypatch.setattr(
+        dialog,
+        "_start_command_with_payload",
+        lambda command, payload, workflow=False: started.append((command, payload, workflow)),
+    )
+
+    try:
+        dialog._start_command("plan")
+        assert started[0][0] == "inspect"
+        assert dialog._pending_after_inspect == "plan"
+
+        dialog._on_result({
+            "event": "result",
+            "command": "inspect",
+            "success": True,
+            "schema": schema,
+        })
+
+        assert started[1][0] == "plan"
+        assert started[1][1]["schema"] == schema
+        assert "Rust Core 검사 완료" in dialog.lbl_schema_status.text()
+    finally:
+        dialog.close()
+
+
 def test_migrate_result_saves_resume_state(monkeypatch, tmp_path):
     saved = {}
 

--- a/tests/test_db_core_service.py
+++ b/tests/test_db_core_service.py
@@ -1,7 +1,14 @@
 import io
 import json
 
-from src.core.db_core_service import DbCoreFacade, DbCoreServiceClient, DbEndpoint, RustDbConnector
+from src.core.db_core_service import (
+    DbCoreFacade,
+    DbCoreServiceClient,
+    DbEndpoint,
+    RustDbConnector,
+    create_rust_db_connector,
+    normalize_db_engine,
+)
 
 
 class FakeProcess:
@@ -94,3 +101,64 @@ def test_rust_connector_masks_success_message_shape():
     assert success is True
     assert message == "연결 성공"
     assert fake.endpoint.engine == "postgresql"
+
+
+def test_execute_on_connection_sends_params_to_core_protocol():
+    process = FakeProcess([
+        '{"event":"result","command":"query.execute","success":true,"rows":[{"id":1}]}',
+    ])
+    client = DbCoreServiceClient(
+        executable="fake-core",
+        popen_factory=lambda *args, **kwargs: process,
+    )
+    facade = DbCoreFacade(client)
+
+    rows = facade.execute_on_connection("conn-1", "SELECT * FROM users WHERE id = %s", params=[1])
+
+    sent = json.loads(process.stdin.getvalue().strip())
+    assert rows == [{"id": 1}]
+    assert sent["payload"]["connection_id"] == "conn-1"
+    assert sent["payload"]["params"] == [1]
+
+
+def test_execute_on_connection_streaming_collects_row_batches():
+    process = FakeProcess([
+        '{"event":"row_batch","rows":[{"id":1}],"total":2}',
+        '{"event":"row_batch","rows":[{"id":2}],"total":2}',
+        '{"event":"result","command":"query.execute","success":true,"rows_streamed":2}',
+    ])
+    client = DbCoreServiceClient(
+        executable="fake-core",
+        popen_factory=lambda *args, **kwargs: process,
+    )
+    facade = DbCoreFacade(client)
+    batches = []
+
+    result = facade.execute_on_connection_streaming(
+        "conn-1",
+        "SELECT * FROM users",
+        row_batch_size=1,
+        on_batch=batches.append,
+    )
+
+    sent = json.loads(process.stdin.getvalue().strip())
+    assert sent["payload"]["stream_rows"] is True
+    assert sent["payload"]["row_batch_size"] == 1
+    assert batches == [[{"id": 1}], [{"id": 2}]]
+    assert result["rows_streamed"] == 2
+
+
+def test_create_rust_db_connector_resolves_postgresql_engine_from_config():
+    connector = create_rust_db_connector(
+        "postgres",
+        "db.local",
+        5432,
+        "user",
+        "pw",
+        schema="analytics",
+    )
+
+    assert normalize_db_engine("pg") == "postgresql"
+    assert connector.endpoint.engine == "postgresql"
+    assert connector.endpoint.database == "postgres"
+    assert connector.endpoint.schema == "analytics"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -488,6 +488,81 @@ class TestBackupScheduler:
         queries = self.scheduler._parse_sql_queries('SELECT 1;')
         assert queries == ['SELECT 1']
 
+    def test_sql_query_task_uses_engine_aware_rust_connector(self, monkeypatch):
+        """예약 SQL 실행은 터널의 db_engine을 Rust Core connector로 전달"""
+        created = {}
+
+        class FakeCursor:
+            description = [("value",)]
+            rowcount = 1
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                return False
+
+            def execute(self, query):
+                self.query = query
+
+            def fetchall(self):
+                return [{"value": 1}]
+
+        class FakeConnection:
+            def cursor(self):
+                return FakeCursor()
+
+            def commit(self):
+                pass
+
+        class FakeConnector:
+            connection = FakeConnection()
+
+            def connect(self):
+                return True, "ok"
+
+            def disconnect(self):
+                pass
+
+        def fake_create(engine, host, port, user, password, database=None, schema=""):
+            created.update({
+                "engine": engine,
+                "host": host,
+                "port": port,
+                "user": user,
+                "database": database,
+                "schema": schema,
+            })
+            return FakeConnector()
+
+        self.mock_engine.get_connection_info.return_value = ("127.0.0.1", 15432)
+        self.mock_engine.tunnel_configs = {
+            "tunnel-001": {
+                "db_engine": "postgresql",
+                "remote_port": 5432,
+                "db_username": "pg_user",
+                "db_password": "pg_pw",
+            }
+        }
+        monkeypatch.setattr("src.core.scheduler.create_rust_db_connector", fake_create)
+
+        schedule = self.ScheduleConfig(
+            id="sql-001",
+            name="SQL",
+            tunnel_id="tunnel-001",
+            schema="analytics",
+            task_type="sql_query",
+            sql_query="SELECT 1",
+            result_format="none",
+        )
+
+        success, _ = self.scheduler._execute_sql_query(schedule)
+
+        assert success is True
+        assert created["engine"] == "postgresql"
+        assert created["user"] == "pg_user"
+        assert created["schema"] == "analytics"
+
     def test_add_schedule_sets_next_run_for_enabled(self):
         """활성화된 스케줄 추가 시 next_run 계산"""
         schedule = self._make_schedule(enabled=True)

--- a/tests/test_tunnel_monitor.py
+++ b/tests/test_tunnel_monitor.py
@@ -354,6 +354,39 @@ class TestTunnelMonitor:
         result = self.monitor._measure_latency('tunnel1')
         assert result == -1
 
+    def test_create_health_connection_uses_configured_db_engine(self, monkeypatch):
+        """Health check는 MySQL 고정 대신 Rust Core engine을 사용"""
+        created = {}
+
+        class FakeConnection:
+            def autocommit(self, enabled):
+                self.autocommit_enabled = enabled
+
+            def close(self):
+                pass
+
+        class FakeConnector:
+            def __init__(self):
+                self.connection = FakeConnection()
+
+            def connect(self):
+                return True, "ok"
+
+        def fake_create(engine, host, port, user, password, database=None, schema=""):
+            created["engine"] = engine
+            created["database"] = database
+            return FakeConnector()
+
+        monkeypatch.setattr("src.core.tunnel_monitor.create_rust_db_connector", fake_create)
+
+        conn = self.monitor._create_health_connection(
+            "pg-tunnel", "postgresql", "127.0.0.1", 5432, "user", "pw", "analytics"
+        )
+
+        assert conn is not None
+        assert created["engine"] == "postgresql"
+        assert created["database"] == "analytics"
+
     def test_attempt_reconnect_exceeds_max(self):
         """최대 재연결 시도 초과 시 ERROR 상태로 전환"""
         from src.core.tunnel_monitor import TunnelStatus, TunnelState


### PR DESCRIPTION
## Summary
- Harden Rust Core DB workflows with an engine-aware connector factory used by SQL editor, scheduler, tunnel monitor, and SQL file database listing paths.
- Improve cross-engine migration UX by auto-running source schema inspect before downstream planning when the schema is empty.
- Add Rust Core query params, row-batch streaming support, clearer cancel metadata/checkpoint preservation, and a Rust Core regression/performance evidence gate.
- Reduce SQL editor DB connection duplication by centralizing credential, target resolution, temporary tunnel, and connector creation helpers.

## Validation
- `pytest` -> 1504 passed, 5 warnings
- `cargo test --manifest-path migration_core\Cargo.toml` -> passed
- `$env:RUST_CORE_REQUIRE_PERF_EVIDENCE='1'; powershell -NoProfile -ExecutionPolicy Bypass -File scripts\rust-core-regression-gate.ps1` -> passed
- Focused cleanup check: `pytest tests/test_scheduler.py tests/test_tunnel_monitor.py` -> 88 passed, 2 warnings

## Notes
- The local worktree still has unrelated unstaged changes that were intentionally excluded from this PR.
