### PR TITLE
Fix: bundle tunnelforge-core in releases and show installer wizard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,31 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            migration_core/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('migration_core/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build tunnelforge-core (Rust)
+        shell: pwsh
+        run: |
+          cargo build --manifest-path migration_core\Cargo.toml --release
+          if (-not (Test-Path "migration_core\target\release\tunnelforge-core.exe")) {
+            Write-Host "::error::tunnelforge-core.exe not produced by cargo build"
+            exit 1
+          }
+          $coreSize = (Get-Item "migration_core\target\release\tunnelforge-core.exe").Length / 1MB
+          Write-Host "tunnelforge-core.exe built: $($coreSize.ToString('0.0')) MB"
+
       - name: Setup GitHub App credentials
         if: ${{ vars.GH_APP_ID != '' }}
         shell: bash

--- a/installer/TunnelForge.iss
+++ b/installer/TunnelForge.iss
@@ -7,7 +7,7 @@
 ;   3. 또는: .\scripts\build-installer.ps1
 
 #define MyAppName "TunnelForge"
-#define MyAppVersion "2.0.5"
+#define MyAppVersion "2.0.6"
 #define MyAppPublisher "sanghyun-io"
 #define MyAppURL "https://github.com/sanghyun-io/tunnelforge"
 #define MyAppExeName "TunnelForge.exe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tunnelforge"
-version = "2.0.5"
+version = "2.0.6"
 description = "SSH Tunnel and Rust DB Core Manager"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ui/dialogs/settings.py
+++ b/src/ui/dialogs/settings.py
@@ -1146,7 +1146,8 @@ class SettingsDialog(QDialog):
         main_window = self.parent()
         confirm_msg = (
             f"TunnelForge v{self._latest_version} 설치를 시작하시겠습니까?\n\n"
-            "설치를 위해 현재 앱이 종료됩니다."
+            "현재 앱이 종료되고 설치 마법사가 실행됩니다.\n"
+            "설치가 끝나면 마법사에서 TunnelForge를 다시 실행할 수 있습니다."
         )
 
         if main_window and hasattr(main_window, 'engine'):
@@ -1161,7 +1162,7 @@ class SettingsDialog(QDialog):
                     f"TunnelForge v{self._latest_version} 설치를 시작하시겠습니까?\n\n"
                     f"⚠️ 현재 {active_count}개의 활성 터널이 연결 해제됩니다:\n"
                     f"{tunnel_list}\n\n"
-                    "설치를 위해 현재 앱이 종료됩니다."
+                    "현재 앱이 종료되고 설치 마법사가 실행됩니다."
                 )
 
         # 확인 다이얼로그
@@ -1179,15 +1180,14 @@ class SettingsDialog(QDialog):
         try:
             if sys.platform == 'win32':
                 # 배치 스크립트가 업데이트 전체 라이프사이클을 관리:
-                #   ① 기존 프로세스 종료 대기
-                #   ② 설치 프로그램 /SILENT 실행 (skipifsilent로 Inno Setup 자동 실행 방지)
-                #   ③ 설치 프로세스 완료 대기
-                #   ④ 앱 실행
-                # 이렇게 하면 Inno Setup의 [Run] 자동 실행과의 경합(race condition)을 방지하고
-                # PyInstaller _MEI 임시 디렉토리 충돌 문제를 해결
+                #   ① 기존 프로세스 종료 대기 (PyInstaller _MEI 디렉토리 정리 보장)
+                #   ② 인스톨러 정상 모드로 실행 — 마법사 UI 노출
+                # 마법사가 끝나면 Inno Setup [Run] postinstall 옵션이 사용자에게
+                # "TunnelForge 실행" 체크박스를 보여주고 동의 시 자동 재실행.
+                # 따라서 bat에서 별도로 explorer.exe %APP_EXE% 를 띄우지 않는다
+                # (중복 실행 방지).
                 import tempfile
                 current_pid = os.getpid()
