### PR TITLE
fix(guard): production 확인 메시지 details append 순서 수정 (WP-1.6)

### DIFF
--- a/src/core/production_guard.py
+++ b/src/core/production_guard.py
@@ -328,12 +328,17 @@ class ProductionGuard:
 
         elif environment == Environment.STAGING:
             # Staging: Yes/No 확인 (기본값 No)
+            message = (
+                f"<b>{operation}</b> 작업을 실행하시겠습니까?<br><br>"
+                f"스키마: <b>{schema_name}</b><br><br>"
+            )
+            if details:
+                message += details
+
             reply = QMessageBox.warning(
                 self.parent,
                 f"🟠 STAGING 환경 - {operation}",
-                f"<b>{operation}</b> 작업을 실행하시겠습니까?<br><br>"
-                f"스키마: <b>{schema_name}</b><br><br>"
-                f"{details}" if details else "",
+                message,
                 QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
                 QMessageBox.StandardButton.No  # 기본값: No
             )

--- a/tests/test_production_guard.py
+++ b/tests/test_production_guard.py
@@ -1,0 +1,59 @@
+from PyQt6.QtWidgets import QMessageBox
+
+from src.core.production_guard import ProductionGuard
+
+
+def test_staging_confirmation_includes_operation_and_schema_when_details_empty(monkeypatch):
+    captured = {}
+
+    def fake_warning(parent, title, text, buttons, default_button):
+        captured["parent"] = parent
+        captured["title"] = title
+        captured["text"] = text
+        captured["buttons"] = buttons
+        captured["default_button"] = default_button
+        return QMessageBox.StandardButton.Yes
+
+    monkeypatch.setattr("src.core.production_guard.QMessageBox.warning", fake_warning)
+
+    guard = ProductionGuard(parent=None)
+
+    result = guard.confirm_dangerous_operation(
+        {"environment": "staging"},
+        "데이터 Import",
+        "prod_db",
+    )
+
+    assert result is True
+    assert captured["title"] == "🟠 STAGING 환경 - 데이터 Import"
+    assert "<b>데이터 Import</b> 작업을 실행하시겠습니까?" in captured["text"]
+    assert "스키마: <b>prod_db</b>" in captured["text"]
+    assert captured["text"] != ""
+    assert captured["buttons"] == (
+        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+    )
+    assert captured["default_button"] == QMessageBox.StandardButton.No
+
+
+def test_staging_confirmation_appends_details_when_present(monkeypatch):
+    captured = {}
+
+    def fake_warning(parent, title, text, buttons, default_button):
+        captured["text"] = text
+        return QMessageBox.StandardButton.No
+
+    monkeypatch.setattr("src.core.production_guard.QMessageBox.warning", fake_warning)
+
+    guard = ProductionGuard(parent=None)
+
+    result = guard.confirm_dangerous_operation(
+        {"environment": "staging"},
+        "데이터 Import",
+        "prod_db",
+        "<p>추가 상세</p>",
+    )
+
+    assert result is False
+    assert "<b>데이터 Import</b> 작업을 실행하시겠습니까?" in captured["text"]
+    assert "스키마: <b>prod_db</b>" in captured["text"]
+    assert captured["text"].endswith("<p>추가 상세</p>")


### PR DESCRIPTION
## Finding

`ProductionGuard.confirm_dangerous_operation`의 STAGING 분기에서 `QMessageBox.warning`에 전달되는 메시지 문자열이 다음과 같이 잘못 구성되어 있었습니다:

```python
f"<b>{operation}</b> 작업을 실행하시겠습니까?<br><br>"
f"스키마: <b>{schema_name}</b><br><br>"
f"{details}" if details else ""
```

Python 연산자 우선순위상 위 표현식은 `(전체 concatenated 문자열) if details else ""`로 파싱됩니다. 즉 `details`가 빈 문자열(기본값)이면 STAGING 확인 다이얼로그 본문 전체가 `""`가 되어 작업명/스키마명이 전혀 표시되지 않는 버그였습니다.

## 변경 요약

- `src/core/production_guard.py`: STAGING 분기에서 메시지를 로컬 변수(`message`)로 먼저 구성한 뒤, `details`가 존재할 때만 append하도록 수정. 작업명/스키마명은 항상 포함됩니다. title/버튼/기본값/PRODUCTION·DEVELOPMENT 분기/쿼리 감지 로직은 변경하지 않았습니다.
- `tests/test_production_guard.py` (신규): `QMessageBox.warning`을 monkeypatch하여 STAGING 확인 메시지를 캡처하는 회귀 테스트 2건 추가
  - `details=""`일 때도 작업명/스키마명이 포함되고 본문이 비어있지 않음을 검증
  - `details`가 있을 때 기존처럼 append됨을 검증

## 검증 결과

- `py_compile src/core/production_guard.py tests/test_production_guard.py` → OK
- `pytest tests/test_production_guard.py -q` (단독 실행) → `2 passed`
- `pytest -q` (전체 스위트) → `1877 passed, 1 failed`
  - 실패 1건은 `tests/test_rust_core_packaging.py::test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`로, macOS/GitHub Actions 워크플로 조회에 의존하는 로컬 환경 한정 알려진 플레이키 테스트입니다 (이 변경과 무관).

## 범위

`src/core/production_guard.py`, `tests/test_production_guard.py` 두 파일만 수정했습니다. 버전 bump 및 docs 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)