### PR TITLE
Fix: use MySQL default database in connection tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tunnelforge"
-version = "2.0.2"
+version = "2.0.3"
 description = "SSH Tunnel and Rust DB Core Manager"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ui/dialogs/test_dialogs.py
+++ b/src/ui/dialogs/test_dialogs.py
@@ -318,7 +318,7 @@ class TestProgressDialog(QDialog):
     def __init__(self, parent, title: str = "연결 테스트"):
         super().__init__(parent)
         self.setWindowTitle(title)
-        self.setMinimumSize(400, 200)
+        self.setMinimumSize(480, 320)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowType.WindowCloseButtonHint)
 
         layout = QVBoxLayout(self)
@@ -336,8 +336,8 @@ class TestProgressDialog(QDialog):
         # 상세 로그
         self.log_text = QTextEdit()
         self.log_text.setReadOnly(True)
-        self.log_text.setMaximumHeight(100)
-        layout.addWidget(self.log_text)
+        self.log_text.setMinimumHeight(180)
+        layout.addWidget(self.log_text, 1)
 
         # 결과 버튼 (초기 숨김)
         self.btn_close = QPushButton("닫기")

--- a/src/ui/workers/test_worker.py
+++ b/src/ui/workers/test_worker.py
@@ -238,7 +238,7 @@ class ConnectionTestWorker(QThread):
             database = self.config.get('default_database') or 'postgres'
             schema = self.config.get('default_schema') or ''
             return RustDbConnector(engine, host, port, user, password, database, schema)
-        database = self.config.get('default_schema')
+        database = self.config.get('default_database') or self.config.get('default_schema')
         return RustDbConnector(engine, host, port, user, password, database or '')
 
     def _engine_label(self, engine: str) -> str:

--- a/src/version.py
+++ b/src/version.py
@@ -4,7 +4,7 @@
 모든 버전 참조는 이 파일을 사용해야 합니다.
 """
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 __app_name__ = "TunnelForge"
 
 # GitHub 저장소 정보 (업데이트 확인용)

--- a/tests/test_connection_test_worker.py
+++ b/tests/test_connection_test_worker.py
@@ -56,3 +56,35 @@ def test_postgresql_core_connector_uses_default_database_not_schema(monkeypatch)
     assert captured["engine"] == "postgresql"
     assert captured["database"] == "appdb"
     assert captured["schema"] == "analytics"
+
+
+def test_mysql_core_connector_uses_default_database(monkeypatch):
+    captured = {}
+
+    class FakeRustDbConnector:
+        def __init__(self, engine, host, port, user, password, database, schema=""):
+            captured["engine"] = engine
+            captured["database"] = database
+            captured["schema"] = schema
+
+    import types
+    import sys
+
+    fake_module = types.SimpleNamespace(RustDbConnector=FakeRustDbConnector)
+    monkeypatch.setitem(sys.modules, "src.core.db_core_service", fake_module)
+    worker = ConnectionTestWorker(
+        TestType.DB_ONLY,
+        {
+            "db_engine": "mysql",
+            "default_database": "tf_source84",
+            "default_schema": "",
+        },
+        tunnel_engine=None,
+        config_manager=None,
+    )
+
+    worker._create_connector("mysql", "127.0.0.1", 33406, "root", "pw")
+
+    assert captured["engine"] == "mysql"
+    assert captured["database"] == "tf_source84"
+    assert captured["schema"] == ""


### PR DESCRIPTION
## Summary
- pass MySQL default_database to Rust Core during DB auth tests
- allow the connection test dialog log panel to grow when the window is resized
- add regression coverage for MySQL default database connector creation

## Tests
- pytest
- powershell -NoProfile -ExecutionPolicy Bypass -File scripts\\rust-core-regression-gate.ps1
- Rust connector smoke: MySQL 8.4 127.0.0.1:33406 / tf_source84