### PR TITLE
fix(i18n): QComboBox 번역 monkey-patch 제거로 식별자 보존 (WP-1.4)

### DIFF
--- a/src/core/i18n.py
+++ b/src/core/i18n.py
@@ -936,7 +936,6 @@ _EN_PHRASE_TRANSLATIONS = {
     "출력 경로를 선택하세요.": "Select an output path.",
     "서버가 지역명 타임존을 지원하지 않으면 자동으로 +09:00(KST)로 보정합니다.": "If the server does not support named time zones, it is automatically adjusted to +09:00 (KST).",
     "FK 안전 변경 방식으로 모든 테이블이 일괄 처리됩니다.": "All tables are processed in batch using the FK-safe change method.",
-    "체크 해제 시 해당 테이블을 건너뜁니다.": "Uncheck to skip that table.",
     "사전 검사": "Pre-flight Check",
     "마이그레이션 전 필수 요건을 검사합니다.": "Checks required conditions before migration.",
     "검사 항목": "Check Items",
@@ -969,7 +968,6 @@ _EN_PHRASE_TRANSLATIONS = {
     "마지막 실행": "Last Run",
     "활성화": "Enabled",
     "Export/Import 오류 시 자동으로 GitHub 이슈 생성": "Create GitHub issues automatically on Export/Import errors",
-    "백업 목록": "Backup List",
     "최근": "recent",
     "선택한 백업으로 설정을 복원하시겠습니까?": "Do you want to restore settings from the selected backup?",
     "선택한 파일에서 설정을 가져오시겠습니까?": "Do you want to import settings from the selected file?",
@@ -1063,8 +1061,6 @@ _EN_PHRASE_TRANSLATIONS = {
     "셀 편집": "Cell edits",
     "버튼": "button",
     "클릭하여": "click to",
-    "항목": "items",
-    "자동 커밋": "auto commit",
     "커밋 완료": "Commit complete",
     "커밋에 실패했습니다": "Commit failed",
     "롤백 완료": "Rollback complete",
@@ -1095,7 +1091,6 @@ _EN_PHRASE_TRANSLATIONS = {
     "남은 이슈": "Remaining issues",
     "새 이슈": "New issues",
     "풀": "pools",
-    "사용 중": "in use",
     "인증 테스트 건너뜀": "auth test skipped",
     "자격 증명 없음": "no credentials",
     "도달 실패": "reach failed",
@@ -1120,7 +1115,6 @@ _EN_PHRASE_TRANSLATIONS = {
     "주소": "address",
     "목적지": "destination",
     "기본 DB 이름": "Default DB name",
-    "기본 스키마": "Default schema",
     "위험 작업 시": "for dangerous operations",
     "직접 입력 필요": "manual input required",
     "다이얼로그 표시": "show dialog",
@@ -1503,16 +1497,8 @@ def install_qt_i18n() -> bool:
     patch_method(QPlainTextEdit, "appendPlainText", [0])
 
     patch_method(QComboBox, "setPlaceholderText", [0])
+    # Combo inserted items can be schema/database identifiers; preserve them exactly.
     patch_method(QComboBox, "setItemText", [1])
-    patch_all_string_args_method(QComboBox, "addItem")
-    patch_all_string_args_method(QComboBox, "insertItem")
-    original_add_items = QComboBox.addItems
-    if not getattr(original_add_items, "_tf_i18n_wrapped", False):
-        def add_items(self, texts):
-            return original_add_items(self, _translate_sequence(list(texts)))
-
-        add_items._tf_i18n_wrapped = True
-        QComboBox.addItems = add_items
 
     patch_all_string_args_method(QTabWidget, "addTab")
     patch_method(QTabWidget, "setTabText", [1])

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -92,6 +92,9 @@ def test_translate_text_handles_common_hardcoded_ui_phrases():
     assert i18n.translate_text("Mismatch: {}개") == "Mismatch: {}"
     assert i18n.translate_text("Rust Core 검사 완료: {}개 테이블") == "Rust Core inspection complete: {} tables"
     assert i18n.translate_text("✅ {}개 테이블 로드됨 (MySQL {})") == "✅ {} tables loaded (MySQL {})"
+    assert i18n.translate_text("항목") == "Item"
+    assert i18n.translate_text("자동 커밋") == "Auto Commit"
+    assert i18n.translate_text("사용 중") == "In Use"
 
 
 def test_qt_i18n_hooks_translate_hardcoded_widget_text(monkeypatch):
@@ -122,7 +125,8 @@ def test_qt_i18n_hooks_translate_hardcoded_widget_text(monkeypatch):
     field = QLineEdit()
     form.addRow("이름:", field)
     combo = QComboBox()
-    combo.addItem("삭제")
+    combo.addItem("백업")
+    assert combo.itemText(0) == "백업"
     combo.setItemText(0, "취소")
     table = QTableWidget(1, 2)
     table.setHorizontalHeaderLabels(["시간", "메시지"])
@@ -147,6 +151,55 @@ def test_qt_i18n_hooks_translate_hardcoded_widget_text(monkeypatch):
     assert container.windowTitle() == "Tunnel Status"
 
 
+def test_qcombobox_inserted_identity_text_is_not_translated(monkeypatch):
+    monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
+    from PyQt6.QtWidgets import QApplication, QComboBox
+
+    app = QApplication.instance() or QApplication([])
+    assert app is not None
+
+    i18n.set_language("en")
+    i18n.install_qt_i18n()
+
+    combo = QComboBox()
+    combo.addItem("백업")
+    combo.insertItem(0, "로그")
+    combo.addItems(["스키마", "데이터베이스"])
+    combo.addItem("원본", "백업")
+
+    assert combo.itemText(0) == "로그"
+    assert combo.itemText(1) == "백업"
+    assert combo.itemText(2) == "스키마"
+    assert combo.itemText(3) == "데이터베이스"
+    assert combo.itemText(4) == "원본"
+    assert combo.itemData(4) == "백업"
+
+
+def test_en_phrase_translations_have_no_duplicate_source_keys():
+    project_root = Path(__file__).resolve().parents[1]
+    source_path = project_root / "src" / "core" / "i18n.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+
+    duplicates = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "_EN_PHRASE_TRANSLATIONS" for target in node.targets):
+            continue
+
+        seen = {}
+        for key_node in node.value.keys:
+            if not isinstance(key_node, ast.Constant) or not isinstance(key_node.value, str):
+                continue
+            key = key_node.value
+            if key in seen:
+                duplicates.append((key, seen[key], key_node.lineno))
+            else:
+                seen[key] = key_node.lineno
+
+    assert duplicates == []
+
+
 def test_direct_hardcoded_qt_ui_strings_have_english_runtime_translation():
     ui_functions = {
         "QLabel", "QPushButton", "QCheckBox", "QRadioButton", "QGroupBox",
@@ -156,7 +209,7 @@ def test_direct_hardcoded_qt_ui_strings_have_english_runtime_translation():
     ui_methods = {
         "setWindowTitle", "setText", "setTitle", "setToolTip", "setStatusTip",
         "setWhatsThis", "setPlaceholderText", "addTab", "setTabText",
-        "addRow", "addItem", "insertItem", "addItems", "setItemText",
+        "addRow", "setItemText",
         "setHeaderLabels", "setHorizontalHeaderLabels", "setVerticalHeaderLabels",
         "showMessage", "information", "warning", "critical", "question",
         "getOpenFileName", "getSaveFileName", "getExistingDirectory",


### PR DESCRIPTION
## Finding (Audit R1 / WP-1.4)

`src/core/i18n.py`의 `install_qt_i18n()`이 `QComboBox.addItem` / `insertItem` / `addItems`에 삽입되는 모든 문자열 인자를 monkey-patch로 번역하고 있었다. 콤보박스가 스키마명, 데이터베이스명 같은 식별자를 담는 이 앱의 특성상, 영문 UI 모드에서 `백업`, `로그`, `스키마`, `데이터베이스` 같은 값이 `Backup`, `Log`, `Schema`, `Database`로 조용히 바뀌어 이후 `currentText()`로 읽는 호출부가 잘못된 식별자를 사용하게 되는 문제가 있었다.

추가로 `_EN_PHRASE_TRANSLATIONS`에 리터럴 키 중복 6건이 있어, 후행 값이 선행 값을 조용히 덮어쓰며 일부 phrase의 대소문자(casing)가 흔들렸다.

## 변경 요약

**`src/core/i18n.py`**
- `install_qt_i18n()`에서 `QComboBox.addItem` / `insertItem` / `addItems`에 대한 `patch_all_string_args_method` / custom wrapper 제거. `setPlaceholderText`, `setItemText`는 chrome 텍스트이므로 그대로 유지.
- `_EN_PHRASE_TRANSLATIONS`의 중복 리터럴 키 6건 정리 (후행 중복만 삭제, 선행 canonical 값 유지):
  - `체크 해제 시 해당 테이블을 건너뜁니다.`, `백업 목록`, `항목`(→"Item" 유지), `자동 커밋`(→"Auto Commit" 유지), `사용 중`(→"In Use" 유지), `기본 스키마`

**`tests/test_i18n.py`**
- `test_qt_i18n_hooks_translate_hardcoded_widget_text`: `addItem`이 더 이상 번역되지 않고, `setItemText`는 여전히 chrome 텍스트로 번역됨을 검증하도록 수정.
- 신규 `test_qcombobox_inserted_identity_text_is_not_translated`: `addItem`/`insertItem`/`addItems`/`addItem(text, userData)` 전 경로에서 한글 스키마·DB 식별자(백업/로그/스키마/데이터베이스)가 정확히 보존됨을 회귀 검증.
- 신규 `test_en_phrase_translations_have_no_duplicate_source_keys`: AST로 `_EN_PHRASE_TRANSLATIONS`에 중복 리터럴 키가 없음을 소스 레벨에서 검증.
- `test_translate_text_handles_common_hardcoded_ui_phrases`: 정리된 phrase(`항목`, `자동 커밋`, `사용 중`)의 casing 어서션 추가.
- `test_direct_hardcoded_qt_ui_strings_have_english_runtime_translation`: 정적 스캔 대상 `ui_methods`에서 `addItem`/`insertItem`/`addItems` 제외 (데이터 담김 API이므로 chrome 하드코딩 스캔에서 분리).

Rust Core DB 소유권 경계에는 영향 없음 — UI 텍스트 번역 훅과 i18n 테스트만 변경.

## 검증 결과

- `python -m py_compile src/core/i18n.py tests/test_i18n.py` — 통과
- `python -m pytest tests/test_i18n.py -q` — 9 passed
- `python -m pytest -q` (전체) — **1877 passed, 1 failed** (기준선 1876 passed + 신규 테스트 2개)
  - 실패 1건은 `tests/test_rust_core_packaging.py::test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`로, macOS/GitHub-CI 환경에 의존하는 로컬 Windows 환경 사전 known failure (본 변경과 무관, 무시 대상으로 확인됨).
- `git diff` 확인: `src/core/i18n.py`, `tests/test_i18n.py` 외 파일 변경 없음. `QComboBox.addItem/insertItem/addItems` monkey-patch 완전 제거 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)