### PR TITLE
fix(diff-dialog): 스키마 로드 워커화 + 커넥터 누수/취소 정리 (WP-3.4)

### DIFF
--- a/src/ui/dialogs/diff_dialog.py
+++ b/src/ui/dialogs/diff_dialog.py
@@ -33,7 +33,9 @@ class SchemaCompareThread(QThread):
     """스키마 비교 백그라운드 스레드"""
 
     progress = pyqtSignal(str)
-    finished = pyqtSignal(list, object, object)  # diffs, SeveritySummary, VersionContext
+    # NOTE: QThread에는 인자 없는 기본 finished 시그널이 있으므로,
+    # 이름을 겹치지 않게 compare_finished로 분리한다.
+    compare_finished = pyqtSignal(list, object, object)  # diffs, SeveritySummary, VersionContext
     error = pyqtSignal(str)
 
     def __init__(self, source_connector, target_connector,
@@ -76,10 +78,55 @@ class SchemaCompareThread(QThread):
             classifier = SeverityClassifier(version_ctx)
             diffs, summary = classifier.classify(diffs)
 
-            self.finished.emit(diffs, summary, version_ctx)
+            self.compare_finished.emit(diffs, summary, version_ctx)
 
         except Exception as e:
             self.error.emit(str(e))
+
+
+class SchemaLoadThread(QThread):
+    """스키마 목록 조회 백그라운드 스레드
+
+    DB 연결/조회/해제가 UI 스레드를 블로킹하지 않도록 별도 스레드에서 수행한다.
+    """
+
+    loaded = pyqtSignal(str, list)       # side, schema_names
+    load_failed = pyqtSignal(str, str)   # side, display_message
+
+    def __init__(self, side: str, host: str, port: int,
+                 user: str, password: str):
+        super().__init__()
+        self.side = side
+        self.host = host
+        self.port = port
+        self.user = user
+        self.password = password
+
+    def run(self):
+        connector = None
+        try:
+            connector = MySQLConnector(
+                host=self.host, port=self.port,
+                user=self.user, password=self.password
+            )
+
+            success, _ = connector.connect()
+            if not success:
+                self.load_failed.emit(self.side, "(연결 실패)")
+                return
+
+            schemas = connector.get_schemas(use_cache=False)
+            self.loaded.emit(self.side, list(schemas))
+
+        except Exception as e:
+            logger.error(f"스키마 로드 실패: {e}")
+            self.load_failed.emit(self.side, "(오류)")
+        finally:
+            if connector:
+                try:
+                    connector.disconnect()
+                except Exception:
+                    pass
 
 
 class PixelLoadingWidget(QWidget):
@@ -324,6 +371,13 @@ class SchemaDiffDialog(QDialog):
         self._compare_thread = None
         self._severity_summary = None
         self._version_ctx = None
+        # 비교 시작 시점에 캡처한 스키마 이름 (비교 도중 콤보 변경과 무관하게 고정)
+        self._compared_source_schema = None
+        self._compared_target_schema = None
+        # side('source'/'target') -> 현재 진행 중인 SchemaLoadThread (stale 결과 판별용)
+        self._schema_load_threads: Dict[str, "SchemaLoadThread"] = {}
+        # 종료 전까지 참조를 유지해 GC로 인한 스레드 파괴를 방지
+        self._pending_schema_threads: List["SchemaLoadThread"] = []
 
         self._setup_ui()
         self._connect_signals()
@@ -510,7 +564,7 @@ class SchemaDiffDialog(QDialog):
         return (True, host, port, db_user, db_password)
 
     def _load_schemas(self, side: str):
-        """스키마 목록 로드"""
+        """스키마 목록 로드 (백그라운드 스레드에서 조회, UI 스레드 블로킹 방지)"""
         if side == 'source':
             combo = self.source_tunnel_combo
             schema_combo = self.source_schema_combo
@@ -531,33 +585,37 @@ class SchemaDiffDialog(QDialog):
 
         _, host, port, db_user, db_password = result
 
-        # DB 연결
-        connector = None
-        try:
-            connector = MySQLConnector(
-                host=host, port=port,
-                user=db_user, password=db_password
-            )
+        thread = SchemaLoadThread(side, host, port, db_user, db_password)
+        thread.loaded.connect(self._on_schema_loaded)
+        thread.load_failed.connect(self._on_schema_load_failed)
+        thread.finished.connect(lambda t=thread: self._on_schema_thread_finished(t))
 
-            success, msg = connector.connect()
-            if not success:
-                schema_combo.addItem("(연결 실패)")
-                return
+        # 같은 side의 이전 결과는 stale로 취급 (아래 콜백에서 sender 비교)
+        self._schema_load_threads[side] = thread
+        self._pending_schema_threads.append(thread)
+        thread.start()
 
-            # 스키마 목록 조회
-            schemas = connector.get_schemas(use_cache=False)
-            for schema_name in schemas:
-                schema_combo.addItem(schema_name)
+    def _on_schema_loaded(self, side: str, schemas: list):
+        """스키마 목록 로드 완료 콜백 (stale 결과는 무시)"""
+        if self._schema_load_threads.get(side) is not self.sender():
+            return
+        schema_combo = self.source_schema_combo if side == 'source' else self.target_schema_combo
+        schema_combo.clear()
+        for schema_name in schemas:
+            schema_combo.addItem(schema_name)
 
-        except Exception as e:
-            logger.error(f"스키마 로드 실패: {e}")
-            schema_combo.addItem("(오류)")
-        finally:
-            if connector:
-                try:
-                    connector.disconnect()
-                except Exception:
-                    pass
+    def _on_schema_load_failed(self, side: str, message: str):
+        """스키마 목록 로드 실패 콜백 (stale 결과는 무시)"""
+        if self._schema_load_threads.get(side) is not self.sender():
+            return
+        schema_combo = self.source_schema_combo if side == 'source' else self.target_schema_combo
+        schema_combo.clear()
+        schema_combo.addItem(message)
+
+    def _on_schema_thread_finished(self, thread: "SchemaLoadThread"):
+        """스레드 종료 후 보관 참조 정리 (실행 중 GC로 파괴되는 것 방지용 목록)"""
+        if thread in self._pending_schema_threads:
+            self._pending_schema_threads.remove(thread)
 
     def _start_compare(self):
         """비교 시작"""
@@ -587,6 +645,24 @@ class SchemaDiffDialog(QDialog):
 
         _, source_host, source_port, source_user, source_pw = source_params
         _, target_host, target_port, target_user, target_pw = target_params
+
+        # 이전 비교에서 남아있는 커넥터 정리 (반복 비교 시 세션 누수 방지)
+        if self._source_connector:
+            try:
+                self._source_connector.disconnect()
+            except Exception:
+                pass
+            self._source_connector = None
+        if self._target_connector:
+            try:
+                self._target_connector.disconnect()
+            except Exception:
+                pass
+            self._target_connector = None
+
+        # 비교 시작 시점의 스키마 이름을 캡처 (비교 중 콤보가 바뀌어도 결과와 일치 보장)
+        self._compared_source_schema = source_schema
+        self._compared_target_schema = target_schema
 
         # 연결 생성
         try:
@@ -649,7 +725,7 @@ class SchemaDiffDialog(QDialog):
             source_schema, target_schema, compare_level
         )
         self._compare_thread.progress.connect(self._on_progress)
