### PR TITLE
[codex] Run Rust Core regression gate in CI

### DIFF
--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v4
 
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Run Rust Core regression gate
         shell: pwsh
         run: ./scripts/rust-core-regression-gate.ps1

--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -18,6 +18,18 @@ permissions:
   pull-requests: write
 
 jobs:
+  rust-core-regression-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - name: Run Rust Core regression gate
+        shell: pwsh
+        run: ./scripts/rust-core-regression-gate.ps1
+
   version-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Thumbs.db
 # Project specific
 *.log
 config.json
+migration_core/target/
 *.exe
 *.spec
 !tunnel-manager.spec  # PyInstaller 빌드 설정 파일은 커밋

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tunnelforge"
-version = "2.0.0"
+version = "2.0.1"
 description = "SSH Tunnel and Rust DB Core Manager"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/version.py
+++ b/src/version.py
@@ -4,7 +4,7 @@
 모든 버전 참조는 이 파일을 사용해야 합니다.
 """
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __app_name__ = "TunnelForge"
 
 # GitHub 저장소 정보 (업데이트 확인용)


### PR DESCRIPTION
## Summary
- Run the Rust Core regression gate as a dedicated PR workflow job.
- Ignore `migration_core/target/` locally so Rust build artifacts do not dirty the worktree.

## Validation
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\rust-core-regression-gate.ps1` -> passed

## Release
- Marked as `version:patch` for v2.0.1 after merge.
