### PR TITLE
fix(sql-validator): 스키마별 캐시 + CTE/alias 인식 (WP-2.11)

### DIFF
--- a/src/core/sql_validator.py
+++ b/src/core/sql_validator.py
@@ -5,10 +5,229 @@ SQL 구문 Validator
 - 정규식 기반 파싱 (의존성 없음)
 """
 import re
+import threading
 from enum import Enum
 from dataclasses import dataclass, field
 from typing import List, Dict, Set, Optional, Tuple
 from difflib import get_close_matches
+
+
+# 별칭/CTE 파싱에서 공통으로 사용하는 예약어 스킵 목록
+ALIAS_STOP_WORDS = {
+    'WHERE', 'ON', 'AND', 'OR', 'SET', 'VALUES',
+    'LEFT', 'RIGHT', 'INNER', 'OUTER', 'CROSS', 'FULL',
+    'JOIN', 'ORDER', 'GROUP', 'HAVING', 'LIMIT', 'OFFSET',
+    'UNION', 'ALL', 'SELECT', 'FROM', 'BY', 'AS',
+}
+
+
+def _schema_key(schema: Optional[str]) -> Optional[str]:
+    """스키마명을 캐시 키로 정규화 (None/빈 문자열/공백만 있으면 None)"""
+    if schema is None:
+        return None
+    stripped = schema.strip()
+    return stripped or None
+
+
+def _normalize_identifier(identifier: str) -> str:
+    """식별자를 감싸는 백틱 한 겹 제거 (없으면 그대로 반환)"""
+    if len(identifier) >= 2 and identifier[0] == '`' and identifier[-1] == '`':
+        return identifier[1:-1]
+    return identifier
+
+
+def _read_identifier(sql: str, pos: int) -> Tuple[Optional[str], int]:
+    """pos 위치(앞쪽 공백 허용)부터 식별자 하나를 읽는다.
+
+    백틱 식별자(`name`)와 일반 \\w+ 식별자를 모두 지원한다.
+
+    Returns:
+        (식별자, 다음 위치) 또는 식별자를 읽지 못하면 (None, pos)
+    """
+    length = len(sql)
+    i = pos
+    while i < length and sql[i].isspace():
+        i += 1
+
+    if i >= length:
+        return None, pos
+
+    if sql[i] == '`':
+        end = sql.find('`', i + 1)
+        if end == -1:
+            return None, pos
+        return sql[i + 1:end], end + 1
+
+    match = re.match(r'\w+', sql[i:])
+    if not match:
+        return None, pos
+    return match.group(0), i + match.end()
+
+
+def _skip_balanced_parentheses(sql: str, open_pos: int) -> int:
+    """open_pos가 가리키는 '('과 짝이 맞는 ')' 바로 다음 위치를 반환한다.
+
+    문자열 리터럴(작은따옴표/큰따옴표) 내부의 괄호는 무시하며,
+    이스케이프 처리는 `_find_string_regions`와 동일하게 따옴표 2개 연속을 이스케이프로 본다.
+    짝이 맞지 않으면 len(sql)을 반환한다.
+    """
+    length = len(sql)
+    if open_pos >= length or sql[open_pos] != '(':
+        return open_pos
+
+    depth = 0
+    in_string = False
+    string_char = None
+    i = open_pos
+
+    while i < length:
+        char = sql[i]
+
+        if in_string:
+            if char == string_char:
+                if i + 1 < length and sql[i + 1] == string_char:
+                    i += 1  # 이스케이프된 따옴표 스킵
+                else:
+                    in_string = False
+                    string_char = None
+        else:
+            if char in ("'", '"'):
+                in_string = True
+                string_char = char
+            elif char == '(':
+                depth += 1
+            elif char == ')':
+                depth -= 1
+                if depth == 0:
+                    return i + 1
+
+        i += 1
+
+    return length
+
+
+def extract_cte_names(sql: str) -> Set[str]:
+    """WITH 절에 정의된 CTE 이름 목록 추출 (테이블 존재 검증 제외용)
+
+    지원 형태:
+        WITH cte AS (...) SELECT * FROM cte
+        WITH a AS (...), b AS (...) SELECT * FROM b
+        WITH RECURSIVE cte AS (...) SELECT * FROM cte
+        WITH `cte` AS (...) SELECT * FROM `cte`
+    """
+    names: Set[str] = set()
+
+    with_match = re.search(r'\bWITH\b', sql, re.IGNORECASE)
+    if not with_match:
+        return names
+
+    length = len(sql)
+    pos = with_match.end()
+
+    recursive_match = re.match(r'\s+RECURSIVE\b', sql[pos:], re.IGNORECASE)
+    if recursive_match:
+        pos += recursive_match.end()
+
+    while True:
+        name, pos = _read_identifier(sql, pos)
+        if not name:
+            break
+        names.add(_normalize_identifier(name).lower())
+
+        while pos < length and sql[pos].isspace():
+            pos += 1
+
+        # 선택적 컬럼 목록: cte(col1, col2)
+        if pos < length and sql[pos] == '(':
+            pos = _skip_balanced_parentheses(sql, pos)
+            while pos < length and sql[pos].isspace():
+                pos += 1
+
+        as_match = re.match(r'AS\b', sql[pos:], re.IGNORECASE)
+        if not as_match:
+            break
+        pos += as_match.end()
+
+        while pos < length and sql[pos].isspace():
+            pos += 1
+
+        if pos >= length or sql[pos] != '(':
+            break
+        pos = _skip_balanced_parentheses(sql, pos)
+
+        while pos < length and sql[pos].isspace():
+            pos += 1
+
+        if pos < length and sql[pos] == ',':
+            pos += 1
+            continue
+        break
+
+    return names
+
+
+def extract_derived_table_aliases(sql: str) -> Set[str]:
+    """FROM (...) AS alias / JOIN (...) AS alias 형태의 파생 테이블 별칭 추출
+
+    파생 테이블 별칭은 실제 테이블이 아니므로, 테이블 존재 검증에서 제외하기 위한
+    스킵 목록으로만 사용한다 (메타데이터 조회용이 아님).
+    """
+    aliases: Set[str] = set()
+    length = len(sql)
+
+    for match in re.finditer(r'\b(?:FROM|JOIN)\s*\(', sql, re.IGNORECASE):
+        open_pos = match.end() - 1
+        pos = _skip_balanced_parentheses(sql, open_pos)
+
+        while pos < length and sql[pos].isspace():
+            pos += 1
+
+        as_match = re.match(r'AS\b', sql[pos:], re.IGNORECASE)
+        if as_match:
+            pos += as_match.end()
+
+        alias, _ = _read_identifier(sql, pos)
+        if not alias:
+            continue
+
+        normalized = _normalize_identifier(alias)
+        if normalized.upper() not in ALIAS_STOP_WORDS:
+            aliases.add(normalized.lower())
+
+    return aliases
+
+
+def extract_table_aliases(sql: str, metadata: 'SchemaMetadata') -> Dict[str, str]:
+    """FROM/JOIN 절의 실제 테이블 참조에서 별칭(별칭 → 테이블명) 추출
+
+    CTE 이름과 파생 테이블(서브쿼리)은 실제 테이블이 아니므로 별칭 매핑에서 제외한다.
+    Validator와 AutoCompleter가 공용으로 사용하는 단일 파서다.
+    """
+    aliases: Dict[str, str] = {}
+    cte_names = extract_cte_names(sql)
+
+    # FROM/JOIN 뒤가 '('인 경우(파생 테이블)는 이 패턴에서 제외
+    pattern = r'\b(?:FROM|JOIN)\s+(?!\()(?:`?(\w+)`?\.)?`?(\w+)`?(?:\s+(?:AS\s+)?`?(\w+)`?)?'
+
+    for match in re.finditer(pattern, sql, re.IGNORECASE):
+        table = match.group(2)
+        alias = match.group(3)
+
+        # CTE 이름이면서 실제 메타데이터 테이블이 아니면 별칭 소스로 사용하지 않음
+        if table.lower() in cte_names and not metadata.has_table(table):
+            continue
+
+        if alias and alias.upper() in ALIAS_STOP_WORDS:
+            alias = None
+
+        if alias:
+            aliases[alias.lower()] = table
+
+    # 테이블 자체도 추가 (self-reference)
+    for real_table in metadata.tables:
+        aliases[real_table.lower()] = real_table
+
+    return aliases
 
 
 class IssueSeverity(Enum):
@@ -84,49 +303,87 @@ class SchemaMetadata:
 
 
 class SchemaMetadataProvider:
-    """스키마 메타데이터 제공자 (캐싱)"""
+    """스키마 메타데이터 제공자 (스키마별 인메모리 캐시)
+
+    Python 쪽에서는 동기 DB 조회를 하지 않는다. 메타데이터는 반드시
+    `set_metadata()` (또는 호환용 `_metadata` 직접 대입)로 채워져야 하며,
+    캐시 미스 시에는 커넥터를 호출하지 않고 빈 SchemaMetadata를 반환한다.
+    이는 ValidationWorker가 MetadataLoadWorker와 같은 커넥터를 두고
+    경쟁(race)하는 것을 방지하기 위함이다.
+    """
 
     def __init__(self):
-        self._metadata: Optional[SchemaMetadata] = None
+        self._metadata_by_schema: Dict[Optional[str], SchemaMetadata] = {}
+        self._active_schema_key: Optional[str] = None
         self._connector = None
+        self._lock = threading.RLock()
+
+    @property
+    def _metadata(self) -> Optional[SchemaMetadata]:
+        """호환용 속성 (UI 등 외부에서 `_metadata`를 직접 읽는 경우 대응)"""
+        with self._lock:
+            if self._active_schema_key in self._metadata_by_schema:
+                return self._metadata_by_schema[self._active_schema_key]
+            return self._metadata_by_schema.get(None)
+
+    @_metadata.setter
+    def _metadata(self, value: Optional[SchemaMetadata]):
+        """호환용 속성 (UI 등 외부에서 `_metadata`를 직접 대입하는 경우 대응)
+
+        `set_connector(connector)` 직후 활성 스키마(`connector.database`)에
+        매핑해 저장한다. 신규 코드는 `set_metadata(schema, metadata)`를 사용할 것.
+        """
+        with self._lock:
+            if value is None:
+                if self._active_schema_key is not None:
+                    self._metadata_by_schema.pop(self._active_schema_key, None)
+                else:
+                    self._metadata_by_schema.clear()
+                return
+            self._metadata_by_schema[self._active_schema_key] = value
 
     def set_connector(self, connector):
-        """DB 커넥터 설정"""
-        self._connector = connector
-        self._metadata = None  # 캐시 무효화
+        """DB 커넥터 설정
+
+        커넥터가 바뀌면 이전 캐시가 다른 연결의 것일 수 있으므로 무효화한다.
+        여기서는 DB에 동기 조회를 하지 않는다.
+        """
+        with self._lock:
+            self._connector = connector
+            self._active_schema_key = _schema_key(getattr(connector, "database", None))
+            self._metadata_by_schema.clear()
+
+    def set_metadata(self, schema: str, metadata: SchemaMetadata):
+        """스키마에 대한 메타데이터를 캐시에 저장 (백그라운드 로드 완료 후 호출)"""
+        if metadata is None:
+            raise ValueError("metadata는 None일 수 없습니다")
+
+        key = _schema_key(schema)
+        with self._lock:
+            self._metadata_by_schema[key] = metadata
+            self._active_schema_key = key
 
     def get_metadata(self, schema: str = None) -> SchemaMetadata:
-        """메타데이터 조회 (캐싱)"""
-        if self._metadata:
-            return self._metadata
-
-        if not self._connector:
+        """메타데이터 조회 (캐시 히트만 반환, 캐시 미스 시 커넥터 조회하지 않음)"""
+        key = _schema_key(schema)
+        with self._lock:
+            if key in self._metadata_by_schema:
+                return self._metadata_by_schema[key]
+            if key is None and None in self._metadata_by_schema:
+                return self._metadata_by_schema[None]
             return SchemaMetadata()
 
-        metadata = SchemaMetadata()
+    def invalidate(self, schema: str = None):
+        """캐시 무효화
 