-        self._compare_thread.finished.connect(self._on_compare_finished)
+        self._compare_thread.compare_finished.connect(self._on_compare_finished)
         self._compare_thread.error.connect(self._on_compare_error)
         self._compare_thread.start()
 
@@ -964,7 +1040,8 @@ class SchemaDiffDialog(QDialog):
             if reply != QMessageBox.StandardButton.Yes:
                 return
 
-        target_schema = self.target_schema_combo.currentText()
+        # 비교 시작 시점에 캡처한 스키마를 사용한다 (완료 후 콤보를 바꿔도 결과와 일치)
+        target_schema = self._compared_target_schema or self.target_schema_combo.currentText()
         generator = SyncScriptGenerator()
         script = generator.generate_sync_script(self._diffs, target_schema)
 
@@ -974,20 +1051,64 @@ class SchemaDiffDialog(QDialog):
 
     def closeEvent(self, event):
         """다이얼로그 닫힐 때"""
+        # 진행 중인 스레드를 먼저 정리(시그널 해제 + 대기)한 뒤 커넥터를 정리해야
+        # 스레드가 사용 중인 커넥터를 도중에 끊어버리는 경합을 피할 수 있다.
+        self._cancel_compare_thread()
+        self._cancel_schema_load_threads()
+
         # 연결 정리
         if self._source_connector:
             try:
                 self._source_connector.disconnect()
             except Exception:
                 pass
