### PR TITLE
fix(connector): facade 통합 + 스키마 전환 복원 + 메타 예외 로깅 (WP-2.10)

### DIFF
--- a/src/core/db_connector.py
+++ b/src/core/db_connector.py
@@ -7,7 +7,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from src.core.logger import get_logger
 from src.core.constants import SYSTEM_SCHEMAS
-from src.core.db_core_service import DbCoreFacade, DbEndpoint, RustDbConnection
+from src.core.db_core_service import (
+    RustDbConnection,
+    RustDbConnector,
+    get_shared_db_core_facade,
+    quote_mysql_ident,
+)
 
 logger = get_logger('db_connector')
 
@@ -87,7 +92,7 @@ class MySQLConnector:
     """
 
     def __init__(self, host: str, port: int, user: str, password: str,
-                 database: str = None, use_cache: bool = True):
+                 database: str = None, use_cache: bool = True, facade: Optional[Any] = None):
         """
         Args:
             host: MySQL 호스트
@@ -96,6 +101,7 @@ class MySQLConnector:
             password: MySQL 비밀번호
             database: 기본 데이터베이스
             use_cache: 메타데이터 캐싱 사용 여부 (기본 True)
+            facade: 주입할 Rust DB core facade (없으면 앱 공유 facade 사용)
         """
         self.host = host
         self.port = port
@@ -104,7 +110,12 @@ class MySQLConnector:
         self.database = database
         self.engine = "mysql"
         self.connection: Optional[RustDbConnection] = None
-        self._facade = DbCoreFacade()
+        self.facade = facade if facade is not None else get_shared_db_core_facade()
+        # 연결 프로토콜은 RustDbConnector에 위임 — 커넥터별 전용 서브프로세스를 띄우지 않는다.
+        self._delegate = RustDbConnector(
+            "mysql", host, port, user, password,
+            database=database, facade=self.facade,
+        )
 
         # 캐싱 설정
         self._use_cache = use_cache
@@ -113,20 +124,11 @@ class MySQLConnector:
 
     def connect(self) -> Tuple[bool, str]:
         """데이터베이스 연결"""
-        try:
-            endpoint = DbEndpoint(
-                engine="mysql",
-                host=self.host,
-                port=int(self.port),
-                user=self.user,
-                password=self.password,
-                database=self.database or "",
-            )
-            connection_id = self._facade.open_connection(endpoint)
-            self.connection = RustDbConnection(endpoint, self._facade, connection_id)
+        success, msg = self._delegate.connect()
+        if success:
+            self.connection = self._delegate.connection
             return True, "연결 성공"
-        except Exception as e:
-            return False, f"MySQL 오류: {str(e)}"
+        return False, f"MySQL 오류: {msg}"
 
     def disconnect(self):
         """연결 종료"""
@@ -137,6 +139,9 @@ class MySQLConnector:
                 pass
             finally:
                 self.connection = None
+        # delegate가 참조하던 연결 정보도 함께 정리 (재사용 시 잔여 상태 방지)
+        self._delegate.connection = None
+        self._delegate.connection_id = None
 
     def is_connected(self) -> bool:
         """연결 상태 확인"""
@@ -392,18 +397,25 @@ class MySQLConnector:
         tables = self.get_tables(schema)
         return table in tables
 
+    def _qualified_table_ref(self, table: str, schema: str = None) -> str:
+        """스키마 한정 테이블 참조 생성 (현재 세션의 DB를 전환하지 않음)"""
+        if schema:
+            return f"{quote_mysql_ident(schema)}.{quote_mysql_ident(table)}"
+        return quote_mysql_ident(table)
+
     def get_create_table_statement(self, table: str, schema: str = None) -> str:
-        """CREATE TABLE 문 조회"""
+        """CREATE TABLE 문 조회
+
+        schema가 지정되어도 세션의 현재 DB(self.database)는 전환하지 않고,
+        스키마 한정 식별자(`schema`.`table`)로 조회한다.
+        """
         if not self.connection:
             return ""
 
         try:
-            # 스키마가 지정되면 해당 스키마로 전환
-            if schema and schema != self.database:
-                self.connection.select_db(schema)
-
+            table_ref = self._qualified_table_ref(table, schema)
             with self.connection.cursor() as cursor:
-                cursor.execute(f"SHOW CREATE TABLE `{table}`")
+                cursor.execute(f"SHOW CREATE TABLE {table_ref}")
                 result = cursor.fetchone()
                 if result:
                     return result.get('Create Table', '')
@@ -413,22 +425,24 @@ class MySQLConnector:
             return ""
 
     def get_table_data(self, table: str, schema: str = None, limit: int = None) -> List[Dict[str, Any]]:
-        """테이블 데이터 조회"""
-        if schema and schema != self.database:
-            self.connection.select_db(schema)
+        """테이블 데이터 조회
 