-        try:
-            # DB 버전
-            metadata.db_version = self._connector.get_db_version()
-
-            # 테이블 목록
-            tables = self._connector.get_tables(schema)
-            metadata.tables = set(tables)
-
-            # 각 테이블의 컬럼 정보
-            for table in tables:
-                columns = self._connector.get_column_names(table, schema)
-                metadata.columns[table] = set(columns)
-
-        except Exception as e:
-            print(f"메타데이터 조회 오류: {e}")
-
-        self._metadata = metadata
-        return metadata
-
-    def invalidate(self):
-        """캐시 무효화"""
-        self._metadata = None
+        Args:
+            schema: 지정하면 해당 스키마만 무효화, None이면 전체 무효화
+        """
+        with self._lock:
+            if schema is None:
+                self._metadata_by_schema.clear()
+            else:
+                self._metadata_by_schema.pop(_schema_key(schema), None)
 
 
 class SQLValidator:
@@ -234,6 +491,9 @@ class SQLValidator:
         comment_regions = self._find_comment_regions(sql)
         excluded_regions = string_regions + comment_regions
 
+        # CTE 이름 / 파생 테이블(서브쿼리) 별칭은 실제 테이블이 아니므로 존재 검증에서 제외
+        virtual_tables = extract_cte_names(sql) | extract_derived_table_aliases(sql)
+
         # 이미 검증한 위치 추적 (중복 방지)
         validated_positions = set()
 
@@ -266,6 +526,10 @@ class SQLValidator:
                 if self._is_in_regions(table_start, excluded_regions):
                     continue
 
+                # CTE/파생 테이블 별칭이면 존재하지 않는 테이블로 오탐하지 않도록 스킵
+                if table_name.lower() in virtual_tables:
+                    continue
+
                 # 테이블 존재 여부 확인
                 if not metadata.has_table(table_name):
                     line, col = self._offset_to_line_col(table_start, line_offsets)
@@ -290,8 +554,8 @@ class SQLValidator:
         # 문자열 리터럴 영역
         string_regions = self._find_string_regions(sql)
 
-        # FROM 절에서 테이블/별칭 매핑 추출
-        table_aliases = self._extract_table_aliases(sql, metadata)
+        # FROM 절에서 테이블/별칭 매핑 추출 (Validator/AutoCompleter 공용 파서)
+        table_aliases = extract_table_aliases(sql, metadata)
 
         # table.column 패턴 검증
         column_pattern = r'`?(\w+)`?\s*\.\s*`?(\w+)`?'
@@ -432,30 +696,6 @@ class SQLValidator:
                 return True
         return False
 
-    def _extract_table_aliases(self, sql: str, metadata: SchemaMetadata) -> Dict[str, str]:
-        """테이블 별칭 추출 (별칭 → 테이블명)"""
-        aliases = {}
-
-        # FROM table AS alias / FROM table alias
-        pattern = r'\b(?:FROM|JOIN)\s+(?:`?(\w+)`?\.)?`?(\w+)`?\s+(?:AS\s+)?`?(\w+)`?'
-
-        for match in re.finditer(pattern, sql, re.IGNORECASE):
-            # schema = match.group(1)
-            table = match.group(2)
-            alias = match.group(3)
-
-            # alias가 키워드가 아닌지 확인
-            if alias and alias.upper() not in {'WHERE', 'ON', 'AND', 'OR', 'SET', 'VALUES',
-                                                 'LEFT', 'RIGHT', 'INNER', 'OUTER', 'CROSS',
-                                                 'JOIN', 'ORDER', 'GROUP', 'HAVING', 'LIMIT'}:
-                aliases[alias.lower()] = table
-
-        # 테이블 자체도 추가 (self-reference)
-        for table in metadata.tables:
-            aliases[table.lower()] = table
-
-        return aliases
-
 
 class SQLAutoCompleter:
     """SQL 자동완성 제공자"""
@@ -518,11 +758,10 @@ class SQLAutoCompleter:
             target_table = context.get('table')
 
             if target_table:
-                # 특정 테이블의 컬럼
-                real_table = metadata.get_table_name(target_table)
-                if not real_table:
-                    aliases = self._extract_table_aliases(sql, metadata)
-                    real_table = aliases.get(target_table.lower())
+                # 특정 테이블의 컬럼 (별칭 → 실제 테이블명 변환은 조회 전에 수행)
+                aliases = extract_table_aliases(sql, metadata)
+                resolved_table = aliases.get(target_table.lower(), target_table)
+                real_table = metadata.get_table_name(resolved_table)
                 if real_table and real_table in metadata.columns:
                     for col in sorted(metadata.columns[real_table]):
                         if self._matches_prefix(col, prefix):
@@ -613,34 +852,17 @@ class SQLAutoCompleter:
         return item.lower().startswith(prefix.lower())
 
     def _extract_from_tables(self, sql: str, metadata: SchemaMetadata) -> List[str]:
-        """FROM 절에서 테이블 추출"""
+        """FROM 절에서 테이블 추출 (CTE 이름 / 파생 테이블 별칭은 제외)"""
         tables = []
+        virtual_tables = extract_cte_names(sql) | extract_derived_table_aliases(sql)
         pattern = r'\b(?:FROM|JOIN)\s+(?:`?(\w+)`?\.)?`?(\w+)`?'
 
         for match in re.finditer(pattern, sql, re.IGNORECASE):
             table = match.group(2)
+            if table.lower() in virtual_tables:
+                continue
             real_table = metadata.get_table_name(table)
             if real_table and real_table not in tables:
                 tables.append(real_table)
 
         return tables
-
-    def _extract_table_aliases(self, sql: str, metadata: SchemaMetadata) -> Dict[str, str]:
-        """테이블 별칭 추출 (별칭 → 테이블명)."""
-        aliases = {}
-        pattern = r'\b(?:FROM|JOIN)\s+(?:`?(\w+)`?\.)?`?(\w+)`?\s+(?:AS\s+)?`?(\w+)`?'
-        keywords = {
-            'WHERE', 'ON', 'AND', 'OR', 'SET', 'VALUES',
-            'LEFT', 'RIGHT', 'INNER', 'OUTER', 'CROSS',
-            'JOIN', 'ORDER', 'GROUP', 'HAVING', 'LIMIT',
-        }
-
-        for match in re.finditer(pattern, sql, re.IGNORECASE):
-            table = match.group(2)
-            alias = match.group(3)
-            if alias and alias.upper() not in keywords:
-                aliases[alias.lower()] = table
-
-        for table in metadata.tables:
-            aliases[table.lower()] = table
-        return aliases

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from src.core.sql_validator import (
     SchemaMetadata, SchemaMetadataProvider, SQLValidator, SQLAutoCompleter,
-    ValidationIssue, IssueSeverity
+    ValidationIssue, IssueSeverity, extract_table_aliases
 )
 
 
@@ -134,6 +134,84 @@ class TestSchemaMetadata(unittest.TestCase):
         self.assertEqual(len(suggestions), 0)
 
 
+class TestSchemaMetadataProvider(unittest.TestCase):
+    """SchemaMetadataProvider 캐시 동작 테스트 (스키마별 캐시, 동기 DB 조회 없음)"""
+
+    def _make_metadata(self, tables):
+        metadata = SchemaMetadata()
+        metadata.tables = set(tables)
+        return metadata
+
+    def test_metadata_cache_is_schema_scoped(self):
+        """[SUCCESS] 스키마별로 독립된 캐시를 가진다 (스키마 전환 시 오염되지 않음)"""
+        provider = SchemaMetadataProvider()
+        db1_metadata = self._make_metadata({'users'})
+        db2_metadata = self._make_metadata({'customers'})
+
+        provider.set_metadata("db1", db1_metadata)
+        provider.set_metadata("db2", db2_metadata)
+
+        self.assertTrue(provider.get_metadata("db1").has_table("users"))
+        self.assertFalse(provider.get_metadata("db1").has_table("customers"))
+        self.assertTrue(provider.get_metadata("db2").has_table("customers"))
+        self.assertFalse(provider.get_metadata("db2").has_table("users"))
+
+    def test_unknown_schema_returns_empty_metadata_not_previous_schema(self):
+        """[FAIL] 캐시에 없는 스키마 조회 시 이전 스키마가 아닌 빈 메타데이터 반환"""
+        provider = SchemaMetadataProvider()
+        provider.set_metadata("db1", self._make_metadata({'users'}))
+
+        result = provider.get_metadata("db2")
+        self.assertEqual(result.tables, set())
+
+    def test_invalidate_specific_schema(self):
+        """[SUCCESS] 특정 스키마만 무효화, 다른 스키마 캐시는 유지"""
+        provider = SchemaMetadataProvider()
+        provider.set_metadata("db1", self._make_metadata({'users'}))
+        provider.set_metadata("db2", self._make_metadata({'customers'}))
+
+        provider.invalidate("db1")
+
+        self.assertEqual(provider.get_metadata("db1").tables, set())
+        self.assertTrue(provider.get_metadata("db2").has_table("customers"))
+
+    def test_get_metadata_does_not_query_connector_on_cache_miss(self):
+        """[SUCCESS] 캐시 미스여도 커넥터에 동기 DB 조회를 하지 않는다"""
+
+        class FakeConnector:
+            database = "db1"
+
+            def get_db_version(self):
+                raise AssertionError("get_db_version이 호출되면 안 됨 (동기 DB 조회 금지)")
+
+            def get_tables(self, schema=None):
+                raise AssertionError("get_tables가 호출되면 안 됨 (동기 DB 조회 금지)")
+
+            def get_column_names(self, table, schema=None):
+                raise AssertionError("get_column_names가 호출되면 안 됨 (동기 DB 조회 금지)")
+
+        provider = SchemaMetadataProvider()
+        provider.set_connector(FakeConnector())
+
+        result = provider.get_metadata("db1")
+        self.assertEqual(result.tables, set())
+
+    def test_legacy_metadata_assignment_uses_active_connector_schema(self):
+        """[SUCCESS] 호환용 `_metadata` 직접 대입은 활성 커넥터의 스키마에 매핑된다"""
+
+        class FakeConnector:
+            database = "db1"
+
+        provider = SchemaMetadataProvider()
+        provider.set_connector(FakeConnector())
+
+        db1_metadata = self._make_metadata({'users'})
+        provider._metadata = db1_metadata  # 레거시 UI 호환 경로 (out-of-scope UI 파일이 사용)
+
+        self.assertIs(provider.get_metadata("db1"), db1_metadata)
+        self.assertEqual(provider.get_metadata("db2").tables, set())
+
+
 class TestSQLValidator(unittest.TestCase):
     """SQLValidator 클래스 테스트"""
 
@@ -150,7 +228,7 @@ class TestSQLValidator(unittest.TestCase):
             'products': {'id', 'name', 'price', 'category_id'},
         }
         metadata.db_version = (5, 7, 44)  # MySQL 5.7 (8.0 기능 미지원)
-        self.provider._metadata = metadata
+        self.provider.set_metadata(None, metadata)
 
         self.validator = SQLValidator(self.provider)
 
@@ -358,7 +436,9 @@ class TestSQLValidator(unittest.TestCase):
     def test_validate_version_no_warning_on_mysql8(self):
         """[SUCCESS] MySQL 8.0에서는 경고 없음"""
         # MySQL 8.0으로 변경
-        self.provider._metadata.db_version = (8, 0, 32)
+        metadata = self.provider.get_metadata()
+        metadata.db_version = (8, 0, 32)
+        self.provider.set_metadata(None, metadata)
 
         sql = "SELECT id, ROW_NUMBER() OVER (ORDER BY id) as rn FROM users"
         issues = self.validator.validate(sql)
@@ -409,6 +489,96 @@ WHERE id = 1"""
         column_warnings = [i for i in issues if 'created_at' in i.message and 'orders' in i.message]
         self.assertEqual(len(column_warnings), 1)
 