+            self._source_connector = None
 
         if self._target_connector:
             try:
                 self._target_connector.disconnect()
             except Exception:
                 pass
+            self._target_connector = None
 
         super().closeEvent(event)
+
+    def _cancel_compare_thread(self):
+        """진행 중인 비교 스레드를 정리한다.
+
+        다이얼로그가 파괴된 뒤 완료 콜백이 죽은 위젯을 건드리지 않도록
+        시그널을 먼저 해제하고, 스레드가 끝날 때까지 기다린 뒤 반환한다.
+        """
+        thread = self._compare_thread
+        if thread is None:
+            return
+
+        for signal, slot in (
+            (thread.progress, self._on_progress),
+            (thread.compare_finished, self._on_compare_finished),
+            (thread.error, self._on_compare_error),
+        ):
+            try:
+                signal.disconnect(slot)
+            except (TypeError, RuntimeError):
+                pass
+
+        if thread.isRunning():
+            thread.wait(5000)
+
+    def _cancel_schema_load_threads(self):
+        """진행 중인 스키마 로드 스레드를 정리한다."""
+        for thread in list(self._pending_schema_threads):
+            for signal, slot in (
+                (thread.loaded, self._on_schema_loaded),
+                (thread.load_failed, self._on_schema_load_failed),
+            ):
+                try:
+                    signal.disconnect(slot)
+                except (TypeError, RuntimeError):
+                    pass
+            if thread.isRunning():
+                thread.wait(3000)
 
 
 class SyncScriptDialog(QDialog):

--- a/tests/test_diff_dialog.py
+++ b/tests/test_diff_dialog.py
@@ -1,24 +1,38 @@
 """
 스키마 비교 다이얼로그 테스트
 - _resolve_connection_params(): 연결 파라미터 검증 헬퍼
-- _load_schemas(): tuple 언패킹 + try/finally cleanup 검증
+- _load_schemas(): 백그라운드 스레드 실행 + tuple 언패킹 + try/finally cleanup 검증
 - _start_compare(): 사전 검증 + tuple 언패킹 + credentials 조회 검증
+  + 이전 커넥터 정리 + 비교 시점 스키마 이름 캡처
+- closeEvent(): 진행 중인 스레드 정리 후 커넥터 disconnect 검증
 """
+import time
+
 import pytest
 from unittest.mock import MagicMock, patch, call
 
 # PyQt6 QApplication 필요 (위젯 생성 전 초기화)
 from PyQt6.QtWidgets import QApplication
+from PyQt6.QtGui import QCloseEvent
 import sys
 
 app = QApplication.instance() or QApplication(sys.argv)
 
 
-from src.ui.dialogs.diff_dialog import SchemaDiffDialog
+from src.ui.dialogs.diff_dialog import SchemaDiffDialog, SchemaCompareThread
 from src.core.schema_diff import (
     CompareLevel, SeveritySummary, VersionContext,
     DiffType, TableDiff, ColumnDiff, ColumnInfo, DiffSeverity,
 )
+
+
+def _wait_for_schema_load(dialog, side, timeout=3000):
+    """백그라운드 스키마 로드 스레드가 끝날 때까지 대기하고, 큐잉된 시그널을 처리한다."""
+    thread = dialog._schema_load_threads.get(side)
+    assert thread is not None, f"'{side}' 스키마 로드 스레드가 시작되지 않았습니다"
+    finished = thread.wait(timeout)
+    QApplication.processEvents()
+    assert finished, f"'{side}' 스키마 로드 스레드가 제한 시간 내에 끝나지 않았습니다"
 
 
 @pytest.fixture
@@ -46,7 +60,13 @@ def sample_tunnels():
 
 @pytest.fixture
 def dialog(sample_tunnels, mock_tunnel_engine, mock_config_manager):