-        query = f"SELECT * FROM `{table}`"
+        schema가 지정되어도 세션의 현재 DB(self.database)는 전환하지 않는다.
+        """
+        table_ref = self._qualified_table_ref(table, schema)
+        query = f"SELECT * FROM {table_ref}"
         if limit:
-            query += f" LIMIT {limit}"
+            query += f" LIMIT {int(limit)}"
 
         return self.execute(query)
 
     def get_row_count(self, table: str, schema: str = None) -> int:
-        """테이블 행 수 조회"""
-        if schema and schema != self.database:
-            self.connection.select_db(schema)
+        """테이블 행 수 조회
 
-        result = self.execute(f"SELECT COUNT(*) as cnt FROM `{table}`")
+        schema가 지정되어도 세션의 현재 DB(self.database)는 전환하지 않는다.
+        """
+        table_ref = self._qualified_table_ref(table, schema)
+        result = self.execute(f"SELECT COUNT(*) AS cnt FROM {table_ref}")
         if result:
             return result[0].get('cnt', 0)
         return 0

--- a/src/core/db_core_service.py
+++ b/src/core/db_core_service.py
@@ -9,9 +9,13 @@ from collections import deque
 from dataclasses import dataclass
 from typing import Any, Callable, Deque, Dict, List, Optional, Sequence, Tuple
 
+from src.core.constants import SYSTEM_SCHEMAS
 from src.core.cross_engine_migration import db_core_executable, parse_helper_event
+from src.core.logger import get_logger
 from src.core.platform_integration import no_window_creation_flags
 from src.core.sql_query_classifier import statement_returns_rows
+
+logger = get_logger("db_core_service")
 
 
 class DbCoreServiceError(RuntimeError):
@@ -466,9 +470,12 @@ class RustDbConnector:
             database=database or ("postgres" if engine == "postgresql" else ""),
             schema=schema,
         )
-        self.facade = facade or get_shared_db_core_facade()
+        self.facade = facade if facade is not None else get_shared_db_core_facade()
         self.connection_id: Optional[str] = None
         self.connection: Optional[RustDbConnection] = None
+
+    def _log_metadata_error(self, operation: str, exc: Exception) -> None:
+        logger.exception("%s 메타데이터 조회 실패: %s", operation, exc)
 
     def connect(self) -> Tuple[bool, str]:
         try:
@@ -501,7 +508,11 @@ class RustDbConnector:
                 else:
                     cursor.execute("SHOW DATABASES LIKE %s", (schema_name,))
                 return cursor.fetchone() is not None
-        except Exception:
+        except DbCoreServiceError as exc:
+            self._log_metadata_error("schema_exists", exc)
+            raise
+        except Exception as exc:
+            self._log_metadata_error("schema_exists", exc)
             return False
 
     def get_schemas(self, use_cache: bool = True) -> List[str]:
@@ -520,13 +531,16 @@ class RustDbConnector:
                     )
                     return [str(row.get("schema_name")) for row in cursor.fetchall()]
                 cursor.execute("SHOW DATABASES")
-                excluded = {"information_schema", "performance_schema", "mysql", "sys"}
                 return [
                     str(row.get("Database"))
                     for row in cursor.fetchall()
-                    if str(row.get("Database")) not in excluded
+                    if str(row.get("Database")) not in SYSTEM_SCHEMAS
                 ]
-        except Exception:
+        except DbCoreServiceError as exc:
+            self._log_metadata_error("get_schemas", exc)
+            raise
+        except Exception as exc:
+            self._log_metadata_error("get_schemas", exc)
             return []
 
     def get_tables(self, schema: Optional[str] = None, use_cache: bool = True) -> List[str]:
@@ -541,7 +555,14 @@ class RustDbConnector:
                 database=self.endpoint.database if self.endpoint.engine == "postgresql" else schema,
                 schema=schema if self.endpoint.engine == "postgresql" else "",
             )
-        return self.facade.list_tables(endpoint)
+        try:
+            return self.facade.list_tables(endpoint)
+        except DbCoreServiceError as exc:
+            self._log_metadata_error("get_tables", exc)
+            raise
+        except Exception as exc:
+            self._log_metadata_error("get_tables", exc)
+            return []
 
     def get_db_version(self) -> Tuple[int, int, int]:
         return parse_db_version_tuple(self.get_db_version_string())
@@ -556,7 +577,11 @@ class RustDbConnector:
                 cursor.execute("SELECT VERSION() AS version" if self.endpoint.engine == "mysql" else "SELECT version() AS version")
                 row = cursor.fetchone() or {}
                 return str(row.get("version", ""))
-        except Exception:
+        except DbCoreServiceError as exc:
+            self._log_metadata_error("get_db_version_string", exc)
+            raise
+        except Exception as exc:
+            self._log_metadata_error("get_db_version_string", exc)
             return ""
 
     def get_column_names(self, table: str, schema: Optional[str] = None) -> List[str]:
@@ -581,7 +606,11 @@ class RustDbConnector:
                         (schema or self.endpoint.database, table),
                     )
                 return [str(row.get("column_name")) for row in cursor.fetchall()]
-        except Exception:
+        except DbCoreServiceError as exc:
+            self._log_metadata_error("get_column_names", exc)
+            raise
+        except Exception as exc:
+            self._log_metadata_error("get_column_names", exc)
             return []
 
 

--- a/src/core/postgres_connector.py
+++ b/src/core/postgres_connector.py
@@ -1,20 +1,22 @@
 """PostgreSQL database connection helpers."""
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
-from src.core.db_core_service import DbCoreFacade, DbEndpoint, RustDbConnection
+from src.core.db_core_service import DbEndpoint, RustDbConnection, get_shared_db_core_facade
 
 
 class PostgresConnector:
     """Small PostgreSQL connector used for connection tests."""
 
-    def __init__(self, host: str, port: int, user: str, password: str, database: str = None):
+    def __init__(self, host: str, port: int, user: str, password: str, database: str = None,
+                 facade: Optional[Any] = None):
         self.host = host
         self.port = port
         self.user = user
         self.password = password
         self.database = database or "postgres"
         self.engine = "postgresql"
-        self.facade = DbCoreFacade()
+        # 앱 공유 facade 재사용 — 커넥터별 전용 Rust 서브프로세스를 띄우지 않는다.
+        self.facade = facade if facade is not None else get_shared_db_core_facade()
         self.connection = None
 
     def connect(self) -> Tuple[bool, str]:

--- a/tests/test_db_connector.py
+++ b/tests/test_db_connector.py
@@ -141,7 +141,7 @@ class TestMySQLConnector:
 
     def test_connect_success(self):
         """연결 성공 테스트"""
-        self.connector._facade = FakeFacade()
+        self.connector._delegate.facade = FakeFacade()
 
         success, msg = self.connector.connect()
 
@@ -151,7 +151,7 @@ class TestMySQLConnector:
 
     def test_connect_mysql_error(self):
         """MySQL 에러 발생 시 실패 반환"""
-        self.connector._facade = FakeFacade(Exception("Access denied"))
+        self.connector._delegate.facade = FakeFacade(Exception("Access denied"))
 
         success, msg = self.connector.connect()
 
@@ -160,7 +160,7 @@ class TestMySQLConnector:
 
     def test_connect_general_error(self):
         """일반 예외 발생 시 실패 반환"""
-        self.connector._facade = FakeFacade(Exception("Connection refused"))
+        self.connector._delegate.facade = FakeFacade(Exception("Connection refused"))
 
         success, msg = self.connector.connect()
 
@@ -351,7 +351,7 @@ class TestMySQLConnector:
 
     def test_context_manager_connects_and_disconnects(self):
         """컨텍스트 매니저 연결/해제 확인"""
-        self.connector._facade = FakeFacade()
+        self.connector._delegate.facade = FakeFacade()
 
         with self.connector:
             assert self.connector.connection is not None
@@ -423,3 +423,121 @@ class TestMySQLConnector:
         """테이블 미존재 확인"""
         self.connector.get_tables = MagicMock(return_value=['users', 'orders'])
         assert self.connector.table_exists('products') is False
+
+    def test_get_create_table_statement_uses_qualified_name_without_switching_database(self):
+        """CREATE TABLE 조회 시 스키마 한정 식별자만 사용하고 self.database는 유지"""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_cursor.fetchone.return_value = {'Create Table': 'CREATE TABLE `users` (id INT)'}
+        mock_conn.cursor.return_value = mock_cursor
+        self.connector.connection = mock_conn
+
+        ddl = self.connector.get_create_table_statement('users', schema='schema_b')
+
+        assert 'CREATE TABLE' in ddl
+        assert self.connector.database == 'test_db'
+        mock_conn.select_db.assert_not_called()
+        executed_sql = mock_cursor.execute.call_args[0][0]
+        assert '`schema_b`.`users`' in executed_sql
+
+    def test_get_table_data_uses_qualified_name_without_switching_database(self):
+        """테이블 데이터 조회 시 스키마 한정 식별자만 사용하고 self.database는 유지"""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_cursor.fetchall.return_value = [{'id': 1}]
+        mock_conn.cursor.return_value = mock_cursor
+        self.connector.connection = mock_conn
+
+        rows = self.connector.get_table_data('users', schema='schema_b', limit=10)
+
+        assert rows == [{'id': 1}]
+        assert self.connector.database == 'test_db'
+        mock_conn.select_db.assert_not_called()
+        executed_sql = mock_cursor.execute.call_args[0][0]
+        assert '`schema_b`.`users`' in executed_sql
+        assert 'LIMIT 10' in executed_sql
+
+    def test_get_row_count_uses_qualified_name_without_switching_database(self):
+        """행 수 조회 시 스키마 한정 식별자만 사용하고 self.database는 유지"""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_cursor.fetchall.return_value = [{'cnt': 5}]
+        mock_conn.cursor.return_value = mock_cursor
+        self.connector.connection = mock_conn
+
+        count = self.connector.get_row_count('users', schema='schema_b')
+
+        assert count == 5
+        assert self.connector.database == 'test_db'
+        mock_conn.select_db.assert_not_called()
+        executed_sql = mock_cursor.execute.call_args[0][0]
+        assert '`schema_b`.`users`' in executed_sql
+
+    def test_mysql_temporary_schema_methods_do_not_switch_database(self):
+        """세 메서드 모두 schema 지정 시에도 connector.database가 바뀌지 않음을 종합 확인"""
+        from src.core.db_connector import MySQLConnector
+        connector = MySQLConnector(
+            host='127.0.0.1', port=3306, user='u', password='p', database='schema_a'
+        )
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_cursor.fetchone.return_value = {'Create Table': 'CREATE TABLE `users` (id INT)'}
+        mock_cursor.fetchall.return_value = [{'cnt': 5}]
+        mock_conn.cursor.return_value = mock_cursor
+        connector.connection = mock_conn
+
+        connector.get_create_table_statement('users', schema='schema_b')
+        connector.get_table_data('users', schema='schema_b', limit=10)
+        connector.get_row_count('users', schema='schema_b')
+
+        assert connector.database == 'schema_a'
+        mock_conn.select_db.assert_not_called()
+
+
+# =====================================================================
+# Facade 주입/공유 테스트 (WP-2.10: connector-facade 통합)
+# =====================================================================
+
+class TestMySQLConnectorFacadeUnification:
+    """MySQLConnector가 커넥터별 전용 facade를 만들지 않고 공유 facade를 사용하는지 검증"""
+
+    def test_mysql_connector_uses_shared_facade_by_default(self):
+        """facade 미지정 시 앱 공유 facade를 사용하고, delegate에 그대로 주입됨을 확인"""
+        from src.core import db_connector
+
+        sentinel = object()
+        with patch.object(db_connector, 'get_shared_db_core_facade', return_value=sentinel) as mock_get_shared, \
+                patch.object(db_connector, 'RustDbConnector') as mock_rust_connector:
+            connector = db_connector.MySQLConnector(
+                host='127.0.0.1', port=3306, user='u', password='p', database='db'
+            )
+
+            mock_get_shared.assert_called_once()
+            assert connector.facade is sentinel
+            _, kwargs = mock_rust_connector.call_args
+            assert kwargs['facade'] is sentinel
+
+    def test_mysql_connector_uses_injected_facade_without_shared_lookup(self):
+        """facade를 주입하면 공유 facade 조회를 건너뛰고 delegate에 주입된 facade를 그대로 사용"""
+        from src.core import db_connector
+
+        sentinel = object()
+        with patch.object(db_connector, 'get_shared_db_core_facade') as mock_get_shared, \
+                patch.object(db_connector, 'RustDbConnector') as mock_rust_connector:
+            connector = db_connector.MySQLConnector(
+                host='127.0.0.1', port=3306, user='u', password='p', database='db',
+                facade=sentinel,
+            )
+
+            mock_get_shared.assert_not_called()
+            assert connector.facade is sentinel
+            _, kwargs = mock_rust_connector.call_args
+            assert kwargs['facade'] is sentinel

--- a/tests/test_db_core_service.py
+++ b/tests/test_db_core_service.py
@@ -3,6 +3,8 @@ import json
 import threading
 import time
 
+import pytest
+
 import src.core.db_core_service as db_core_service
 from src.core.db_core_service import (
     DbCoreFacade,
@@ -663,3 +665,157 @@ def test_shutdown_and_concurrent_request_are_serialized_by_lock():
     assert results["value"]["success"] is True
     assert client._process is second_process
     assert len(popen_calls) == 2
+
+
+# =====================================================================
+# RustDbConnector: 공유 facade / SYSTEM_SCHEMAS / 메타데이터 예외 처리
+# (WP-2.10: connector-facade 통합)
+# =====================================================================
+
+def test_rust_connector_uses_shared_facade_by_default(monkeypatch):
+    """facade 미지정 시 앱 공유 facade를 사용해야 한다 (커넥터별 전용 프로세스 금지)."""
+    sentinel = object()
+    monkeypatch.setattr(db_core_service, "get_shared_db_core_facade", lambda: sentinel)
+
+    connector = RustDbConnector("mysql", "127.0.0.1", 3306, "root", "pw", "app")
+
+    assert connector.facade is sentinel
+
+
+def test_rust_connector_uses_injected_facade_without_shared_lookup(monkeypatch):
+    """facade가 주입되면 공유 facade 조회를 건너뛴다."""
+    called = []
+    monkeypatch.setattr(
+        db_core_service, "get_shared_db_core_facade",
+        lambda: called.append(True) or object(),
+    )
+    sentinel = object()
+
+    connector = RustDbConnector("mysql", "127.0.0.1", 3306, "root", "pw", "app", facade=sentinel)
+
+    assert connector.facade is sentinel
+    assert called == []
+
+
+def test_rust_connector_uses_constants_for_system_schema_filtering(monkeypatch):
+    """MySQL 스키마 필터링은 하드코딩이 아닌 SYSTEM_SCHEMAS 상수를 사용해야 한다."""
+    monkeypatch.setattr(db_core_service, "SYSTEM_SCHEMAS", frozenset({"mysql", "ndbinfo"}))
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def execute(self, *a, **k):
+            pass
+
+        def fetchall(self):
+            return [{"Database": "app"}, {"Database": "mysql"}, {"Database": "ndbinfo"}]
+
+    class FakeConnection:
+        def cursor(self):
+            return FakeCursor()
+
+    connector = RustDbConnector("mysql", "127.0.0.1", 3306, "root", "pw", "app", facade=object())
+    connector.connection = FakeConnection()
+
+    assert connector.get_schemas() == ["app"]
+
+
+class _FailingCursor:
+    """execute 호출 시 지정된 예외를 던지는 cursor 스텁."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def execute(self, *a, **k):
+        raise self._exc
+
+
+class _FailingConnection:
+    def __init__(self, exc):
+        self._exc = exc
+
+    def cursor(self):
+        return _FailingCursor(self._exc)
+
+
+def test_get_schemas_propagates_and_logs_db_core_service_error(caplog):
+    connector = RustDbConnector("mysql", "127.0.0.1", 3306, "root", "pw", "app", facade=object())
+    connector.connection = _FailingConnection(DbCoreServiceError("Access denied"))
+
+    caplog.set_level("ERROR")
+    with pytest.raises(DbCoreServiceError):
+        connector.get_schemas()
+
+    assert "get_schemas" in caplog.text
+    assert "Access denied" in caplog.text
+
+
+def test_schema_exists_propagates_and_logs_db_core_service_error(caplog):
+    connector = RustDbConnector("mysql", "127.0.0.1", 3306, "root", "pw", "app", facade=object())
+    connector.connection = _FailingConnection(DbCoreServiceError("Access denied"))
+
+    caplog.set_level("ERROR")
+    with pytest.raises(DbCoreServiceError):
+        connector.schema_exists("app")
+
+    assert "schema_exists" in caplog.text
+    assert "Access denied" in caplog.text
+
+
+def test_get_tables_propagates_and_logs_db_core_service_error(caplog):
+    class FailingFacade:
+        def list_tables(self, endpoint):
+            raise DbCoreServiceError("Access denied")
+
+    connector = RustDbConnector("mysql", "127.0.0.1", 3306, "root", "pw", "app", facade=FailingFacade())
+
+    caplog.set_level("ERROR")
+    with pytest.raises(DbCoreServiceError):
+        connector.get_tables()
+
+    assert "get_tables" in caplog.text
+    assert "Access denied" in caplog.text
+
+
+def test_get_db_version_string_propagates_and_logs_db_core_service_error(caplog):
+    connector = RustDbConnector("mysql", "127.0.0.1", 3306, "root", "pw", "app", facade=object())
+    connector.connection = _FailingConnection(DbCoreServiceError("Access denied"))
+
+    caplog.set_level("ERROR")
+    with pytest.raises(DbCoreServiceError):
+        connector.get_db_version_string()
+
+    assert "get_db_version_string" in caplog.text
+    assert "Access denied" in caplog.text
+
+
+def test_get_column_names_propagates_and_logs_db_core_service_error(caplog):
+    connector = RustDbConnector("mysql", "127.0.0.1", 3306, "root", "pw", "app", facade=object())
+    connector.connection = _FailingConnection(DbCoreServiceError("Access denied"))
+
+    caplog.set_level("ERROR")
+    with pytest.raises(DbCoreServiceError):
+        connector.get_column_names("users")
+
+    assert "get_column_names" in caplog.text
+    assert "Access denied" in caplog.text
+
+
+def test_get_schemas_generic_exception_is_logged_and_returns_empty_default():
+    """facade 예외가 아닌 일반 예외는 기존 계약대로 빈 기본값을 반환한다 (호환성 유지)."""
+    connector = RustDbConnector("mysql", "127.0.0.1", 3306, "root", "pw", "app", facade=object())
+    connector.connection = _FailingConnection(RuntimeError("boom"))
+
+    result = connector.get_schemas()
+
+    assert result == []