+    # =========================================================================
+    # CTE(WITH 절) 검증 테스트
+    # =========================================================================
+    def test_validate_cte_name_not_reported_as_missing_table(self):
+        """[SUCCESS] CTE 이름은 존재하지 않는 테이블로 오탐되지 않음"""
+        sql = """
+        WITH cte AS (
+            SELECT id, name FROM users
+        )
+        SELECT * FROM cte
+        """
+        issues = self.validator.validate(sql)
+
+        table_errors = [i for i in issues if i.severity == IssueSeverity.ERROR]
+        self.assertEqual(len(table_errors), 0)
+
+    def test_validate_multiple_ctes_not_reported_as_missing_tables(self):
+        """[SUCCESS] 콤마로 연결된 여러 CTE 모두 오탐되지 않음"""
+        sql = """
+        WITH first_cte AS (
+            SELECT id FROM users
+        ), second_cte AS (
+            SELECT id FROM first_cte
+        )
+        SELECT * FROM second_cte
+        """
+        issues = self.validator.validate(sql)
+
+        table_errors = [i for i in issues if i.severity == IssueSeverity.ERROR]
+        self.assertEqual(len(table_errors), 0)
+
+    def test_validate_recursive_cte_not_reported_as_missing_table(self):
+        """[SUCCESS] WITH RECURSIVE CTE도 오탐되지 않음"""
+        sql = """
+        WITH RECURSIVE nums AS (
+            SELECT id FROM users
+            UNION ALL
+            SELECT id FROM nums
+        )
+        SELECT * FROM nums
+        """
+        issues = self.validator.validate(sql)
+
+        table_errors = [i for i in issues if i.severity == IssueSeverity.ERROR]
+        self.assertEqual(len(table_errors), 0)
+
+    def test_validate_unknown_real_table_still_errors_when_with_present(self):
+        """[FAIL] WITH 절이 있어도 실제로 존재하지 않는 테이블은 여전히 에러"""
+        sql = """
+        WITH cte AS (
+            SELECT id FROM users
+        )
+        SELECT * FROM missing_table
+        """
+        issues = self.validator.validate(sql)
+
+        table_errors = [i for i in issues if i.severity == IssueSeverity.ERROR and '테이블' in i.message]
+        self.assertEqual(len(table_errors), 1)
+        self.assertIn('missing_table', table_errors[0].message)
+
+    # =========================================================================
+    # 파생 테이블(서브쿼리) 별칭 검증 테스트
+    # =========================================================================
+    def test_validate_derived_table_alias_not_reported_as_missing_table(self):
+        """[SUCCESS] 파생 테이블 별칭은 존재하지 않는 테이블로 오탐되지 않음"""
+        sql = """
+        SELECT d.id
+        FROM (
+            SELECT id FROM users
+        ) AS d
+        """
+        issues = self.validator.validate(sql)
+
+        table_errors = [i for i in issues if i.severity == IssueSeverity.ERROR and '테이블' in i.message]
+        self.assertEqual(len(table_errors), 0)
+
+    def test_validate_table_inside_derived_query_still_checked(self):
+        """[FAIL] 파생 테이블 내부의 실제 테이블 오타는 여전히 검증됨"""
+        sql = """
+        SELECT d.id
+        FROM (
+            SELECT id FROM userss
+        ) AS d
+        """
+        issues = self.validator.validate(sql)
+
+        table_errors = [i for i in issues if i.severity == IssueSeverity.ERROR and '테이블' in i.message]
+        self.assertEqual(len(table_errors), 1)
+        self.assertIn('userss', table_errors[0].message)
+
 
 class TestSQLAutoCompleter(unittest.TestCase):
     """SQLAutoCompleter 클래스 테스트"""
