### PR TITLE
Fix: resolve Rust core executable in packaged app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tunnelforge"
-version = "2.0.1"
+version = "2.0.2"
 description = "SSH Tunnel and Rust DB Core Manager"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/core/cross_engine_migration.py
+++ b/src/core/cross_engine_migration.py
@@ -155,6 +155,9 @@ def db_core_executable() -> str:
 
     if hasattr(sys, "_MEIPASS"):
         candidate_dirs.append(Path(sys._MEIPASS))  # type: ignore[attr-defined]
+    if getattr(sys, "frozen", False):
+        candidate_dirs.append(Path(sys.executable).resolve().parent)
+        candidate_dirs.append(Path.cwd())
 
     root = project_root()
     candidate_dirs.extend([

--- a/src/core/db_core_service.py
+++ b/src/core/db_core_service.py
@@ -1,5 +1,6 @@
 """Client facade for the Rust TunnelForge DB core service."""
 import json
+import os
 import subprocess
 import threading
 import uuid
@@ -73,15 +74,24 @@ class DbCoreServiceClient:
     def start(self) -> None:
         if self._process and self._process.poll() is None:
             return
-        self._process = self._popen_factory(
-            [self.executable],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-        )
+        try:
+            self._process = self._popen_factory(
+                [self.executable],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+            )
+        except FileNotFoundError as exc:
+            raise DbCoreServiceError(
+                "Rust DB Core 실행 파일을 찾을 수 없습니다: "
+                f"{self.executable}\n"
+                "소스 실행이면 `cargo build --manifest-path migration_core\\Cargo.toml --release`를 먼저 실행하고, "
+                "설치본이면 배포 패키지에 tunnelforge-core.exe가 포함되어 있는지 확인하세요."
+            ) from exc
 
     def request(
         self,

--- a/src/ui/dialogs/sql_editor_dialog.py
+++ b/src/ui/dialogs/sql_editor_dialog.py
@@ -2144,6 +2144,7 @@ class SQLEditorDialog(QDialog):
             if error:
                 self.message_text.append(f"❌ {error}")
                 return
+            db_engine = self._db_engine()
             connector = self._create_db_connector(
                 host,
                 port,

--- a/src/version.py
+++ b/src/version.py
@@ -4,7 +4,7 @@
 모든 버전 참조는 이 파일을 사용해야 합니다.
 """
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 __app_name__ = "TunnelForge"
 
 # GitHub 저장소 정보 (업데이트 확인용)

--- a/tests/test_cross_engine_migration_protocol.py
+++ b/tests/test_cross_engine_migration_protocol.py
@@ -1,4 +1,6 @@
 import json
+import os
+import sys
 
 import pytest
 
@@ -7,6 +9,7 @@ from src.core.cross_engine_migration import (
     HelperProtocolError,
     MigrationDirection,
     build_helper_request,
+    db_core_executable,
     load_resume_state,
     next_workflow_command,
     parse_helper_event,
@@ -192,3 +195,19 @@ def test_state_key_from_payload_is_filename_safe():
     assert " " not in key
     assert "mysql" in key
     assert "postgresql" in key
+
+
+def test_db_core_executable_checks_frozen_app_directory(monkeypatch, tmp_path):
+    exe_name = "tunnelforge-core.exe" if os.name == "nt" else "tunnelforge-core"
+    app_dir = tmp_path / "TunnelForge"
+    app_dir.mkdir()
+    core = app_dir / exe_name
+    core.write_text("", encoding="utf-8")
+    app_exe = app_dir / ("TunnelForge.exe" if os.name == "nt" else "TunnelForge")
+    app_exe.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(app_exe))
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+    assert db_core_executable() == str(core)

--- a/tests/test_db_core_service.py
+++ b/tests/test_db_core_service.py
@@ -3,6 +3,7 @@ import json
 
 from src.core.db_core_service import (
     DbCoreFacade,
+    DbCoreServiceError,
     DbCoreServiceClient,
     DbEndpoint,
     RustDbConnector,
@@ -42,6 +43,26 @@ def test_client_sends_jsonl_and_returns_result():
     assert sent["command"] == "service.hello"
     assert result["success"] is True
     assert events[0]["event"] == "phase"
+
+
+def test_client_reports_missing_core_executable_cleanly():
+    def missing_executable(*args, **kwargs):
+        raise FileNotFoundError("missing")
+
+    client = DbCoreServiceClient(
+        executable="missing-tunnelforge-core.exe",
+        popen_factory=missing_executable,
+    )
+
+    try:
+        client.request("service.hello")
+    except DbCoreServiceError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("DbCoreServiceError was not raised")
+
+    assert "Rust DB Core 실행 파일을 찾을 수 없습니다" in message
+    assert "missing-tunnelforge-core.exe" in message
 
 
 def test_facade_uses_connection_test_protocol():

--- a/tests/test_sql_editor_dialog.py
+++ b/tests/test_sql_editor_dialog.py
@@ -92,3 +92,65 @@ def test_result_tabs_can_be_deleted_and_cleared(monkeypatch):
         assert dialog.result_tabs.tabText(0).startswith("결과 1")
     finally:
         close_dialog(dialog)
+
+
+def test_refresh_databases_uses_configured_engine(monkeypatch):
+    refresh_databases = SQLEditorDialog.refresh_databases
+
+    class FakeConnector:
+        def __init__(self):
+            self.disconnected = False
+
+        def connect(self):
+            return True, "ok"
+
+        def get_schemas(self):
+            return ["tf_target"]
+
+        def disconnect(self):
+            self.disconnected = True
+
+    monkeypatch.setattr(SQLEditorDialog, "refresh_databases", lambda self: None)
+    config_manager = MagicMock()
+    config_manager.get_tunnel_credentials.return_value = ("postgres", "tunnelpass")
+    tunnel_engine = MagicMock()
+    connector = FakeConnector()
+    created = {}
+
+    dialog = SQLEditorDialog(
+        None,
+        {
+            "id": "pg-test",
+            "name": "PostgreSQL 테스트",
+            "connection_mode": "direct",
+            "remote_host": "127.0.0.1",
+            "remote_port": 35432,
+            "db_engine": "postgresql",
+            "default_database": "tf_target",
+        },
+        config_manager,
+        tunnel_engine,
+    )
+    try:
+        dialog.refresh_databases = refresh_databases.__get__(dialog, SQLEditorDialog)
+        dialog._resolve_db_target = MagicMock(return_value=("127.0.0.1", 35432, None, None))
+        def create_connector(*args):
+            created["args"] = args
+            return connector
+
+        dialog._create_db_connector = MagicMock(side_effect=create_connector)
+        dialog._load_metadata = MagicMock()
+
+        dialog.refresh_databases()
+
+        assert created["args"] == (
+            "127.0.0.1",
+            35432,
+            "postgres",
+            "tunnelpass",
+            "tf_target",
+        )
+        assert dialog.db_combo.findText("tf_target") >= 0
+        assert connector.disconnected is True
+    finally:
+        close_dialog(dialog)


### PR DESCRIPTION
## Summary
- search the packaged app directory for tunnelforge-core when the app is frozen
- surface a clear Rust DB Core missing-binary error instead of raw WinError 2
- keep Rust core process hidden on Windows

## Tests
- pytest tests\\test_db_core_service.py tests\\test_cross_engine_migration_protocol.py
- pytest
- powershell -NoProfile -ExecutionPolicy Bypass -File scripts\\rust-core-regression-gate.ps1
- Rust Core PostgreSQL connection smoke against 127.0.0.1:35432