### PR TITLE
fix(sql-parser): 커스텀 DELIMITER를 dollar-quote보다 우선 매칭 (WP-1.2)

### DIFF
--- a/src/core/sql_statement_parser.py
+++ b/src/core/sql_statement_parser.py
@@ -121,12 +121,18 @@ def parse_sql_statement_ranges(sql_text: str) -> list[SqlStatement]:
             i += 1
             continue
 
-        marker = read_dollar_quote(sql_text, i)
-        if marker:
-            dollar_quote = marker
-            append_text(marker, i)
-            i += len(marker)
+        if delimiter != ";" and delimiter and sql_text.startswith(delimiter, i):
+            flush(i, i + len(delimiter))
+            i += len(delimiter)
             continue
+
+        if delimiter == ";":
+            marker = read_dollar_quote(sql_text, i)
+            if marker:
+                dollar_quote = marker
+                append_text(marker, i)
+                i += len(marker)
+                continue
 
         if char in ("'", '"', "`"):
             quote = char

--- a/tests/test_sql_execution_worker.py
+++ b/tests/test_sql_execution_worker.py
@@ -1,4 +1,4 @@
-from src.core.sql_statement_parser import read_dollar_quote
+from src.core.sql_statement_parser import find_sql_statement_at_position, read_dollar_quote
 from src.ui.workers.test_worker import SQLExecutionWorker
 
 
@@ -126,6 +126,40 @@ def test_sql_statement_parser_supports_client_delimiters():
         "CREATE PROCEDURE p()\n    BEGIN\n        SELECT 'a;b';\n    END",
         "SELECT 1",
     ]
+
+
+def test_sql_statement_parser_supports_mysql_dollar_delimiter():
+    sql = """
+    DELIMITER $$
+    CREATE PROCEDURE p()
+    BEGIN
+        SELECT 'a;b';
+    END$$
+    DELIMITER ;
+    SELECT 1;
+    """
+
+    assert SQLExecutionWorker._parse_sql_statements(sql) == [
+        "CREATE PROCEDURE p()\n    BEGIN\n        SELECT 'a;b';\n    END",
+        "SELECT 1",
+    ]
+
+
+def test_find_sql_statement_at_position_supports_mysql_dollar_delimiter():
+    sql = """
+    DELIMITER $$
+    CREATE PROCEDURE p()
+    BEGIN
+        SELECT 'a;b';
+    END$$
+    DELIMITER ;
+    SELECT 1;
+    """
+
+    procedure = "CREATE PROCEDURE p()\n    BEGIN\n        SELECT 'a;b';\n    END"
+
+    assert find_sql_statement_at_position(sql, sql.index("SELECT 'a;b'")) == procedure
+    assert find_sql_statement_at_position(sql, sql.rindex("SELECT 1")) == "SELECT 1"
 
 
 def test_sql_statement_parser_supports_postgresql_dollar_quotes():


### PR DESCRIPTION
## 감사 지적 사항 (Finding)

`src/core/sql_statement_parser.py`의 `parse_sql_statement_ranges()`에서 PostgreSQL dollar-quote 감지(`read_dollar_quote`)가 커스텀 `DELIMITER` 매칭보다 먼저 실행되어, MySQL 스타일의 `DELIMITER $$` 스크립트를 파싱할 때 종료 마커 `END$$`의 `$$`가 (빈 태그) dollar-quote 오프너로 먼저 소비되는 버그가 있었습니다. 그 결과 프로시저 본문이 하나의 SQL statement로 올바르게 분리되지 않았습니다.

## 변경 요약

`parse_sql_statement_ranges()`의 처리 순서만 수정했습니다:

1. 활성 `DELIMITER` 라인 처리, 라인/블록 주석, 활성 dollar-quote 본문, 활성 quote(`'`/`"`/`` ` ``) 처리는 기존 순서 그대로 유지.
2. 그 다음 **커스텀 delimiter(`;`가 아닌 경우) 매칭을 dollar-quote 감지보다 먼저 검사**하도록 이른 분기 추가.
3. `read_dollar_quote(...)` 호출은 **기본 `;` delimiter 컨텍스트에서만** 수행하도록 제한.
4. 이후의 일반 delimiter 종료 체크는 그대로 유지 (기존 `DELIMITER //` 동작에 영향 없음).

`read_dollar_quote(...)` 함수 자체(빈 태그 지원, fail-closed 입력 처리)는 변경하지 않았습니다.

변경 파일:
- `src/core/sql_statement_parser.py`
- `tests/test_sql_execution_worker.py` (회귀 테스트 2건 추가)

## 검증 결과

```
python -m py_compile src/core/sql_statement_parser.py tests/test_sql_execution_worker.py   # OK
python -m pytest tests/test_sql_execution_worker.py -q   # 8 passed
python -m pytest -q   # 1877 passed, 1 failed
```

전체 스위트의 유일한 실패는 `tests/test_rust_core_packaging.py::test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`로, GitHub CI 실행 이력에 의존하는 통합 테스트라 로컬/worktree 환경에서는 코드 변경과 무관하게 항상 실패합니다 (기준선 1875 passed + 이번에 추가한 신규 테스트 2건 = 1877 passed로 정확히 일치, 실패 1건은 동일 테스트).

## 영향 범위

- MySQL `DELIMITER $$`, `DELIMITER //` 등 커스텀 delimiter 스크립트가 올바르게 statement 단위로 분리됩니다.
- PostgreSQL 기본(`;`) delimiter 컨텍스트의 dollar-quote 파싱 동작은 그대로 유지됩니다.
- Rust Core가 소유하는 실제 DB 실행 경로는 변경하지 않았습니다 (순수 파서 로직 수정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)