### PR DESCRIPTION
## 요약

- `MySQLConnector`/`PostgresConnector`/`RustDbConnector`가 커넥터 인스턴스마다 `DbCoreFacade()`를 직접 생성해 전용 Rust core 서브프로세스를 띄우던 문제를 `get_shared_db_core_facade()` 공유로 통일 (facade 주입도 지원).
- `MySQLConnector`는 연결 프로토콜(connect/disconnect)을 `RustDbConnector` 위임(`self._delegate`)으로 처리.
- `get_create_table_statement`/`get_table_data`/`get_row_count`가 `schema` 인자를 받으면 `select_db`로 세션 DB를 영구 전환해 `self.database`와 실제 세션 상태가 어긋나던 버그를 스키마 한정 식별자(`` `schema`.`table` ``, `quote_mysql_ident` 사용)로 수정.
- `RustDbConnector`의 메타데이터 조회 메서드(`get_schemas`/`schema_exists`/`get_tables`/`get_db_version_string`/`get_column_names`)가 `DbCoreServiceError`(인증/터널 실패 등)를 포함한 모든 예외를 조용히 빈 결과로 삼키던 문제를 로깅 후 재발생하도록 수정.
- `get_schemas`의 하드코딩된 시스템 스키마 집합을 `SYSTEM_SCHEMAS` 상수로 교체.