-                app_exe_path = sys.executable
                 bat_path = os.path.join(
                     tempfile.gettempdir(),
                     f"tunnelforge_update_{current_pid}.bat"
@@ -1197,7 +1197,6 @@ class SettingsDialog(QDialog):
                     "setlocal\r\n"
                     f"set PID={current_pid}\r\n"
                     f'set INSTALLER="{self._downloaded_installer_path}"\r\n'
-                    f'set APP_EXE="{app_exe_path}"\r\n'
                     "set MAX_WAIT=30\r\n"
                     "set COUNT=0\r\n"
                     "\r\n"
@@ -1210,16 +1209,10 @@ class SettingsDialog(QDialog):
                     "ping -n 2 127.0.0.1 >NUL\r\n"
                     "goto WAIT_EXIT\r\n"
                     "\r\n"
-                    "rem === Phase 2: Run installer silently and wait ===\r\n"
+                    "rem === Phase 2: Run installer with visible wizard ===\r\n"
                     ":RUN_INSTALLER\r\n"
                     "ping -n 2 127.0.0.1 >NUL\r\n"
-                    "%INSTALLER% /SILENT /NORESTART /SUPPRESSMSGBOXES\r\n"
-                    "\r\n"
-                    "rem === Phase 3: Launch updated app via explorer ===\r\n"
-                    "rem explorer.exe launches the app as if user double-clicked it,\r\n"
-                    "rem ensuring correct working directory and environment for PyInstaller\r\n"
-                    "ping -n 4 127.0.0.1 >NUL\r\n"
-                    "explorer.exe %APP_EXE%\r\n"
+                    "start \"\" %INSTALLER%\r\n"
                     "\r\n"
                     "rem === Cleanup ===\r\n"
                     f'del /f /q "{bat_path}"\r\n'

--- a/src/version.py
+++ b/src/version.py
@@ -4,7 +4,7 @@
 모든 버전 참조는 이 파일을 사용해야 합니다.
 """
 
-__version__ = "2.0.5"
+__version__ = "2.0.6"
 __app_name__ = "TunnelForge"
 
 # GitHub 저장소 정보 (업데이트 확인용)

--- a/tests/test_rust_core_packaging.py
+++ b/tests/test_rust_core_packaging.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -10,6 +11,8 @@ def test_pyinstaller_spec_includes_core_service_binaries_cross_platform():
     assert "core_suffix = '.exe' if os.name == 'nt' else ''" in spec
     assert "tunnelforge-core{core_suffix}" in spec
     assert "binaries=binaries" in spec
+    assert "raise SystemExit" in spec
+    assert "Run `cargo build --manifest-path migration_core/Cargo.toml --release` first." in spec
 
 
 def test_windows_installer_builds_and_checks_core_service_binaries():
@@ -18,3 +21,28 @@ def test_windows_installer_builds_and_checks_core_service_binaries():
     assert "cargo build --manifest-path migration_core\\Cargo.toml --release" in script
     assert "migration_core\\target\\release\\tunnelforge-core.exe" in script
     assert "tunnelforge-core DB service 빌드 완료" in script
+
+
+def test_release_workflow_builds_core_before_pyinstaller():
+    workflow = (PROJECT_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    core_build_index = workflow.index("Build tunnelforge-core (Rust)")
+    pyinstaller_index = workflow.index("Build with PyInstaller")
+
+    assert core_build_index < pyinstaller_index
+    assert "uses: dtolnay/rust-toolchain@stable" in workflow
+    assert "cargo build --manifest-path migration_core\\Cargo.toml --release" in workflow
+    assert "migration_core\\target\\release\\tunnelforge-core.exe" in workflow
+
+
+def test_release_version_files_are_in_sync():
+    version_py = (PROJECT_ROOT / "src" / "version.py").read_text(encoding="utf-8")
+    pyproject = (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    installer = (PROJECT_ROOT / "installer" / "TunnelForge.iss").read_text(encoding="utf-8")
+
+    app_version = re.search(r'__version__\s*=\s*"([^"]+)"', version_py).group(1)
+    package_version = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE).group(1)
+    installer_version = re.search(r'#define MyAppVersion "([^"]+)"', installer).group(1)
+
+    assert package_version == app_version
+    assert installer_version == app_version

--- a/tunnel-manager.spec
+++ b/tunnel-manager.spec
@@ -63,9 +63,12 @@ datas = [
 
 core_suffix = '.exe' if os.name == 'nt' else ''
 tunnelforge_core_exe = os.path.join(project_root, 'migration_core', 'target', 'release', f'tunnelforge-core{core_suffix}')
-binaries = []
-if os.path.exists(tunnelforge_core_exe):
-    binaries.append((tunnelforge_core_exe, '.'))
+if not os.path.exists(tunnelforge_core_exe):
+    raise SystemExit(
+        f"tunnelforge-core{core_suffix} not found at {tunnelforge_core_exe}. "
+        "Run `cargo build --manifest-path migration_core/Cargo.toml --release` first."
+    )
+binaries = [(tunnelforge_core_exe, '.')]
 
 # Analysis: 실행 파일에 포함될 내용 분석
 a = Analysis(


### PR DESCRIPTION
## Summary
- **CI에서 Rust 빌드 누락 fix**: `release.yml`에 `cargo build --release` 단계 추가. 이전엔 PyInstaller spec이 `if os.path.exists(...)`로 조용히 스킵해서, **모든 v2.x 인스톨러에 `tunnelforge-core.exe`가 빠진 채 배포**되고 있었음 → 사용자 화면의 "Rust DB Core 실행 파일을 찾을 수 없습니다" 에러의 root cause.
- **재발 방지**: `tunnel-manager.spec`을 hard-fail 로 변경해서 Rust 바이너리가 없으면 PyInstaller 빌드 자체를 실패시킴.
- **업데이트 설치 UX fix**: `settings.py`에서 `/SILENT /SUPPRESSMSGBOXES` 제거. 정상 마법사가 노출되고 Inno Setup `[Run] postinstall skipifsilent`가 재실행을 담당. bat의 `explorer.exe` fallback도 제거 (중복 실행 방지 + "그냥 꺼져버림" 증상 해결).

## Test plan
- [ ] 로컬 `python main.py` 정상 기동 (Rust core가 로컬 빌드된 환경에서)
- [ ] `python -m PyInstaller tunnel-manager.spec` — Rust 바이너리 없을 때 hard-fail 동작 확인
- [ ] CI 통과 후 받은 인스톨러로 클린 설치 → DB 연결 시 Rust core 정상 spawn
- [ ] 정보 탭 → 업데이트 다운로드 → 설치 시작 → Inno Setup 마법사 표시 → 완료 후 "TunnelForge 실행" 체크박스로 자동 재기동

🤖 Generated with [Claude Code](https://claude.com/claude-code)