### PR TITLE
fix(worker): cross-engine helper stderr 동시 드레인 (WP-2.9)

### DIFF
--- a/src/ui/workers/cross_engine_migration_worker.py
+++ b/src/ui/workers/cross_engine_migration_worker.py
@@ -1,6 +1,9 @@
 """Worker for the Rust cross-engine migration helper."""
+import re
 import subprocess
-from typing import Any, Callable, Dict, Optional
+import threading
+from collections import deque
+from typing import Any, Callable, Deque, Dict, Optional
 
 from PyQt6.QtCore import QThread, pyqtSignal
 
@@ -10,6 +13,19 @@ from src.core.cross_engine_migration import (
     db_core_executable,
     parse_helper_event,
 )
+
+_STDERR_TAIL_LINES = 200
+_STDERR_LINE_CHARS = 4000
+# Best-effort scrub for connection-secret shaped substrings (password/token/etc.)
+# that the helper may echo into stderr on panic, since payloads carry DB credentials.
+_SECRET_PATTERN = re.compile(
+    r'(?i)(\b(?:password|passwd|pwd|secret|token|api_key|access_token|refresh_token)\b\s*"?\s*[:=]\s*"?)'
+    r'([^",}\s]+)'
+)
+
+
+def _redact_stderr_line(text: str) -> str:
+    return _SECRET_PATTERN.sub(lambda m: f"{m.group(1)}[REDACTED]", text)
 
 
 class CrossEngineMigrationWorker(QThread):
@@ -42,11 +58,47 @@ class CrossEngineMigrationWorker(QThread):
         self._process: Optional[subprocess.Popen] = None
         self._cancelled = False
         self._last_checkpoint: Optional[Dict[str, Any]] = None
+        self._stderr_tail: Deque[str] = deque(maxlen=_STDERR_TAIL_LINES)
+        self._stderr_lock = threading.Lock()
+        self._stderr_thread: Optional[threading.Thread] = None
 
     def cancel(self):
         self._cancelled = True
         if self._process and self._process.poll() is None:
             self._process.terminate()
+
+    def _start_stderr_drain(self) -> None:
+        """Drain stderr on a background thread so a chatty helper never fills
+        the OS pipe buffer and deadlocks the stdout read loop below."""
+        process = self._process
+        if process is None or process.stderr is None:
+            return
+
+        def _drain() -> None:
+            try:
+                while True:
+                    line = process.stderr.readline()
+                    if line == "":
+                        return
+                    text = _redact_stderr_line(line.rstrip())
+                    if not text:
+                        continue
+                    with self._stderr_lock:
+                        self._stderr_tail.append(text[-_STDERR_LINE_CHARS:])
+            except (ValueError, OSError):
+                return
+
+        thread = threading.Thread(target=_drain, daemon=True)
+        self._stderr_thread = thread
+        thread.start()
+
+    def _join_stderr_drain(self, timeout: float = 2.0) -> None:
+        if self._stderr_thread is not None:
+            self._stderr_thread.join(timeout=timeout)
+
+    def _stderr_tail_text(self) -> str:
+        with self._stderr_lock:
+            return "\n".join(self._stderr_tail)
 
     def run(self):
         final_payload = None
@@ -62,6 +114,7 @@ class CrossEngineMigrationWorker(QThread):
                 encoding="utf-8",
                 errors="replace",
             )
+            self._start_stderr_drain()
 
             request = build_helper_request(self.command, self.payload, self.request_id)
             assert self._process.stdin is not None
@@ -99,11 +152,10 @@ class CrossEngineMigrationWorker(QThread):
                     self.log_message.emit(line.rstrip())
 
             return_code = self._process.wait()
+            self._join_stderr_drain()
             if return_code != 0 and not self._cancelled:
-                stderr = ""
-                if self._process.stderr:
-                    stderr = self._process.stderr.read().strip()
                 success = False
+                stderr = self._stderr_tail_text()
                 final_payload = {"error": stderr or f"tunnelforge-core exited with {return_code}"}
                 self.failed.emit(final_payload["error"])
 
@@ -117,6 +169,7 @@ class CrossEngineMigrationWorker(QThread):
             final_payload = {"error": str(exc)}
             self.failed.emit(str(exc))
         finally:
+            self._join_stderr_drain()
             if self._cancelled:
                 success = False
                 final_payload = {"cancelled": True}

--- a/tests/test_cross_engine_migration_worker.py
+++ b/tests/test_cross_engine_migration_worker.py
@@ -1,4 +1,10 @@
 import io
+import subprocess
+import sys
+import threading
+
+import pytest
+from PyQt6.QtCore import Qt
 
 from src.ui.workers.cross_engine_migration_worker import CrossEngineMigrationWorker
 
@@ -84,3 +90,80 @@ def test_worker_run_emits_failure_on_error():
     worker.run()
 
     assert failures == ["boom"]
