### PR TITLE
fix: 자동 버전 bump가 installer .iss도 동기화

### DIFF
--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -411,7 +411,7 @@ jobs:
           else
             if [ "$NEEDS_REBUMP" = "true" ]; then
               echo "라벨 변경으로 인한 재bump. base 버전으로 복원 후 재bump."
-              git checkout "origin/${BASE_REF}" -- src/version.py pyproject.toml
+              git checkout "origin/${BASE_REF}" -- src/version.py pyproject.toml installer/TunnelForge.iss
             fi
             python scripts/bump_version.py --bump-type "$BUMP_TYPE" --dry-run > /tmp/bump_dry.txt
             EXPECTED=$(grep 'new_version=' /tmp/bump_dry.txt | cut -d= -f2)
@@ -429,7 +429,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           python scripts/bump_version.py --bump-type "${{ needs.version-gate.outputs.bump_type }}"
-          git add src/version.py pyproject.toml
+          git add src/version.py pyproject.toml installer/TunnelForge.iss
           git commit -m "chore: bump version to v${NEW_VERSION} [${{ needs.version-gate.outputs.bump_type }}]"
           git push origin "${{ github.event.pull_request.head.ref }}"
           echo "버전 bump 완료: v${NEW_VERSION}"

--- a/installer/TunnelForge.iss
+++ b/installer/TunnelForge.iss
@@ -7,7 +7,7 @@
 ;   3. 또는: .\scripts\build-installer.ps1
 
 #define MyAppName "TunnelForge"
-#define MyAppVersion "2.1.0"
+#define MyAppVersion "2.1.1"
 #define MyAppPublisher "sanghyun-io"
 #define MyAppURL "https://github.com/sanghyun-io/tunnelforge"
 #define MyAppExeName "TunnelForge.exe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tunnelforge"
-version = "2.1.0"
+version = "2.1.1"
 description = "SSH Tunnel and Rust DB Core Manager"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -62,6 +62,11 @@ def main() -> int:
         default='pyproject.toml',
         help='pyproject.toml 경로 (기본값: pyproject.toml)'
     )
+    parser.add_argument(
+        '--installer-file',
+        default='installer/TunnelForge.iss',
+        help='Inno Setup 스크립트 경로 (기본값: installer/TunnelForge.iss)'
+    )
 
     args = parser.parse_args()
 
@@ -71,11 +76,18 @@ def main() -> int:
 
     version_file = project_root / args.version_file
     pyproject_file = project_root / args.pyproject_file
+    installer_file = project_root / args.installer_file
 
     # versioning 모듈 임포트 (scripts/ 디렉토리를 sys.path에 추가)
     sys.path.insert(0, str(script_dir))
     try:
-        from versioning import read_version, write_version, sync_pyproject, bump_version
+        from versioning import (
+            read_version,
+            write_version,
+            sync_pyproject,
+            sync_installer,
+            bump_version,
+        )
     except ImportError as e:
         print(f"ERROR: versioning.py 임포트 실패: {e}", file=sys.stderr)
         return 1
@@ -123,6 +135,17 @@ def main() -> int:
                 return 1
         else:
             print(f"[SKIP] {pyproject_file} 없음, 건너뜁니다.", file=sys.stderr)
+
+        # Inno Setup 인스톨러 버전 동기화 (test_release_version_files_are_in_sync 요구사항)
+        if installer_file.exists():
+            try:
+                sync_installer(installer_file, new_version)
+                print(f"[OK] {installer_file} 업데이트 완료", file=sys.stderr)
+            except (ValueError, OSError) as e:
+                print(f"ERROR: installer .iss 쓰기 실패: {e}", file=sys.stderr)
+                return 1
+        else:
+            print(f"[SKIP] {installer_file} 없음, 건너뜁니다.", file=sys.stderr)
 
     # $GITHUB_OUTPUT 호환 형식으로 stdout 출력
     print(f"new_version={new_version}")

--- a/scripts/versioning.py
+++ b/scripts/versioning.py
@@ -91,6 +91,34 @@ def sync_pyproject(pyproject_file: Path, new_version: str) -> None:
     pyproject_file.write_text(''.join(new_lines), encoding='utf-8')
 
 