-    """SchemaDiffDialog 인스턴스 (초기 스키마 로드 모킹)"""
+    """SchemaDiffDialog 인스턴스 (초기 스키마 로드 모킹)
+
+    __init__ 중 _connect_signals()가 source/target 스키마 로드를 백그라운드
+    스레드로 시작시키므로, `with patch(...)` 블록이 해제(=MySQLConnector 원복)되기
+    전에 두 스레드가 끝나도록 대기한다. 대기하지 않으면 스레드가 patch 해제 후에
+    실제 MySQLConnector를 호출하려는 경합이 생긴다.
+    """
     with patch('src.ui.dialogs.diff_dialog.MySQLConnector') as MockConnector:
         mock_conn = MagicMock()
         mock_conn.connect.return_value = (True, 'OK')
@@ -58,6 +78,12 @@ def dialog(sample_tunnels, mock_tunnel_engine, mock_config_manager):
             tunnel_engine=mock_tunnel_engine,
             config_manager=mock_config_manager,
         )
+
+        for side in ('source', 'target'):
+            thread = dlg._schema_load_threads.get(side)
+            if thread is not None:
+                thread.wait(3000)
+                QApplication.processEvents()
     return dlg
 
 
@@ -101,7 +127,7 @@ class TestResolveConnectionParams:
 # ============================================================
 
 class TestLoadSchemas:
-    """_load_schemas() 테스트"""
+    """_load_schemas() 테스트 (백그라운드 스레드에서 실행됨)"""
 
     def test_success_loads_schemas(self, dialog, mock_tunnel_engine, mock_config_manager):
         """정상 경로: 스키마 목록이 콤보박스에 로드됨"""
@@ -113,6 +139,7 @@ class TestLoadSchemas:
 
             dialog.source_schema_combo.clear()
             dialog._load_schemas('source')
+            _wait_for_schema_load(dialog, 'source')
 
             # tuple 언패킹으로 호출 확인
             mock_tunnel_engine.get_connection_info.assert_called()
@@ -132,8 +159,33 @@ class TestLoadSchemas:
             # disconnect 호출 (finally 블록)
             mock_conn.disconnect.assert_called_once()
 
+    def test_load_schemas_is_non_blocking(self, dialog):
+        """_load_schemas 호출 직후 UI 스레드가 즉시 반환되어야 한다 (동기 블로킹 금지)"""
+        with patch('src.ui.dialogs.diff_dialog.MySQLConnector') as MockConn:
+            def _slow_connect():
+                time.sleep(0.2)
+                return (True, 'OK')
+
+            mock_conn = MagicMock()
+            mock_conn.connect.side_effect = _slow_connect
+            mock_conn.get_schemas.return_value = ['db1']
+            MockConn.return_value = mock_conn
+
+            dialog.source_schema_combo.clear()
+            dialog._load_schemas('source')
+
+            # connect()가 아직 끝나지 않았을 시점 — 호출이 동기 블로킹이었다면
+            # 이 지점에 도달하기까지 최소 0.2초가 걸렸을 것이고 콤보가 이미 채워졌을 것
+            assert dialog.source_schema_combo.count() == 0
+
+            _wait_for_schema_load(dialog, 'source')
+
+            items = [dialog.source_schema_combo.itemText(i)
+                     for i in range(dialog.source_schema_combo.count())]
+            assert items == ['db1']
+
     def test_tunnel_not_running(self, dialog, mock_tunnel_engine):
-        """터널 미실행 시 '(터널 연결 필요)' 표시"""
+        """터널 미실행 시 '(터널 연결 필요)' 표시 (사전 검증 실패라 스레드 없이 즉시 반영)"""
         mock_tunnel_engine.is_running.return_value = False
 
         dialog.source_schema_combo.clear()
@@ -168,6 +220,7 @@ class TestLoadSchemas:
 
             dialog.source_schema_combo.clear()
             dialog._load_schemas('source')
+            _wait_for_schema_load(dialog, 'source')
 
             assert dialog.source_schema_combo.itemText(0) == "(연결 실패)"
             # 연결 실패해도 disconnect는 finally에서 호출
@@ -182,6 +235,7 @@ class TestLoadSchemas:
 
             dialog.source_schema_combo.clear()
             dialog._load_schemas('source')
+            _wait_for_schema_load(dialog, 'source')
 
             assert dialog.source_schema_combo.itemText(0) == "(오류)"
             # finally에서 disconnect 호출 확인
@@ -199,6 +253,7 @@ class TestLoadSchemas:
             dialog.source_schema_combo.clear()
             # 예외가 전파되지 않아야 함
             dialog._load_schemas('source')