+
+
+def test_worker_run_reports_redacted_stderr_tail_on_failure():
+    process = FakeProcess(
+        ['{"event":"phase","phase":"preflight","message":"starting"}'],
+        return_code=1,
+        stderr='connection failed\npassword=supersecret\n"token": "abc123"\n',
+    )
+
+    worker = CrossEngineMigrationWorker(
+        "preflight",
+        {},
+        helper_path="fake-helper",
+        popen_factory=lambda *args, **kwargs: process,
+    )
+
+    failures = []
+    worker.failed.connect(failures.append)
+    worker.run()
+
+    assert failures, "expected a failure message built from the drained stderr tail"
+    message = failures[0]
+    assert "connection failed" in message
+    assert "supersecret" not in message
+    assert "abc123" not in message
+    assert "[REDACTED]" in message
+
+
+def test_worker_run_does_not_deadlock_on_large_stderr():
+    """Regression test for the pipe-buffer deadlock: a helper that writes more
+    than the OS pipe buffer to stderr before emitting its stdout result must
+    not hang the worker, because stderr is now drained concurrently."""
+    script = (
+        "import sys\n"
+        "sys.stderr.write('x' * 300000)\n"
+        "sys.stderr.write('\\npassword=supersecret\\n')\n"
+        "sys.stderr.flush()\n"
+        "print('{\"event\": \"result\", \"command\": \"preflight\", \"success\": true}')\n"
+    )
+
+    process_holder = {}
+
+    def factory(*args, **kwargs):
+        proc = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        process_holder["proc"] = proc
+        return proc
+
+    worker = CrossEngineMigrationWorker("preflight", {}, popen_factory=factory)
+
+    results = []
+    # run() executes on a plain background thread here (not via QThread.start()),
+    # so the default AutoConnection would queue onto an event loop that never runs
+    # in this test. Force DirectConnection so the slot runs synchronously instead.
+    worker.finished.connect(
+        lambda success, payload: results.append((success, payload)),
+        type=Qt.ConnectionType.DirectConnection,
+    )
+
+    thread = threading.Thread(target=worker.run, daemon=True)
+    thread.start()
+    thread.join(timeout=15)
+
+    if thread.is_alive():
+        proc = process_holder.get("proc")
+        if proc is not None:
+            proc.kill()
+        pytest.fail("worker.run() did not complete within timeout - stderr likely deadlocked")
+
+    assert results and results[0][0] is True


### PR DESCRIPTION
## 요약
- WP-2.9: `cross_engine_migration_worker.py`에서 `tunnelforge-core` 헬퍼가 stdout으로 결과를 내기 전에 stderr에 OS 파이프 버퍼 크기를 넘는 출력을 쓰면, 부모는 stdout 루프에서 블로킹, 자식은 stderr 쓰기에서 블로킹되어 서로 영원히 기다리는 데드락이 발생할 수 있었습니다.
- 백그라운드 스레드로 stderr를 동시에 드레인하도록 수정해 데드락 가능성을 제거하고, `process.stderr.read()` 블로킹 호출을 제거했습니다.
- 최종 실패 메시지(`failed` 시그널)는 드레인된 stderr tail(최대 200줄, 줄당 4000자)로 채우되, 헬퍼 요청 payload에 DB 자격증명(host/user/password 등)이 포함되어 있어 헬퍼 패닉 시 그대로 stderr에 노출될 수 있으므로 password/token 형태 문자열을 `[REDACTED]`로 마스킹한 뒤 보존합니다.
- 취소/예외 경로에서도 drain 스레드를 정리(join)하도록 했습니다.

## 변경 파일 (허용 목록만)
- `src/ui/workers/cross_engine_migration_worker.py`
- `tests/test_cross_engine_migration_worker.py`

## 테스트
- `test_worker_run_reports_redacted_stderr_tail_on_failure`: 실패 시 stderr tail이 최종 에러 메시지에 포함되되 password/token 값이 마스킹되는지 검증
- `test_worker_run_does_not_deadlock_on_large_stderr`: 실제 서브프로세스로 OS 파이프 버퍼(300KB)를 초과하는 stderr를 쓰게 한 뒤, 워커가 타임아웃 없이 정상 완료하는지 검증 (데드락 회귀 테스트)
- 기존 3개 테스트 모두 통과 유지

## 검증 결과
- `python -m py_compile` (2개 파일): 통과
- `pytest tests/test_cross_engine_migration_worker.py -q`: 5 passed
- `pytest -q` (전체): 1919 passed, 1 failed — 실패 1건은 `tests/test_rust_core_packaging.py::test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`로, GitHub Actions 환경에 의존하는 로컬 상시 실패 테스트(본 변경과 무관)

Round 1 변경사항은 되돌리지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)