+def sync_installer(installer_file: Path, new_version: str) -> None:
+    """installer/TunnelForge.iss의 #define MyAppVersion 값을 업데이트한다.
+
+    Inno Setup 스크립트의 버전 정의만 교체하며 다른 설정은 보존된다.
+    이 동기화가 없으면 test_release_version_files_are_in_sync가 실패한다
+    (version.py / pyproject.toml / .iss 세 파일의 버전이 일치해야 함).
+
+    Args:
+        installer_file: installer/TunnelForge.iss 경로
+        new_version: 새 버전 문자열 (예: "1.11.1")
+
+    Raises:
+        FileNotFoundError: 파일이 존재하지 않을 때
+        ValueError: #define MyAppVersion 라인을 찾을 수 없을 때
+    """
+    content = installer_file.read_text(encoding='utf-8')
+    new_content, count = re.subn(
+        r'(#define\s+MyAppVersion\s+")[^"]*(")',
+        rf'\g<1>{new_version}\g<2>',
+        content,
+    )
+    if count == 0:
+        raise ValueError(
+            f"#define MyAppVersion 라인을 찾을 수 없습니다: {installer_file}"
+        )
+    installer_file.write_text(new_content, encoding='utf-8')
+
+
 def bump_version(version: str, bump_type: str) -> str:
     """시맨틱 버전을 bump_type에 따라 증가시킨다.
 

--- a/src/version.py
+++ b/src/version.py
@@ -4,7 +4,7 @@
 모든 버전 참조는 이 파일을 사용해야 합니다.
 """
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 __app_name__ = "TunnelForge"
 
 # GitHub 저장소 정보 (업데이트 확인용)

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -24,6 +24,7 @@ from versioning import (
     bump_version,
     compare_versions,
     read_version,
+    sync_installer,
     sync_pyproject,
     write_version,
 )
@@ -50,6 +51,21 @@ def pyproject_file(tmp_path):
     f = tmp_path / "pyproject.toml"
     f.write_text(
         '[build-system]\nrequires = ["setuptools"]\n\n[project]\nname = "tunnelforge"\nversion = "1.11.0"\ndescription = "Test"\n',
+        encoding='utf-8'
+    )
+    return f
+
+
+@pytest.fixture
+def installer_file(tmp_path):
+    """정상적인 Inno Setup(.iss) 형태의 임시 파일."""
+    f = tmp_path / "TunnelForge.iss"
+    f.write_text(
+        '#define MyAppName "TunnelForge"\n'
+        '#define MyAppVersion "1.11.0"\n'
+        '#define MyAppPublisher "sanghyun-io"\n\n'
+        '[Setup]\nAppVersion={#MyAppVersion}\n'
+        'OutputBaseFilename=TunnelForge-Setup-{#MyAppVersion}\n',
         encoding='utf-8'
     )
     return f
@@ -202,6 +218,46 @@ class TestSyncPyproject:
 
 
 # ─────────────────────────────────────────────
+# sync_installer 테스트
+# ─────────────────────────────────────────────
+
+class TestSyncInstaller:
+    def test_updates_version(self, installer_file):
+        sync_installer(installer_file, "1.11.1")
+        content = installer_file.read_text(encoding='utf-8')
+        assert '#define MyAppVersion "1.11.1"' in content
+
+    def test_preserves_other_defines(self, installer_file):
+        sync_installer(installer_file, "1.11.1")
+        content = installer_file.read_text(encoding='utf-8')
+        assert '#define MyAppName "TunnelForge"' in content
+        assert '#define MyAppPublisher "sanghyun-io"' in content
+        # {#MyAppVersion} 참조는 그대로 보존되어야 한다 (값만 바뀜)
+        assert 'AppVersion={#MyAppVersion}' in content
+        assert 'OutputBaseFilename=TunnelForge-Setup-{#MyAppVersion}' in content
+
+    def test_does_not_duplicate(self, installer_file):
+        sync_installer(installer_file, "1.11.1")
+        content = installer_file.read_text(encoding='utf-8')
+        assert content.count('#define MyAppVersion "1.11.1"') == 1
+
+    def test_minor_bump_version(self, installer_file):
+        sync_installer(installer_file, "2.1.0")
+        content = installer_file.read_text(encoding='utf-8')
+        assert '#define MyAppVersion "2.1.0"' in content
+
+    def test_missing_define_raises(self, tmp_path):
+        f = tmp_path / "bad.iss"
+        f.write_text('#define MyAppName "X"\n', encoding='utf-8')
+        with pytest.raises(ValueError):
+            sync_installer(f, "1.0.0")
+
+    def test_file_not_found_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            sync_installer(tmp_path / "nonexistent.iss", "1.0.0")
+
+
+# ─────────────────────────────────────────────
 # compare_versions 테스트
 # ─────────────────────────────────────────────
 