@@ -424,7 +594,7 @@ class TestSQLAutoCompleter(unittest.TestCase):
             'orders': {'id', 'user_id', 'total_amount'},
             'products': {'id', 'name', 'price'},
         }
-        self.provider._metadata = metadata
+        self.provider.set_metadata(None, metadata)
 
         self.completer = SQLAutoCompleter(self.provider)
 
@@ -481,6 +651,11 @@ class TestSQLAutoCompleter(unittest.TestCase):
         self.assertIn('email', column_labels)
         self.assertIn('name', column_labels)
         self.assertNotIn('total_amount', column_labels)
+
+        # alias. 뒤에서는 키워드/함수가 포함되면 안됨 (table. 뒤와 동일)
+        types = set(c['type'] for c in completions)
+        self.assertNotIn('keyword', types, "alias. 뒤에서 키워드가 포함되면 안됨")
+        self.assertNotIn('function', types, "alias. 뒤에서 함수가 포함되면 안됨")
 
     def test_autocomplete_after_schema_dot_in_table_context(self):
         """[SUCCESS] FROM schema. 뒤 → 테이블 목록"""
@@ -555,6 +730,15 @@ class TestSQLAutoCompleter(unittest.TestCase):
         # COUNT()가 포함되어야 함
         self.assertTrue(any('COUNT' in label for label in function_labels))
 