+            _wait_for_schema_load(dialog, 'source')
 
             items = [dialog.source_schema_combo.itemText(i)
                      for i in range(dialog.source_schema_combo.count())]
@@ -214,10 +269,44 @@ class TestLoadSchemas:
 
             dialog.target_schema_combo.clear()
             dialog._load_schemas('target')
+            _wait_for_schema_load(dialog, 'target')
 
             items = [dialog.target_schema_combo.itemText(i)
                      for i in range(dialog.target_schema_combo.count())]
             assert items == ['target_db']
+
+    def test_stale_result_ignored_after_reload(self, dialog):
+        """뒤늦게 도착한 옛(stale) 스레드의 결과가 최신 콤보 상태를 덮어쓰면 안 된다
+
+        실제 스레드 스케줄링 순서에 의존하지 않도록, .start()로 스레드를 실행하는
+        대신 시그널을 직접 emit하여 '먼저 등록된 스레드가 나중에 완료를 알려오는'
+        상황을 결정적으로 재현한다.
+        """
+        from src.ui.dialogs.diff_dialog import SchemaLoadThread
+
+        old_thread = SchemaLoadThread('source', '127.0.0.1', 3307, 'u', 'p')
+        old_thread.loaded.connect(dialog._on_schema_loaded)
+        old_thread.load_failed.connect(dialog._on_schema_load_failed)
+
+        new_thread = SchemaLoadThread('source', '127.0.0.1', 3307, 'u', 'p')
+        new_thread.loaded.connect(dialog._on_schema_loaded)
+        new_thread.load_failed.connect(dialog._on_schema_load_failed)
+
+        # old_thread가 '현재' 스레드였다가 new_thread로 교체된 상황
+        dialog._schema_load_threads['source'] = old_thread
+        dialog._schema_load_threads['source'] = new_thread
+
+        # 최신 스레드가 먼저 결과를 반영
+        new_thread.loaded.emit('source', ['new_db'])
+        items = [dialog.source_schema_combo.itemText(i)
+                 for i in range(dialog.source_schema_combo.count())]
+        assert items == ['new_db']
+
+        # 뒤늦게 도착한 옛 스레드의 결과는 무시되어야 한다
+        old_thread.loaded.emit('source', ['old_db'])
+        items = [dialog.source_schema_combo.itemText(i)
+                 for i in range(dialog.source_schema_combo.count())]
+        assert items == ['new_db']
 
 
 # ============================================================
@@ -352,6 +441,209 @@ class TestStartCompare:
 
             assert dialog._source_connector is None
             assert dialog._target_connector is None