@@ -279,6 +335,30 @@ class TestBumpVersionCLI:
     def test_invalid_bump_type_exit_nonzero(self):
         code, _, _ = self.run_cli("--bump-type", "invalid")
         assert code != 0
+
+    def test_real_bump_syncs_all_three_files(self, tmp_path):
+        """실제 bump 시 version.py / pyproject.toml / .iss 세 파일이 모두 동기화되어야 한다.
+
+        워크트리 실제 파일을 건드리지 않도록 임시 경로를 인자로 전달한다.
+        """
+        vf = tmp_path / "version.py"
+        vf.write_text('__version__ = "2.1.0"\n', encoding='utf-8')
+        pf = tmp_path / "pyproject.toml"
+        pf.write_text('[project]\nname = "x"\nversion = "2.1.0"\n', encoding='utf-8')
+        isf = tmp_path / "TunnelForge.iss"
+        isf.write_text('#define MyAppVersion "2.1.0"\n', encoding='utf-8')
+
+        code, stdout, stderr = self.run_cli(
+            "--bump-type", "patch",
+            "--version-file", str(vf),
+            "--pyproject-file", str(pf),
+            "--installer-file", str(isf),
+        )
+        assert code == 0, stderr
+        assert "new_version=2.1.1" in stdout
+        assert '__version__ = "2.1.1"' in vf.read_text(encoding='utf-8')
+        assert 'version = "2.1.1"' in pf.read_text(encoding='utf-8')
+        assert '#define MyAppVersion "2.1.1"' in isf.read_text(encoding='utf-8')
 
     def test_help_exit_zero(self):
         code, _, _ = self.run_cli("--help")


### PR DESCRIPTION
## 배경

PR #129(View 지원) 머지 중 `version:minor` 라벨로 자동 릴리스 경로가 처음 작동하면서, `test_release_version_files_are_in_sync`가 실패해 머지가 막혔다. 당시엔 `.iss`를 수동으로 2.1.0에 맞춰 우회했고, 이 PR이 그 근본 원인을 제거한다.

## 왜 갑자기 터졌나

두 개의 릴리스 경로가 공존했다:

| 경로 | 커밋 형식 | `.iss` 동기화 |
|------|-----------|:---:|
| 수동 (`Bump version to X`) | 대문자, v접두사 없음 | ✅ (사람이 함께 편집) |
| 자동 (`chore: bump ... [type]`) | `version-gate.yml` → `bump_version.py` → `versioning.py` | ❌ **누락** |

- `.iss` sync 테스트는 `2.0.6`에 추가됨
- 이후 `2.0.x`는 전부 **수동 경로**로 릴리스 → `.iss`가 항상 맞아 테스트 통과
- 자동 경로의 마지막 실제 사용은 `1.15.3`(= sync 테스트 도입 **이전**)
- **PR #129가 sync 테스트 도입 이후 자동 경로를 처음 작동** → `.iss` 미동기화 버그 노출

즉 자동 경로에 잠복하던 버그가 이번에 비로소 드러난 것.

## 수정

- `versioning.py`: `sync_installer()` 추가 — `#define MyAppVersion` 값만 교체, 다른 define/참조 보존
- `bump_version.py`: `--installer-file` 인자 + `sync_installer` 호출. 이제 자동 경로가 `version.py` / `pyproject.toml` / `.iss` **세 파일을 일괄 동기화** (CLAUDE.md의 "version.py = SSOT, 모든 참조 sync" 원칙 준수)
- `test_bump_version.py`: `TestSyncInstaller`(6개) + CLI end-to-end 동기화 검증(1개)

## 테스트
- 전체 pytest **1705개 통과** (신규 7개)
- end-to-end: CLI `patch` bump 시 세 파일이 모두 2.1.0→2.1.1로 동기화됨을 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)