### PR TITLE
Fix: pass MySQL default database in SQL editor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tunnelforge"
-version = "2.0.3"
+version = "2.0.4"
 description = "SSH Tunnel and Rust DB Core Manager"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ui/dialogs/db_dialogs.py
+++ b/src/ui/dialogs/db_dialogs.py
@@ -2635,8 +2635,13 @@ class RustDumpWizard:
             )
             return None, None
 
+        db_engine = tunnel.get('db_engine')
+        database = tunnel.get('default_database') or (
+            tunnel.get('default_schema') if db_engine == 'mysql' else None
+        )
+
         # MySQLConnector 생성 및 연결
-        connector = MySQLConnector(host, port, db_user, db_password)
+        connector = MySQLConnector(host, port, db_user, db_password, database)
         success, msg = connector.connect()
 
         if not success:

--- a/src/ui/dialogs/sql_editor_dialog.py
+++ b/src/ui/dialogs/sql_editor_dialog.py
@@ -2150,7 +2150,9 @@ class SQLEditorDialog(QDialog):
                 port,
                 db_user,
                 db_password,
-                self.config.get('default_database') if db_engine == 'postgresql' else None,
+                self.config.get('default_database') or (
+                    self.config.get('default_schema') if db_engine == 'mysql' else None
+                ),
             )
             try:
                 success, msg = connector.connect()

--- a/src/ui/dialogs/test_dialogs.py
+++ b/src/ui/dialogs/test_dialogs.py
@@ -191,7 +191,9 @@ class SQLExecutionDialog(QDialog):
                 port,
                 db_user,
                 db_password,
-                self.config.get('default_database') if db_engine == 'postgresql' else None,
+                self.config.get('default_database') or (
+                    self.config.get('default_schema') if db_engine == 'mysql' else None
+                ),
             )
             success, msg = connector.connect()
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -461,7 +461,9 @@ class TunnelManagerUI(QMainWindow):
                 )
                 self.statusBar().showMessage(f"연결 테스트 중단: {tunnel_name}")
                 return
-            database = tunnel.get('default_database') if engine == 'postgresql' else tunnel.get('default_schema')
+            database = tunnel.get('default_database') or (
+                tunnel.get('default_schema') if engine == 'mysql' else None
+            )
             connector = self._create_db_connector(engine, host, int(port), user, password, database)
             success, msg = connector.connect()
             connector.disconnect()

--- a/src/version.py
+++ b/src/version.py
@@ -4,7 +4,7 @@
 모든 버전 참조는 이 파일을 사용해야 합니다.
 """
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 __app_name__ = "TunnelForge"
 
 # GitHub 저장소 정보 (업데이트 확인용)

--- a/tests/test_db_dialogs.py
+++ b/tests/test_db_dialogs.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock
+
+from src.ui.dialogs.db_dialogs import RustDumpWizard
+
+
+def test_preselected_export_tunnel_passes_mysql_default_database(monkeypatch):
+    captured = {}
+
+    class FakeMySQLConnector:
+        def __init__(self, host, port, user, password, database=None):
+            captured["host"] = host
+            captured["port"] = port
+            captured["user"] = user
+            captured["password"] = password
+            captured["database"] = database
+
+        def connect(self):
+            return True, "ok"
+
+    monkeypatch.setattr("src.ui.dialogs.db_dialogs.MySQLConnector", FakeMySQLConnector)
+    config_manager = MagicMock()
+    config_manager.get_tunnel_credentials.return_value = ("root", "tunnelpass")
+    tunnel_engine = MagicMock()
+    tunnel_engine.is_running.return_value = True
+    tunnel_engine.get_connection_info.return_value = ("127.0.0.1", 3309)
+
+    wizard = RustDumpWizard(
+        tunnel_engine=tunnel_engine,
+        config_manager=config_manager,
+        preselected_tunnel={
+            "id": "mysql-tunnel",
+            "name": "MySQL 터널",
+            "db_engine": "mysql",
+            "default_database": "tf_source84",
+        },
+    )
+
+    connector, connection_info = wizard._connect_preselected_tunnel()
+
+    assert connector is not None
+    assert connection_info == "MySQL 터널_root"
+    assert captured == {
+        "host": "127.0.0.1",
+        "port": 3309,
+        "user": "root",
+        "password": "tunnelpass",
+        "database": "tf_source84",
+    }

--- a/tests/test_sql_editor_dialog.py
+++ b/tests/test_sql_editor_dialog.py
@@ -154,3 +154,57 @@ def test_refresh_databases_uses_configured_engine(monkeypatch):
         assert connector.disconnected is True
     finally:
         close_dialog(dialog)
+
+
+def test_refresh_databases_passes_mysql_default_database(monkeypatch):
+    refresh_databases = SQLEditorDialog.refresh_databases
+
+    class FakeConnector:
+        def connect(self):
+            return True, "ok"
+
+        def get_schemas(self):
+            return ["tf_source84"]
+
+        def disconnect(self):
+            pass
+
+    monkeypatch.setattr(SQLEditorDialog, "refresh_databases", lambda self: None)
+    config_manager = MagicMock()
+    config_manager.get_tunnel_credentials.return_value = ("root", "tunnelpass")
+    tunnel_engine = MagicMock()
+    created = {}
+
+    dialog = SQLEditorDialog(
+        None,
+        {
+            "id": "mysql84-test",
+            "name": "MySQL 8.4 테스트",
+            "connection_mode": "direct",
+            "remote_host": "127.0.0.1",
+            "remote_port": 33406,
+            "db_engine": "mysql",
+            "default_database": "tf_source84",
+        },
+        config_manager,
+        tunnel_engine,
+    )
+    try:
+        dialog.refresh_databases = refresh_databases.__get__(dialog, SQLEditorDialog)
+        dialog._resolve_db_target = MagicMock(return_value=("127.0.0.1", 33406, None, None))
+        dialog._create_db_connector = MagicMock(
+            side_effect=lambda *args: created.setdefault("args", args) and FakeConnector()
+        )
+        dialog._load_metadata = MagicMock()
+
+        dialog.refresh_databases()
+
+        assert created["args"] == (
+            "127.0.0.1",
+            33406,
+            "root",
+            "tunnelpass",
+            "tf_source84",
+        )
+    finally:
+        close_dialog(dialog)


### PR DESCRIPTION
## Summary
- pass MySQL default_database when SQL Editor refreshes database/schema lists
- keep default_schema as a fallback for older MySQL configs
- add SQL Editor regression coverage for MySQL 8.4 style config

## Tests
- pytest
- powershell -NoProfile -ExecutionPolicy Bypass -File scripts\\rust-core-regression-gate.ps1
- Rust connector smoke: MySQL 8.4 127.0.0.1:33406 / tf_source84