## 스코프 결정 (BLOCKER / 의도적 축소)

- **BLOCKER**: `src/core/connection_pool.py:57`의 `ConnectionPool.__init__`도 `self._facade = DbCoreFacade()`를 직접 생성한다 (동일한 전용 서브프로세스 문제). 이 파일은 이번 WP의 허용 파일 목록 밖이라 수정하지 않았다. 별도 WP/후속 작업 필요.
- `MySQLConnector`의 `get_schemas`/`schema_exists`/`get_tables`/`get_db_version*`/`get_column_names`/`is_connected`/`use_database`/`get_table_columns`는 기존에도 `self.connection`(Rust facade 기반 `RustDbConnection`)을 통해 이미 올바르게 동작하고 있어 별도 버그가 없었고, `RustDbConnector`로 완전 위임 시 기존 mock 기반 테스트(raw `connection` 객체를 직접 주입하는 패턴)를 광범위하게 재작성해야 하는 리스크 대비 실익이 낮다고 판단해 **의도적으로 위임하지 않고 현행 유지**했다. 실질적 버그가 있던 3가지(전용 facade 생성, 스키마 상태 오염, 메타 예외 삼킴)에 수정을 집중했다.
- `PostgresConnector.schema_exists`가 `RustDbConnector`와 SQL이 일부 중복되지만 로직이 짧고 드리프트 위험이 낮아 그대로 두었다 (DRY: 실질적 유지보수 문제를 일으킬 때만 지적).

## 테스트

- `pytest tests/test_db_connector.py tests/test_db_core_service.py -q` → 79 passed
- `pytest -q` (전체) → 1932 passed, 1 failed (`test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge` — 로컬 환경에서 GitHub Actions 상태에 의존해 항상 실패하는 것으로 프로젝트에 문서화된 기존 실패, 이번 변경과 무관)

## Test plan

- [x] `py_compile` 5개 대상 파일
- [x] 대상 테스트 단독 통과 (Round 1 관련 테스트 포함, green 유지)
- [x] 전체 테스트 스위트 회귀 확인 (기존 macOS 1건 제외 전부 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)