### PR TITLE
Fix Windows post-install launch race

### DIFF
--- a/installer/TunnelForge.iss
+++ b/installer/TunnelForge.iss
@@ -92,7 +92,9 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 
 [Run]
 ; 설치 완료 후 프로그램 실행 옵션
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+; PyInstaller one-file 앱은 시작 직후 %TEMP%\_MEI...에 런타임을 풀기 때문에
+; 설치 프로그램 종료/정리와 겹치지 않도록 짧게 지연한 뒤 설치 경로에서 실행한다.
+Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -Command ""Start-Sleep -Seconds 2; Start-Process -FilePath '{app}\{#MyAppExeName}' -WorkingDirectory '{app}'"""; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: runhidden nowait postinstall skipifsilent
 
 [Code]
 /////////////////////////////////////////////////////////////////////

--- a/tests/test_rust_core_packaging.py
+++ b/tests/test_rust_core_packaging.py
@@ -1803,3 +1803,15 @@ def test_windows_installer_captures_selected_app_language():
     assert "LanguageCode := 'ko'" in installer
     assert "SaveStringToFile(HintPath, LanguageCode, False)" in installer
     assert "english.RecoveryShortcut=Recovery and Update" in installer
+
+
+def test_windows_installer_defers_postinstall_launch_for_onefile_runtime():
+    installer = (PROJECT_ROOT / "installer" / "TunnelForge.iss").read_text(encoding="utf-8")
+
+    run_section = installer.split("[Run]", 1)[1].split("[Code]", 1)[0]
+
+    assert "Start-Sleep -Seconds 2" in run_section
+    assert "Start-Process -FilePath '{app}\\{#MyAppExeName}'" in run_section
+    assert "-WorkingDirectory '{app}'" in run_section
+    assert "runhidden nowait postinstall skipifsilent" in run_section
+    assert 'Filename: "{app}\\{#MyAppExeName}"' not in run_section


### PR DESCRIPTION
## Summary
- defer the Windows installer post-install launch before starting the PyInstaller one-file app
- launch TunnelForge from the installed app directory to avoid temporary _MEI runtime cleanup races
- add a packaging regression test for the installer [Run] section

## Tests
- pytest -q tests\\test_rust_core_packaging.py
- git diff --check