### PR TITLE
[codex] Fix export row growth and running logs

### DIFF
--- a/installer/TunnelForge.iss
+++ b/installer/TunnelForge.iss
@@ -7,7 +7,7 @@
 ;   3. 또는: .\scripts\build-installer.ps1
 
 #define MyAppName "TunnelForge"
-#define MyAppVersion "2.1.5"
+#define MyAppVersion "2.1.6"
 #define MyAppPublisher "sanghyun-io"
 #define MyAppURL "https://github.com/sanghyun-io/tunnelforge"
 #define MyAppExeName "TunnelForge.exe"

--- a/migration_core/src/lib.rs
+++ b/migration_core/src/lib.rs
@@ -1816,6 +1816,17 @@ fn dump_tables_sequential<F: FnMut(Value)>(
     Ok((manifests, total_rows, total_chunks))
 }
 
+fn bounded_dump_chunk_limit(total_rows: u64, rows_dumped: u64, chunk_size: usize) -> Option<usize> {
+    if total_rows > 0 && rows_dumped >= total_rows {
+        return None;
+    }
+    let limit = chunk_size.max(1);
+    if total_rows == 0 {
+        return Some(limit);
+    }
+    Some(limit.min((total_rows - rows_dumped) as usize))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct DumpParallelLimits {
     table_workers: usize,
@@ -2835,11 +2846,15 @@ fn dump_one_table<F: FnMut(Value)>(
     let mut chunk_sha256 = BTreeMap::new();
 
     loop {
+        let Some(read_limit) = bounded_dump_chunk_limit(table_row_count, rows_dumped, chunk_size)
+        else {
+            break;
+        };
         let read_started = Instant::now();
         let rows = if use_keyset {
-            adapter.read_rows_after_key(table, &key_columns, last_key.as_deref(), chunk_size)?
+            adapter.read_rows_after_key(table, &key_columns, last_key.as_deref(), read_limit)?
         } else {
-            adapter.read_rows(table, offset, chunk_size)?
+            adapter.read_rows(table, offset, read_limit)?
         };
         let read_ms = read_started.elapsed().as_millis() as u64;
         if rows.is_empty() {
@@ -2939,6 +2954,10 @@ fn dump_one_mysql_table<F: FnMut(Value)>(
     let mut chunk_sha256 = BTreeMap::new();
 
     loop {
+        let Some(read_limit) = bounded_dump_chunk_limit(table_row_count, rows_dumped, chunk_size)
+        else {
+            break;
+        };
         chunks_dumped += 1;
         let chunk_name = dump_chunk_name(chunks_dumped, data_format, compression);
         let chunk_path = table_dir.join(&chunk_name);
@@ -2951,7 +2970,7 @@ fn dump_one_mysql_table<F: FnMut(Value)>(
                 table,
                 &key_columns,
                 last_values.as_deref(),
-                chunk_size,
+                read_limit,
             )
         } else {
             select_chunk_text_sql("mysql", table, &key_columns)
@@ -2959,7 +2978,7 @@ fn dump_one_mysql_table<F: FnMut(Value)>(
         let sql = if use_keyset {
             sql
         } else {
-            sql.replacen('?', &(chunk_size as u64).to_string(), 1)
+            sql.replacen('?', &(read_limit as u64).to_string(), 1)
                 .replacen('?', &(offset as u64).to_string(), 1)
         };
         let result = if use_keyset {
@@ -4793,7 +4812,9 @@ fn validate_single_view_statement(sql: &str) -> Result<(), String> {
     match iter.next() {
         Some(tok) if tok.eq_ignore_ascii_case("create") => {}
         Some(tok) => {
-            return Err(format!("view definition must start with CREATE, got: {tok}"))
+            return Err(format!(
+                "view definition must start with CREATE, got: {tok}"
+            ))
         }
         None => return Err("empty view definition".to_string()),
     }
@@ -10128,6 +10149,20 @@ mod tests {
     }
 
     #[test]
+    fn dump_chunk_limit_stops_at_initial_row_count_when_source_grows() {
+        assert_eq!(bounded_dump_chunk_limit(2, 0, 50_000), Some(2));
+        assert_eq!(bounded_dump_chunk_limit(2, 2, 50_000), None);
+        assert_eq!(
+            bounded_dump_chunk_limit(120_000, 50_000, 50_000),
+            Some(50_000)
+        );
+        assert_eq!(
+            bounded_dump_chunk_limit(120_000, 100_000, 50_000),
+            Some(20_000)
+        );
+    }
+
+    #[test]
     fn adaptive_import_chunk_order_prefers_larger_chunk_files() {
         let dir = std::env::temp_dir().join(format!(
             "tunnelforge-import-order-test-{}",
@@ -12208,7 +12243,10 @@ mod tests {
     #[test]
     fn drop_view_sql_uses_drop_view() {
         assert_eq!(drop_view_sql("mysql", "v"), "DROP VIEW IF EXISTS `v`");
-        assert_eq!(drop_view_sql("postgresql", "v"), "DROP VIEW IF EXISTS \"v\"");
+        assert_eq!(
+            drop_view_sql("postgresql", "v"),
+            "DROP VIEW IF EXISTS \"v\""
+        );
     }
 
     #[test]
@@ -12323,8 +12361,7 @@ mod tests {
         // CREATE 로 시작하지만 VIEW가 아닌 단일 statement는 거부해야 한다.
         assert!(validate_single_view_statement("CREATE USER attacker IDENTIFIED BY 'p'").is_err());
         assert!(
-            validate_single_view_statement("CREATE TABLE stolen AS SELECT * FROM secrets")
-                .is_err()
+            validate_single_view_statement("CREATE TABLE stolen AS SELECT * FROM secrets").is_err()
         );
         let err = validate_single_view_statement("CREATE DATABASE evil").unwrap_err();
         assert!(err.contains("VIEW"));
@@ -12337,9 +12374,7 @@ mod tests {
             "CREATE ALGORITHM=UNDEFINED SQL SECURITY INVOKER VIEW `v` AS select 1"
         )
         .is_ok());
-        assert!(
-            validate_single_view_statement("CREATE OR REPLACE VIEW \"v\" AS SELECT 1").is_ok()
-        );
+        assert!(validate_single_view_statement("CREATE OR REPLACE VIEW \"v\" AS SELECT 1").is_ok());
     }
 
     #[test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tunnelforge"
-version = "2.1.5"
+version = "2.1.6"
 description = "SSH Tunnel and Rust DB Core Manager"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ui/dialogs/db_dialogs.py
+++ b/src/ui/dialogs/db_dialogs.py
@@ -18,6 +18,7 @@ import os
 from src.core.db_connector import MySQLConnector
 from src.core.postgres_connector import PostgresConnector
 from src.core.constants import DEFAULT_MYSQL_PORT, DEFAULT_LOCAL_HOST
+from src.core.i18n import translate_text
 from src.core.logger import get_logger
 from src.exporters.rust_dump_exporter import (
     RustDumpChecker, RustDumpConfig, check_rust_dump,
@@ -1391,6 +1392,8 @@ class RustDumpExportDialog(QDialog):
         timestamp = datetime.now().strftime('%H:%M:%S')
         log_entry = f"[{timestamp}] {msg}"
         self.log_entries.append(log_entry)
+        if hasattr(self, "btn_save_log"):
+            self.btn_save_log.setEnabled(True)
 
     def on_progress(self, msg: str):
         self.txt_log.addItem(msg)
@@ -1699,7 +1702,10 @@ class RustDumpExportDialog(QDialog):
 
         # 기본 파일명 생성
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        status = "success" if self.export_success else "failed"
+        if self.export_success is None:
+            status = "running"
+        else:
+            status = "success" if self.export_success else "failed"
         default_filename = f"export_log_{self.export_schema}_{status}_{timestamp}.txt"
 
         # 파일 저장 대화상자
@@ -1726,7 +1732,11 @@ class RustDumpExportDialog(QDialog):
                     f.write(f"선택 테이블: {', '.join(self.export_tables)}\n")
                 f.write(f"출력 폴더: {self.input_output_dir.text()}\n")
                 f.write(f"연결 정보: {self.connection_info}\n")
-                f.write(f"결과: {'성공 ✅' if self.export_success else '실패 ❌'}\n")
+                if self.export_success is None:
+                    result_label = "진행 중"
+                else:
+                    result_label = "성공 ✅" if self.export_success else "실패 ❌"
+                f.write(f"결과: {result_label}\n")
 
                 if self.export_start_time:
                     f.write(f"시작 시간: {self.export_start_time.strftime('%Y-%m-%d %H:%M:%S')}\n")
@@ -1791,6 +1801,18 @@ class RustDumpExportDialog(QDialog):
             )
 
     def closeEvent(self, event):
+        if self.worker and self.worker.isRunning():
+            self._add_log("닫기 차단: Export가 실행 중입니다. 로그 저장은 계속 사용할 수 있습니다.")
+            self.btn_save_log.setEnabled(True)
+            QMessageBox.warning(
+                self,
+                translate_text("Export 실행 중"),
+                translate_text(
+                    "Export가 실행 중입니다.\n로그 저장은 가능하지만, 진행 중에는 창을 닫을 수 없습니다."
+                )
+            )
+            event.ignore()
+            return
         if self.connector:
             self.connector.disconnect()
         event.accept()

--- a/src/version.py
+++ b/src/version.py
@@ -4,7 +4,7 @@
 모든 버전 참조는 이 파일을 사용해야 합니다.
 """
 
-__version__ = "2.1.5"
+__version__ = "2.1.6"
 __app_name__ = "TunnelForge"
 
 # GitHub 저장소 정보 (업데이트 확인용)

--- a/tests/test_db_dialogs.py
+++ b/tests/test_db_dialogs.py
@@ -351,6 +351,75 @@ def test_export_raw_output_shows_visible_telemetry_summary():
     assert dialog.log_entries[0].endswith("pk_range_parallel")
 
 
+def test_export_add_log_enables_save_log_before_finish(monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    monkeypatch.setattr(
+        "src.ui.dialogs.db_dialogs.check_rust_dump",
+        lambda: (True, "Rust DB Core OK"),
+    )
+    dialog = RustDumpExportDialog()
+
+    assert not dialog.btn_save_log.isEnabled()
+
+    dialog._add_log("export started")
+
+    assert dialog.btn_save_log.isEnabled()
+    dialog.close()
+
+
+def test_export_close_while_running_keeps_dialog_open_and_log_available(monkeypatch):
+    class FakeWorker:
+        def isRunning(self):
+            return True
+
+    class FakeConnector:
+        def __init__(self):
+            self.disconnected = False
+
+        def disconnect(self):
+            self.disconnected = True
+
+    class FakeButton:
+        def __init__(self):
+            self.enabled = False
+
+        def setEnabled(self, enabled):
+            self.enabled = enabled
+
+    class FakeEvent:
+        def __init__(self):
+            self.accepted = False
+            self.ignored = False
+
+        def accept(self):
+            self.accepted = True
+
+        def ignore(self):
+            self.ignored = True
+
+    warnings = []
+    monkeypatch.setattr(
+        "src.ui.dialogs.db_dialogs.QMessageBox.warning",
+        lambda *args: warnings.append(args),
+    )
+    dialog = type("DummyDialog", (), {})()
+    dialog.worker = FakeWorker()
+    dialog.connector = FakeConnector()
+    dialog.btn_save_log = FakeButton()
+    dialog.log_entries = []
+    dialog._add_log = lambda message: dialog.log_entries.append(message)
+    event = FakeEvent()
+
+    RustDumpExportDialog.closeEvent(dialog, event)
+
+    assert event.ignored
+    assert not event.accepted
+    assert not dialog.connector.disconnected
+    assert dialog.btn_save_log.enabled
+    assert any("닫기 차단" in entry for entry in dialog.log_entries)
+    assert warnings
+
+
 def test_preselected_export_tunnel_passes_mysql_default_database(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary

- Cap dump chunk reads to the initial discovered row count so export does not keep following rows inserted while the dump is running.
- Allow Export logs to be saved as soon as log entries exist, including while the operation is still running.
- Prevent closing the Export dialog while its worker is active so the process is not silently interrupted.

## Root Cause

Some dump paths used the initial `COUNT(*)` only for progress totals, while read loops continued requesting full chunks. If a source table grew during export, keyset/whole-table paths could continue reading beyond the discovered total and report more dumped rows than originally planned.

The Export dialog also only enabled log saving after finish and accepted close events while a worker was still running.

## Validation

- `pytest -q` -> 1707 passed
- `cargo test --manifest-path migration_core\Cargo.toml` -> passed
- `cargo fmt --manifest-path migration_core\Cargo.toml --check` -> passed