### PR TITLE
ci: update GitHub Actions runtime versions

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -14,19 +14,19 @@ jobs:
     if: >
       github.event.pull_request.merged == true &&
       contains(toJSON(github.event.pull_request.labels.*.name), 'version:')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASER_APP_ID }}
           private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
 
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,16 @@ permissions:
 jobs:
   build-windows-installer:
     name: Build Windows Installer
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # 전체 히스토리 (릴리스 노트 생성용)
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -281,7 +281,7 @@ jobs:
           echo "============================================="
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: v${{ steps.get_version.outputs.version }}
           body_path: release_notes.md

--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -19,12 +19,12 @@ permissions:
 
 jobs:
   rust-core-regression-gate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep
@@ -34,7 +34,7 @@ jobs:
         run: ./scripts/rust-core-regression-gate.ps1
 
   version-gate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:
@@ -121,14 +121,14 @@ jobs:
       - name: Generate GitHub App Token
         if: steps.check.outputs.bump_type != ''
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASER_APP_ID }}
           private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
 
       - name: Checkout PR branch
         if: steps.check.outputs.bump_type != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -136,7 +136,7 @@ jobs:
 
       - name: Set up Python
         if: steps.check.outputs.bump_type != ''
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
## Summary
- update official GitHub Actions to Node 24 compatible major versions
- pin hosted runners to ubuntu-24.04 and windows-2025
- keep Rust Core regression gate wired into version-gate workflow

## Tests
- powershell -NoProfile -ExecutionPolicy Bypass -File scripts\\rust-core-regression-gate.ps1