+
+
+# ============================================================
+# _start_compare() - 이전 커넥터 정리 + 비교 시점 스키마 캡처
+# ============================================================
+
+class TestStartCompareClearsPreviousConnectors:
+    """반복 비교 시 이전 커넥터를 정리하고 새로 생성해야 한다 (Rust core 세션 누수 방지)"""
+
+    def test_disconnects_previous_connectors_before_new_compare(
+        self, dialog, mock_tunnel_engine, mock_config_manager
+    ):
+        old_source = MagicMock()
+        old_target = MagicMock()
+        dialog._source_connector = old_source
+        dialog._target_connector = old_target
+
+        with patch('src.ui.dialogs.diff_dialog.MySQLConnector') as MockConn:
+            mock_src = MagicMock()
+            mock_src.connect.return_value = (True, 'OK')
+            mock_tgt = MagicMock()
+            mock_tgt.connect.return_value = (True, 'OK')
+            MockConn.side_effect = [mock_src, mock_tgt]
+
+            dialog.source_schema_combo.clear()
+            dialog.source_schema_combo.addItem('db1')
+            dialog.target_schema_combo.clear()
+            dialog.target_schema_combo.addItem('db2')
+
+            with patch.object(dialog, '_compare_thread', None):
+                with patch('src.ui.dialogs.diff_dialog.SchemaCompareThread'):
+                    dialog._start_compare()
+
+            old_source.disconnect.assert_called_once()
+            old_target.disconnect.assert_called_once()
+            # 이전 인스턴스가 아니라 새로 생성된 커넥터로 교체되어야 함
+            assert dialog._source_connector is mock_src
+            assert dialog._target_connector is mock_tgt
+
+
+class TestStartCompareCapturesSchemaNames:
+    """비교 시작 시점의 스키마 이름을 캡처해야 한다 (완료 후 콤보 변경과 무관하게 고정)"""
+
+    def test_captures_source_and_target_schema_at_compare_start(
+        self, dialog, mock_tunnel_engine, mock_config_manager
+    ):
+        with patch('src.ui.dialogs.diff_dialog.MySQLConnector') as MockConn:
+            mock_src = MagicMock()
+            mock_src.connect.return_value = (True, 'OK')
+            mock_tgt = MagicMock()
+            mock_tgt.connect.return_value = (True, 'OK')
+            MockConn.side_effect = [mock_src, mock_tgt]
+
+            dialog.source_schema_combo.clear()
+            dialog.source_schema_combo.addItem('src_db')
+            dialog.target_schema_combo.clear()
+            dialog.target_schema_combo.addItem('tgt_db')
+
+            with patch.object(dialog, '_compare_thread', None):
+                with patch('src.ui.dialogs.diff_dialog.SchemaCompareThread'):
+                    dialog._start_compare()
+
+        assert dialog._compared_source_schema == 'src_db'
+        assert dialog._compared_target_schema == 'tgt_db'
+
+
+class TestSchemaCompareThreadSignals:
+    """완료 시그널이 QThread.finished를 가리지 않는지 확인"""
+
+    def test_compare_finished_signal_exists_separately_from_qthread_finished(self):
+        thread = SchemaCompareThread(MagicMock(), MagicMock(), 'src_db', 'tgt_db')
+
+        assert hasattr(thread, 'compare_finished')
+
+        received = []
+        thread.compare_finished.connect(
+            lambda diffs, summary, version_ctx: received.append((diffs, summary, version_ctx))
+        )
+        thread.compare_finished.emit([], MagicMock(), MagicMock())
+        assert len(received) == 1
+
+    def test_start_compare_connects_to_compare_finished_not_finished(
+        self, dialog, mock_tunnel_engine, mock_config_manager
+    ):
+        """_start_compare()가 compare_finished(신규 이름)에 연결해야 한다"""
+        with patch('src.ui.dialogs.diff_dialog.MySQLConnector') as MockConn:
+            mock_src = MagicMock()
+            mock_src.connect.return_value = (True, 'OK')
+            mock_tgt = MagicMock()
+            mock_tgt.connect.return_value = (True, 'OK')
+            MockConn.side_effect = [mock_src, mock_tgt]
+
+            dialog.source_schema_combo.clear()
+            dialog.source_schema_combo.addItem('db1')
+            dialog.target_schema_combo.clear()
+            dialog.target_schema_combo.addItem('db2')
+
+            with patch.object(dialog, '_compare_thread', None):
+                with patch('src.ui.dialogs.diff_dialog.SchemaCompareThread') as MockThread:
+                    mock_thread = MagicMock()
+                    MockThread.return_value = mock_thread
+
+                    dialog._start_compare()
+
+                    mock_thread.compare_finished.connect.assert_called_once_with(
+                        dialog._on_compare_finished
+                    )
+
+
+# ============================================================
+# _generate_script() - 비교 시점 스키마 사용 검증
+# ============================================================
+
+class TestGenerateScriptUsesCompareTimeSchema:
+    """동기화 스크립트는 비교 시작 시점에 캡처한 타겟 스키마를 사용해야 한다"""
+
+    def test_uses_captured_target_schema_not_live_combo(self, dialog):
+        dialog._diffs = [TableDiff(table_name="t1", diff_type=DiffType.UNCHANGED)]
+        dialog._severity_summary = SeveritySummary(critical=0, warning=0, info=0)
+        dialog._compared_target_schema = 'schema_at_compare_time'
+
+        # 비교 완료 후 유저가 콤보를 바꿔도 스크립트는 비교 시점 스키마를 써야 한다
+        dialog.target_schema_combo.clear()
+        dialog.target_schema_combo.addItem('schema_changed_after_compare')
+
+        with patch('src.ui.dialogs.diff_dialog.SyncScriptGenerator') as MockGen, \
+             patch('src.ui.dialogs.diff_dialog.SyncScriptDialog') as MockDialog:
+            mock_generator = MagicMock()
+            mock_generator.generate_sync_script.return_value = "-- sql"
+            MockGen.return_value = mock_generator
+            mock_dialog_instance = MagicMock()
+            MockDialog.return_value = mock_dialog_instance
+
+            dialog._generate_script()
+
+            mock_generator.generate_sync_script.assert_called_once_with(
+                dialog._diffs, 'schema_at_compare_time'
+            )
+            mock_dialog_instance.exec.assert_called_once()
+
+
+# ============================================================
+# closeEvent() - 스레드 정리 후 커넥터 disconnect 검증
+# ============================================================
+
+class TestCloseEventCleanup:
+    """closeEvent 시 진행 중인 스레드를 정리한 뒤 커넥터를 disconnect해야 한다"""
+
+    def test_close_waits_for_running_compare_thread_before_disconnect(self, dialog):
+        mock_thread = MagicMock()
+        mock_thread.isRunning.return_value = True
+        dialog._compare_thread = mock_thread
+
+        mock_source = MagicMock()
+        mock_target = MagicMock()
+        dialog._source_connector = mock_source
+        dialog._target_connector = mock_target
+
+        event = QCloseEvent()
+        dialog.closeEvent(event)
+
+        mock_thread.wait.assert_called_once()
+        mock_source.disconnect.assert_called_once()
+        mock_target.disconnect.assert_called_once()
+        assert dialog._source_connector is None
+        assert dialog._target_connector is None
+
+    def test_close_disconnects_compare_thread_signals(self, dialog):
+        """콜백이 파괴된 위젯을 건드리지 않도록 시그널을 먼저 해제해야 한다"""
+        mock_thread = MagicMock()
+        mock_thread.isRunning.return_value = False
+        dialog._compare_thread = mock_thread
+
+        event = QCloseEvent()
+        dialog.closeEvent(event)
+
+        mock_thread.progress.disconnect.assert_called_once()
+        mock_thread.compare_finished.disconnect.assert_called_once()
+        mock_thread.error.disconnect.assert_called_once()
+
+    def test_close_without_compare_thread_still_disconnects_connectors(self, dialog):
+        """비교 스레드가 없어도 커넥터 정리는 정상 동작해야 한다"""
+        dialog._compare_thread = None
+        mock_source = MagicMock()
+        dialog._source_connector = mock_source
+        dialog._target_connector = None
+
+        event = QCloseEvent()
+        dialog.closeEvent(event)
+
+        mock_source.disconnect.assert_called_once()
+
+    def test_close_waits_for_pending_schema_load_threads(self, dialog):
+        """진행 중인 스키마 로드 스레드도 종료를 기다려야 한다"""
+        mock_thread = MagicMock()
+        mock_thread.isRunning.return_value = True
+        dialog._pending_schema_threads = [mock_thread]
+        dialog._compare_thread = None
+
+        event = QCloseEvent()
+        dialog.closeEvent(event)
+
+        mock_thread.wait.assert_called_once()
 
 
 # ============================================================


