### PR TITLE
fix(schedule-dialog): SQL 분리 위험검사 + 체크박스 연결 (WP-3.7)

### DIFF
--- a/src/ui/dialogs/schedule_dialog.py
+++ b/src/ui/dialogs/schedule_dialog.py
@@ -22,6 +22,7 @@ from PyQt6.QtCore import Qt, QTime, pyqtSignal
 from PyQt6.QtGui import QIcon, QFont, QColor, QTextCharFormat, QSyntaxHighlighter
 
 from src.core.scheduler import ScheduleConfig, CronParser, BackupScheduler, ScheduleTaskType
+from src.core.sql_statement_parser import parse_sql_statements
 from src.core.logger import get_logger
 from src.core.i18n import translate_text
 
@@ -129,11 +130,16 @@ class ScheduleEditDialog(QDialog):
     """스케줄 추가/수정 다이얼로그"""
 
     # 위험 쿼리 패턴
+    # 주의: 아래 패턴은 문장 단위로 분리된 SQL(1개 statement)에 대해 검사되어야 한다.
+    # 여러 statement가 이어진 통짜 텍스트에 그대로 돌리면, 특히 UPDATE 패턴의
+    # 부정 탐색(negative lookahead)이 뒤에 오는 다른 statement의 WHERE까지
+    # 봐버려 정작 WHERE 없는 UPDATE를 놓칠 수 있다 (_check_dangerous_query 참고).
     DANGER_PATTERNS = [
         (r'\bDROP\s+(TABLE|DATABASE|INDEX)\b', "DROP 문은 데이터를 완전히 삭제합니다!"),
         (r'\bTRUNCATE\s+TABLE\b', "TRUNCATE는 테이블의 모든 데이터를 삭제합니다!"),
         (r'\bDELETE\s+FROM\s+\w+\s*(?:;|$)', "DELETE에 WHERE 절이 없어 전체 데이터가 삭제됩니다!"),
-        (r'\bUPDATE\s+\w+\s+SET\s+.*?(?:;|$)(?!.*WHERE)', "UPDATE에 WHERE 절이 없어 전체 데이터가 수정됩니다!"),
+        # SET절 이후 문장이 끝날 때까지(;/끝) WHERE가 한 번도 등장하지 않아야 매치된다.
+        (r'\bUPDATE\s+\w+\s+SET\s+(?:(?!\bWHERE\b|;).)*(?:;|$)', "UPDATE에 WHERE 절이 없어 전체 데이터가 수정됩니다!"),
     ]
 
     def __init__(self, parent=None, tunnel_list: List[tuple] = None,
@@ -476,19 +482,28 @@ class ScheduleEditDialog(QDialog):
         self.time_widget.setVisible(button_id != 3)  # 매시간이 아닐 때만 시간 표시
 
     def _check_dangerous_query(self):
-        """위험한 SQL 쿼리 검사"""
+        """위험한 SQL 쿼리 검사
+
+        여러 SQL 문이 세미콜론으로 이어진 경우, 통짜 텍스트에 정규식을 돌리면
+        UPDATE의 `(?!.*WHERE)` 부정 탐색이 뒤에 오는 다른 문의 WHERE까지 봐서
+        정작 WHERE 없는 UPDATE를 놓칠 수 있다. 공유 파서로 문 단위로 나눈 뒤
+        문장별로 검사한다.
+        """
         sql_text = self.sql_editor.toPlainText()
         if not sql_text.strip():
             self.sql_warning_label.hide()
             return
 
-        warnings = []
-        for pattern, message in self.DANGER_PATTERNS:
-            if re.search(pattern, sql_text, re.IGNORECASE | re.DOTALL):
-                warnings.append(f"⚠️ {message}")
+        statements = parse_sql_statements(sql_text) or [sql_text]
 
-        if warnings:
-            self.sql_warning_label.setText("\n".join(warnings))
+        messages: List[str] = []
+        for statement in statements:
+            for pattern, message in self.DANGER_PATTERNS:
+                if re.search(pattern, statement, re.IGNORECASE | re.DOTALL) and message not in messages:
+                    messages.append(message)
+
+        if messages:
+            self.sql_warning_label.setText("\n".join(f"⚠️ {m}" for m in messages))
             self.sql_warning_label.show()
         else:
             self.sql_warning_label.hide()
@@ -708,6 +723,9 @@ class ScheduleListDialog(QDialog):
     """스케줄 목록 관리 다이얼로그"""
 
     schedule_changed = pyqtSignal()
+    # BackupScheduler 콜백은 백그라운드 실행 스레드에서 호출되므로,
+    # 시그널을 거쳐 GUI 스레드로 안전하게 전달한다 (Qt Queued Connection).
+    _execution_finished = pyqtSignal(str, bool, str)
 
     def __init__(self, parent=None, scheduler: BackupScheduler = None,
                  tunnel_list: List[tuple] = None):
@@ -720,10 +738,14 @@ class ScheduleListDialog(QDialog):
         super().__init__(parent)
         self.scheduler = scheduler
         self.tunnel_list = tunnel_list or []
+        self._refreshing = False
 
         self._setup_ui()
         self._connect_signals()
         self._refresh_table()
+
+        if self.scheduler:
+            self.scheduler.add_callback(self._on_schedule_completed)
 
     def _setup_ui(self):
         """UI 구성"""
@@ -810,6 +832,9 @@ class ScheduleListDialog(QDialog):
         """시그널 연결"""
         self.table.cellDoubleClicked.connect(self._edit_schedule)
         self.table.itemSelectionChanged.connect(self._update_buttons)
+        self.table.itemChanged.connect(self._on_table_item_changed)
+        self._execution_finished.connect(self._handle_execution_finished)
+        self.finished.connect(self._on_dialog_finished)
 
     def _update_buttons(self):
         """버튼 상태 업데이트"""
@@ -819,7 +844,18 @@ class ScheduleListDialog(QDialog):
         self.run_now_btn.setEnabled(has_selection)
 
     def _refresh_table(self):
-        """테이블 새로고침"""
+        """테이블 새로고침
+
+        체크박스 아이템을 다시 세팅하는 동안 itemChanged가 발생하므로,
+        재진입 방지를 위해 _refreshing 플래그로 감싼다.
+        """
+        self._refreshing = True
+        try:
+            self._refresh_table_inner()
+        finally:
+            self._refreshing = False
+
+    def _refresh_table_inner(self):
         self.table.setRowCount(0)
 
         if not self.scheduler:
@@ -895,6 +931,50 @@ class ScheduleListDialog(QDialog):
         id_item = self.table.item(row, 6)  # 유형 컬럼 추가로 인덱스 변경
         return id_item.data(Qt.ItemDataRole.UserRole) if id_item else None
 
+    def _on_table_item_changed(self, item: QTableWidgetItem):
+        """활성화 체크박스 토글을 scheduler.set_enabled()에 반영
+
+        _refresh_table_inner()가 체크박스를 다시 세팅할 때도 itemChanged가
+        발생하므로 _refreshing 플래그로 사용자 클릭과 구분한다.
+        """
+        if self._refreshing or item.column() != 6 or not self.scheduler:
+            return
+
+        schedule_id = item.data(Qt.ItemDataRole.UserRole)
+        if not schedule_id:
+            return
+
+        enabled = item.checkState() == Qt.CheckState.Checked
+        try:
+            self.scheduler.set_enabled(schedule_id, enabled)
+            self.schedule_changed.emit()
+        except Exception as e:
+            QMessageBox.critical(self, "오류", f"스케줄 상태 변경 실패: {e}")
+
+        self._refresh_table()
+
+    def _on_schedule_completed(self, name: str, success: bool, message: str):
+        """BackupScheduler 콜백 (백그라운드 실행 스레드에서 호출)
+
+        GUI를 직접 건드리지 않고 시그널만 emit해 GUI 스레드로 넘긴다.
+        """
+        self._execution_finished.emit(name, success, message)
+
+    def _handle_execution_finished(self, name: str, success: bool, message: str):
+        """실행 완료 알림 (GUI 스레드, _execution_finished 시그널 슬롯)
+
+        run_now는 등록만 하고 비동기로 실행되므로, 실제 완료 시점에
+        목록/로그를 갱신해 최신 상태를 보여준다. 예약된(cron) 실행도
+        같은 콜백을 타므로 팝업 없이 조용히 갱신만 한다.
+        """
+        self._refresh_table()
+        self._refresh_logs()
+
+    def _on_dialog_finished(self, result: int):
+        """다이얼로그 종료 시 콜백 해제 (누수 방지)"""
+        if self.scheduler:
+            self.scheduler.remove_callback(self._on_schedule_completed)
+
     def _add_schedule(self):
         """스케줄 추가"""
         dialog = ScheduleEditDialog(self, self.tunnel_list)
@@ -967,9 +1047,12 @@ class ScheduleListDialog(QDialog):
         )
 
         if reply == QMessageBox.StandardButton.Yes:
+            # run_now는 실행 큐에 등록만 하고 즉시 반환한다 (비동기).
+            # 실제 완료 여부는 scheduler의 add_callback 통지로 이 다이얼로그가
+            # 받아 _handle_execution_finished에서 표/로그를 갱신한다.
             success, message = self.scheduler.run_now(schedule_id)
             if success:
-                QMessageBox.information(self, "실행 완료", message)
+                QMessageBox.information(self, translate_text("실행 등록됨"), message)
             else:
                 QMessageBox.warning(self, "실행 실패", message)
             self._refresh_table()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2,11 +2,19 @@
 BackupScheduler, CronParser, ScheduleConfig 단위 테스트
 """
 import os
+import sys
 import threading
 import time
 import pytest
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch, call
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QApplication
+
+app = QApplication.instance() or QApplication(sys.argv)
 
 
 # =====================================================================
@@ -1166,3 +1174,220 @@ SELECT 1;"""
         found = self.scheduler.get_schedule('disabled-001')
         # 비활성화 상태이므로 next_run이 설정되지 않음
         assert found.enabled is False
+
+
+# =====================================================================
+# ScheduleEditDialog - 위험 SQL 쿼리 검사 (문장 단위 분리, WP-3.7)
+# =====================================================================
+
+class TestScheduleEditDialogDangerousQuery:
+    """SQL 위험 쿼리 검사가 통짜 텍스트가 아니라 문장 단위로 이뤄지는지 확인"""
+
+    def _make_dialog(self):
+        from src.ui.dialogs.schedule_dialog import ScheduleEditDialog
+
+        return ScheduleEditDialog(parent=None, tunnel_list=[('t1', 'Tunnel 1')])
+
+    def test_update_without_where_flagged_even_with_later_where_statement(self):
+        """회귀 방지: 뒤 문장에 WHERE가 있으면 앞 UPDATE(WHERE 없음)를
+        안전하다고 오판하던 버그(통짜 정규식의 부정 탐색이 문장 경계를 넘어감)"""
+        dialog = self._make_dialog()
+        dialog.sql_editor.setPlainText(
+            "UPDATE users SET status='inactive'; SELECT * FROM logs WHERE id=1;"
+        )
+
+        assert not dialog.sql_warning_label.isHidden()
+        assert "UPDATE" in dialog.sql_warning_label.text()
+
+    def test_update_with_where_not_flagged(self):
+        """WHERE 절이 있는 UPDATE는 위험 경고가 없어야 한다"""
+        dialog = self._make_dialog()
+        dialog.sql_editor.setPlainText("UPDATE users SET status='inactive' WHERE id=1;")
+
+        assert dialog.sql_warning_label.isHidden()
+
+    def test_drop_table_flagged(self):
+        """DROP TABLE은 문장이 하나뿐이어도 위험 경고"""
+        dialog = self._make_dialog()
+        dialog.sql_editor.setPlainText("DROP TABLE users;")
+
+        assert not dialog.sql_warning_label.isHidden()
+        assert "DROP" in dialog.sql_warning_label.text()
+
+    def test_safe_select_not_flagged(self):
+        """WHERE 있는 SELECT는 위험 경고 없음"""
+        dialog = self._make_dialog()
+        dialog.sql_editor.setPlainText("SELECT * FROM users WHERE id=1;")
+
+        assert dialog.sql_warning_label.isHidden()
+
+    def test_duplicate_pattern_message_shown_once(self):
+        """여러 문장에서 같은 위험 패턴이 걸려도 동일 메시지는 한 번만 표시"""
+        dialog = self._make_dialog()
+        dialog.sql_editor.setPlainText("DELETE FROM logs; DELETE FROM audit;")
+
+        text = dialog.sql_warning_label.text()
+        assert text.count("DELETE") == 1
+
+    def test_empty_query_hides_warning(self):
+        """빈 쿼리는 경고를 표시하지 않는다"""
+        dialog = self._make_dialog()
+        dialog.sql_editor.setPlainText("DROP TABLE users;")
+        assert not dialog.sql_warning_label.isHidden()
+
+        dialog.sql_editor.setPlainText("")
+        assert dialog.sql_warning_label.isHidden()
+
+
+# =====================================================================
+# ScheduleListDialog - 활성화 체크박스 & 비동기 run_now 콜백 (WP-3.7)
+# =====================================================================
+
+class TestScheduleListDialogUi:
+    """체크박스 토글이 scheduler.set_enabled()에 반영되는지,
+    run_now의 비동기 완료가 콜백으로 다이얼로그에 전달되는지 확인"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        from src.core.scheduler import BackupScheduler, ScheduleConfig
+        from src.ui.dialogs.schedule_dialog import ScheduleListDialog
+
+        self.mock_config_manager = MagicMock()
+        self.mock_config_manager.get_app_setting.return_value = []
+        self.mock_engine = MagicMock()
+        self.mock_engine.is_running.return_value = True
+
+        self.scheduler = BackupScheduler(
+            config_manager=self.mock_config_manager,
+            tunnel_engine=self.mock_engine,
+        )
+        self.ScheduleConfig = ScheduleConfig
+        self.ScheduleListDialog = ScheduleListDialog
+
+    def teardown_method(self):
+        if self.scheduler.is_running():
+            self.scheduler.stop()
+
+    def _make_schedule(self, schedule_id, enabled=True):
+        return self.ScheduleConfig(
+            id=schedule_id,
+            name=f'Schedule {schedule_id}',
+            tunnel_id='t1',
+            schema='db',
+            cron_expression='0 3 * * *',
+            enabled=enabled,
+        )
+
+    def test_unchecking_checkbox_disables_schedule(self):
+        """활성화 체크박스를 해제하면 scheduler.set_enabled(False)가 반영된다"""
+        self.scheduler.add_schedule(self._make_schedule('sched-ui-1', enabled=True))
+
+        dialog = self.ScheduleListDialog(parent=None, scheduler=self.scheduler, tunnel_list=[])
+        try:
+            item = dialog.table.item(0, 6)
+            assert item is not None
+            item.setCheckState(Qt.CheckState.Unchecked)
+
+            found = self.scheduler.get_schedule('sched-ui-1')
+            assert found.enabled is False
+        finally:
+            dialog.close()
+
+    def test_checking_checkbox_enables_schedule(self):
+        """활성화 체크박스를 체크하면 scheduler.set_enabled(True)가 반영된다"""
+        self.scheduler.add_schedule(self._make_schedule('sched-ui-2', enabled=False))
+
+        dialog = self.ScheduleListDialog(parent=None, scheduler=self.scheduler, tunnel_list=[])
+        try:
+            item = dialog.table.item(0, 6)
+            item.setCheckState(Qt.CheckState.Checked)
+
+            found = self.scheduler.get_schedule('sched-ui-2')
+            assert found.enabled is True
+        finally:
+            dialog.close()
+
+    def test_table_refresh_does_not_reenter_set_enabled(self, monkeypatch):
+        """_refresh_table_inner가 체크박스를 재세팅해도 set_enabled가 재호출되면 안 된다"""
+        self.scheduler.add_schedule(self._make_schedule('sched-ui-3', enabled=True))
+
+        dialog = self.ScheduleListDialog(parent=None, scheduler=self.scheduler, tunnel_list=[])
+        try:
+            calls = []
+            original_set_enabled = self.scheduler.set_enabled
+
+            def spy(schedule_id, enabled):
+                calls.append((schedule_id, enabled))
+                return original_set_enabled(schedule_id, enabled)
+
+            monkeypatch.setattr(self.scheduler, "set_enabled", spy)
+
+            dialog._refresh_table()
+
+            assert calls == []
+        finally:
+            dialog.close()
+
+    def test_run_now_success_message_reflects_async_registration(self):
+        """run_now 성공 메시지는 '완료'가 아니라 큐 등록을 의미해야 한다"""
+        self.scheduler.add_schedule(self._make_schedule('sched-ui-4', enabled=True))
+
+        success, message = self.scheduler.run_now('sched-ui-4')
+
+        assert success is True
+        assert '등록' in message
+        self.scheduler.stop()
+
+    def test_run_now_completion_triggers_dialog_refresh_via_callback(self):
+        """run_now는 등록만 하고 비동기 실행되므로, 실제 완료는
+        scheduler의 add_callback 통지가 시그널을 거쳐 다이얼로그 갱신을 트리거해야 한다"""
+        self.scheduler.add_schedule(self._make_schedule('sched-ui-5', enabled=True))
+
+        release = threading.Event()
+
+        def fake_execute_task(sched):
+            release.wait(timeout=5)
+            return True, "완료"
+
+        self.scheduler._execute_task = fake_execute_task
+
+        dialog = self.ScheduleListDialog(parent=None, scheduler=self.scheduler, tunnel_list=[])
+        try:
+            refreshed = threading.Event()
+            original_refresh = dialog._refresh_table
+
+            def spy_refresh():
+                original_refresh()
+                refreshed.set()
+
+            dialog._refresh_table = spy_refresh
+
+            success, message = self.scheduler.run_now('sched-ui-5')
+            assert success is True
+            assert '등록' in message
+            assert not refreshed.is_set()  # 아직 완료 전이므로 갱신되지 않음
+
+            release.set()
+
+            # 백그라운드 스레드의 콜백 emit은 Qt Queued Connection으로 전달되므로
+            # GUI 스레드 이벤트 루프를 짧게 돌려줘야 슬롯이 실행된다.
+            deadline = time.time() + 5
+            while not refreshed.is_set() and time.time() < deadline:
+                QApplication.processEvents()
+                time.sleep(0.05)
+
+            assert refreshed.is_set()
+        finally:
+            release.set()
+            self.scheduler.stop()
+            dialog.close()
+
+    def test_dialog_removes_callback_on_close(self):
+        """다이얼로그가 닫히면 scheduler 콜백 등록이 해제되어야 한다 (누수 방지)"""
+        dialog = self.ScheduleListDialog(parent=None, scheduler=self.scheduler, tunnel_list=[])
+
+        assert dialog._on_schedule_completed in self.scheduler._callbacks
+
+        dialog.accept()  # "닫기" 버튼과 동일한 경로
+
+        assert dialog._on_schedule_completed not in self.scheduler._callbacks


### PR DESCRIPTION
## 요약
- ScheduleEditDialog의 SQL 위험 쿼리 검사가 통짜 텍스트에 정규식을 돌리던 방식이라, 여러 statement가 이어지면 UPDATE 부정탐색이 뒤 statement의 WHERE까지 봐서 WHERE 없는 UPDATE를 놓치는 문제가 있었음. 공유 파서(`src/core/sql_statement_parser.parse_sql_statements`)로 문장을 분리한 뒤 문장별로 검사하도록 수정. 검사 과정에서 UPDATE 패턴 자체의 lookahead 위치 오류(문장 끝 뒤가 아니라 SET절 안을 봐야 함)도 함께 수정
- ScheduleListDialog의 활성화 체크박스가 표시만 되고 토글해도 아무 동작을 하지 않던 문제를 `scheduler.set_enabled()` 호출로 연결. 테이블 리프레시가 체크박스를 다시 세팅할 때 재진입 호출되지 않도록 플래그로 방지
- Round 2에서 `scheduler.run_now()`가 비동기 큐 등록 방식으로 바뀌어 반환 메시지 의미가 "완료"에서 "등록됨"으로 변경됨. `_run_now()`의 안내 타이틀을 "실행 등록됨"으로 조정하고, `scheduler.add_callback()`으로 실제 완료 통지를 받아(백그라운드 스레드 콜백 → `pyqtSignal`로 GUI 스레드에 안전하게 전달) 목록/로그를 갱신하도록 연결. 다이얼로그 종료 시 콜백을 해제해 누수 방지

## 범위
- `src/ui/dialogs/schedule_dialog.py`, `tests/test_scheduler.py`만 수정 (scheduler.py는 Round 2에서 이미 수정되어 이번 WP 대상 아님)

## Test plan
- [x] `python -m py_compile src/ui/dialogs/schedule_dialog.py tests/test_scheduler.py`
- [x] `pytest tests/test_scheduler.py -q` → 77 passed
- [x] `pytest -q` (전체) → 2046 passed, 1 failed (알려진 macOS 검증 CI 의존 flaky 테스트, 로컬에서 항상 실패)

🤖 Generated with [Claude Code](https://claude.com/claude-code)