+    # =========================================================================
+    # 공용 별칭 파서(extract_table_aliases) 직접 테스트
+    # =========================================================================
+    def test_extract_table_aliases_helper_maps_alias_to_table(self):
+        """[SUCCESS] extract_table_aliases가 AS 별칭을 실제 테이블명으로 매핑"""
+        metadata = self.provider.get_metadata()
+        aliases = extract_table_aliases("SELECT * FROM users AS u", metadata)
+        self.assertEqual(aliases["u"], "users")
+
 
 class TestValidationIssue(unittest.TestCase):
     """ValidationIssue 데이터클래스 테스트"""
@@ -596,7 +780,7 @@ class TestEdgeCases(unittest.TestCase):
             'user_logs': {'id', 'user_id', 'action'},
             'user_settings': {'id', 'user_id', 'key', 'value'},
         }
-        self.provider._metadata = metadata
+        self.provider.set_metadata(None, metadata)
         self.validator = SQLValidator(self.provider)
 
     def test_empty_sql(self):


### PR DESCRIPTION
## 요약
- `SchemaMetadataProvider`를 단일 캐시에서 **스키마별 캐시**로 교체해, 스키마를 전환해도 이전 스키마의 테이블/컬럼 메타데이터가 섞여 보이던 문제를 해결했습니다.
- `get_metadata()`가 캐시 미스 시에도 커넥터에 동기 DB 조회를 하지 않도록 해, `ValidationWorker`가 `MetadataLoadWorker`와 같은 커넥터를 두고 경쟁(race)하지 않게 했습니다.
- `WITH` 절의 CTE 이름과 `FROM (...) AS alias` 형태의 파생 테이블 별칭을 인식해, 테이블 존재 검증에서 실존하지 않는 테이블로 오탐하지 않도록 했습니다.
- `SQLValidator`와 `SQLAutoCompleter`가 각각 갖고 있던 중복 별칭 파서를 모듈 레벨 `extract_table_aliases()`로 통합했습니다.

## 범위
- `src/core/sql_validator.py`
- `tests/test_sql_validator.py`

## Blocker / Scope Note
- `src/ui/dialogs/sql_editor_dialog.py`는 여전히 `metadata_provider._metadata`에 직접 대입/조회합니다 (예: 메타데이터 로드 완료 콜백). 이 파일은 본 WP 범위 밖(UI)이라 수정하지 않았고, 대신 `_metadata`를 호환용 property로 유지해 기존 동작(직전 `set_connector()`가 기록한 활성 스키마에 매핑)을 보존했습니다. 완전한 정리는 `sql_editor_dialog.py`가 `set_metadata(schema, metadata)`를 직접 호출하도록 바꾸는 별도 WP가 필요합니다.

## Test plan
- [x] `py_compile src/core/sql_validator.py tests/test_sql_validator.py`
- [x] `pytest tests/test_sql_validator.py -q` → 70 passed
- [x] `pytest -q` (전체) → 1929 passed, 1 failed (macOS validation artifact 다운로드 테스트, GitHub CI 의존적인 로컬 전용 플레이키 테스트로 본 변경과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)