### PR DESCRIPTION
## Summary
- 스키마 목록 조회(`_load_schemas`)를 `SchemaLoadThread` 백그라운드 스레드로 이동해 UI 스레드 블로킹을 제거. side(source/target)별 최신 스레드만 반영하고 stale 결과는 무시.
- `_start_compare()` 시작 시 이전 비교의 커넥터를 먼저 disconnect하여 반복 비교 시 Rust core 서브프로세스 세션이 누적 누수되는 문제 해소.
- 비교 시작 시점의 소스/타겟 스키마 이름을 캡처해 두어, 비교 완료 후 사용자가 콤보를 바꿔도 동기화 스크립트가 실제 비교 대상 스키마를 사용하도록 고정.
- `closeEvent()`에서 진행 중인 비교/스키마 로드 스레드의 시그널을 먼저 해제하고 종료를 기다린 뒤 커넥터를 disconnect하여, 스레드가 사용 중인 커넥터를 다이얼로그 종료 시점에 바로 끊어버리는 경합 제거.
- `SchemaCompareThread`의 완료 시그널을 `QThread` 내장 `finished`와 이름이 겹치지 않도록 `compare_finished`로 분리.

## Test plan
- [x] `python -m py_compile src/ui/dialogs/diff_dialog.py tests/test_diff_dialog.py`
- [x] `pytest tests/test_diff_dialog.py -q` — 32 passed
- [x] `pytest -q` (전체) — 2045 passed, 1 failed (`test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`, GitHub CI 의존적 로컬 전용 flaky 테스트로 회귀와 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)