### PR TITLE
fix(cross-engine): 안정 issue code + 워커 상태 캡처 + 죽은 경로 제거 (WP-3.3)

### DIFF
--- a/migration_core/src/lib.rs
+++ b/migration_core/src/lib.rs
@@ -7973,6 +7973,24 @@ fn phase_event(request: &Request, phase: &str, message: &str) -> Value {
     })
 }
 
+/// Stable, machine-readable issue code for a non-empty create_only target table.
+/// The PyQt UI matches on this code (never on `message`/`location` substrings) to
+/// decide whether to offer the "clean up target before migrate" workflow.
+const ISSUE_TARGET_NOT_EMPTY: &str = "target_not_empty";
+
+fn target_not_empty_issue(location: String) -> MigrationIssue {
+    MigrationIssue {
+        issue_type: Some(ISSUE_TARGET_NOT_EMPTY.to_string()),
+        severity: "error".to_string(),
+        location,
+        message: "target table is not empty".to_string(),
+        suggestion: "Use an empty target table or run with a non-create_only mode.".to_string(),
+        blocking: true,
+        table_name: None,
+        column_name: None,
+    }
+}
+
 pub fn preflight_issues(payload: &Value) -> Vec<MigrationIssue> {
     let source = read_engine(payload, "source_engine");
     let target = read_engine(payload, "target_engine");
@@ -8046,17 +8064,7 @@ pub fn preflight_issues(payload: &Value) -> Vec<MigrationIssue> {
         if let Ok(schema) = parse_schema(&payload["schema"]) {
             for table in &schema.tables {
                 if target.row_count(&table.name) > 0 {
-                    issues.push(MigrationIssue {
-                        issue_type: None,
-                        severity: "error".to_string(),
-                        location: table.name.clone(),
-                        message: "target table is not empty".to_string(),
-                        suggestion: "Use an empty target table or run with a non-create_only mode."
-                            .to_string(),
-                        blocking: true,
-                        table_name: None,
-                        column_name: None,
-                    });
+                    issues.push(target_not_empty_issue(table.name.clone()));
                 }
             }
         }
@@ -8361,17 +8369,7 @@ fn create_only_issues_with_adapter<T: MigrationAdapter>(
     let mut issues = Vec::new();
     for table in &schema.tables {
         match target.row_count(&table.name) {
-            Ok(count) if count > 0 => issues.push(MigrationIssue {
-                issue_type: None,
-                severity: "error".to_string(),
-                location: table.name.clone(),
-                message: "target table is not empty".to_string(),
-                suggestion: "Use an empty target table or run with a non-create_only mode."
-                    .to_string(),
-                blocking: true,
-                table_name: None,
-                column_name: None,
-            }),
+            Ok(count) if count > 0 => issues.push(target_not_empty_issue(table.name.clone())),
             Err(err) => issues.push(MigrationIssue {
                 issue_type: None,
                 severity: "error".to_string(),
@@ -15073,7 +15071,10 @@ mod tests {
 
         assert!(!result.success);
         assert_eq!(result.rows_copied, 0);
-        assert!(result.issues.iter().any(|issue| issue.blocking));
+        assert!(result
+            .issues
+            .iter()
+            .any(|issue| issue.blocking && issue.issue_type.as_deref() == Some("target_not_empty")));
         assert_eq!(target.row_count("users"), 1);
     }
 
@@ -15096,7 +15097,10 @@ mod tests {
 
         assert!(!result.success);
         assert_eq!(result.rows_copied, 0);
-        assert!(result.issues.iter().any(|issue| issue.blocking));
+        assert!(result
+            .issues
+            .iter()
+            .any(|issue| issue.blocking && issue.issue_type.as_deref() == Some("target_not_empty")));
         assert_eq!(target.row_count("users"), 1);
     }
 
@@ -16503,6 +16507,30 @@ mod tests {
         assert_eq!(unsupported.severity, "warning");
         assert!(!unsupported.blocking);
         assert!(issues.iter().any(|issue| issue.location == "users_grants"));
+    }
+
+    #[test]
+    fn preflight_reports_stable_target_not_empty_issue_type_for_non_empty_target() {
+        let issues = preflight_issues(&json!({
+            "source_engine": "mysql",
+            "target_engine": "postgresql",
+            "schema": {
+                "tables": [{
+                    "name": "users",
+                    "columns": [
+                        {"name": "id", "type": "int(11)", "nullable": false, "primary_key": true}
+                    ]
+                }]
+            },
+            "execution_options": {"mode": "create_only"},
+            "target_data": {"users": [{"id": 1}]}
+        }));
+
+        let target_issue = issues
+            .iter()
+            .find(|issue| issue.location == "users" && issue.blocking)
+            .expect("expected a blocking issue for the non-empty target table");
+        assert_eq!(target_issue.issue_type.as_deref(), Some("target_not_empty"));
     }
 
     #[test]

--- a/src/ui/dialogs/cross_engine_migration_dialog.py
+++ b/src/ui/dialogs/cross_engine_migration_dialog.py
@@ -1,4 +1,5 @@
 """MySQL <-> PostgreSQL migration dialog."""
+import copy
 import json
 from typing import Any, Dict, List, Optional, cast
 
@@ -52,6 +53,8 @@ class CrossEngineMigrationDialog(QDialog):
         self._workflow_active = False
         self._current_command: Optional[str] = None
         self._pending_after_inspect: Optional[str] = None
+        self._active_payload: Optional[Dict[str, Any]] = None
+        self._active_state_key: Optional[str] = None
         self._execution_unlocked = False
         self._verify_result_received = False
         self._safety_activity_base = ""
@@ -354,12 +357,9 @@ class CrossEngineMigrationDialog(QDialog):
 
         self.btn_full_run = QPushButton("전체 실행")
         self.btn_inspect = QPushButton("스키마 검사")
-        self.btn_preflight = QPushButton("사전 점검")
-        self.btn_readiness = QPushButton("양방향 점검")
         self.btn_guide = QPushButton("상세 가이드")
         self.btn_plan = QPushButton("계획 생성")
         self.btn_run_plan = self.btn_plan
-        self.btn_migrate = QPushButton("DB 변경 실행")
         self.btn_resume = QPushButton("중단 지점부터 재개")
         self.btn_cleanup_failed = QPushButton("실패한 전환 정리")
         self.btn_verify = QPushButton("검증")
@@ -371,23 +371,14 @@ class CrossEngineMigrationDialog(QDialog):
         self.btn_previous.setObjectName("WizardBackButton")
         self.btn_next.setObjectName("WizardNextButton")
         self.btn_full_run.hide()
-        self.btn_migrate.hide()
-        self.btn_migrate.setToolTip("대상 DB에 스키마 생성과 데이터 적재를 실행합니다.")
         self.btn_resume.setToolTip("저장된 상태부터 대상 DB 변경 작업을 재개합니다.")
         self.btn_cleanup_failed.setToolTip("실패한 전환에서 생성된 Target 테이블을 정리합니다.")
         self.btn_cleanup_failed.hide()
-        self.btn_migrate.setStyleSheet(
-            "QPushButton { background-color: #b42318; color: white; font-weight: 600; }"
-            "QPushButton:disabled { background-color: #d0d5dd; color: #667085; }"
-        )
 
         self.btn_full_run.clicked.connect(self._start_full_workflow)
         self.btn_inspect.clicked.connect(lambda: self._start_command("inspect"))
-        self.btn_preflight.clicked.connect(lambda: self._start_command("preflight"))
-        self.btn_readiness.clicked.connect(lambda: self._start_command("readiness"))
         self.btn_guide.clicked.connect(lambda: self._start_command("guide"))
         self.btn_plan.clicked.connect(lambda: self._start_command("plan"))
-        self.btn_migrate.clicked.connect(lambda: self._start_command("migrate"))
         self.btn_resume.clicked.connect(self._resume_migration)
         self.btn_cleanup_failed.clicked.connect(self._cleanup_failed_migration)
         self.btn_verify.clicked.connect(lambda: self._start_command("verify"))
@@ -399,7 +390,7 @@ class CrossEngineMigrationDialog(QDialog):
         self.btn_save_report.setEnabled(False)
         self.btn_cancel.setEnabled(False)
         self.input_approval_schema.textChanged.connect(self._update_execution_state_from_approval)
-        self._update_execution_state(False)
+        self._update_execution_state()
 
         self.plan_group = QGroupBox("실행 계획 확인")
         plan_layout = QVBoxLayout(self.plan_group)
@@ -714,12 +705,8 @@ class CrossEngineMigrationDialog(QDialog):
             return False
         if issue.get("blocking") is not True:
             return False
-        location = str(issue.get("location", "")).lower()
-        message = str(issue.get("message", "")).lower()
-        text = f"{location} {message}"
-        has_target = "target" in text
-        has_non_empty = any(marker in text for marker in ("not empty", "non-empty", "existing"))
-        return has_target and has_non_empty
+        code = str(issue.get("code") or issue.get("issue_type") or "").strip()
+        return code == "target_not_empty"
 
     def _update_target_safety_from_issues(self, issues) -> bool:
         issue_list = issues if isinstance(issues, list) else []
@@ -835,14 +822,16 @@ class CrossEngineMigrationDialog(QDialog):
             if self._cleanup_plan_resolves_safety_blockers():
                 return "Target 정리를 실행 직전에 수행하도록 계획했습니다. 다음 단계로 이동할 수 있습니다."
             return "전환 가능 여부 점검이 통과되면 다음 단계로 이동할 수 있습니다."
+        if self.current_step_id == "execute":
+            if self._step_completed.get("execute", False):
+                return "DB 변경 실행이 완료되었습니다. 다음 단계로 이동할 수 있습니다."
+            if not self._approval_matches_target_schema():
+                return "Target schema 이름을 정확히 입력한 뒤 DB 변경 실행을 눌러 주세요."
+            return "DB 변경 실행 버튼을 누르면 전환이 시작됩니다."
         if self._next_enabled_for_current_step():
             return "현재 단계가 완료되었습니다. 다음 단계로 이동할 수 있습니다."
         if self.current_step_id == "plan":
             return "실행 계획 생성이 완료되면 다음 단계로 이동할 수 있습니다."
-        if self.current_step_id == "execute":
-            if not self._approval_matches_target_schema():
-                return "Target schema 이름을 정확히 입력한 뒤 DB 변경 실행을 눌러 주세요."
-            return "DB 변경 실행이 완료되면 다음 단계로 이동할 수 있습니다."
         if self.current_step_id == "verify":
             return "검증 결과를 받은 뒤 완료할 수 있습니다."
         return ""
@@ -974,6 +963,8 @@ class CrossEngineMigrationDialog(QDialog):
         self._current_command = command
         if command == "verify":
             self._verify_result_received = False
+        self._active_payload = copy.deepcopy(payload)
+        self._active_state_key = state_key_from_payload(payload)
         self._reset_command_ui(command)
         self._append_log(f"[{command}] 시작")
         self._set_running(True)
@@ -990,16 +981,20 @@ class CrossEngineMigrationDialog(QDialog):
         self.worker.start()
 
     def _save_checkpoint(self, state: Dict):
-        key = state_key_from_payload(self._payload())
-        self._last_checkpoint_path = save_resume_state(key, state)
+        if not self._active_state_key:
+            self._append_log("재개 상태 저장 실패: 활성 작업 상태 키가 없습니다.")
+            return
+        self._last_checkpoint_path = save_resume_state(self._active_state_key, state)
 
     def _on_result(self, payload: Dict):
         self.last_result = payload
         self.btn_save_report.setEnabled(True)
         if payload.get("command") == "migrate" and isinstance(payload.get("state"), dict):
-            key = state_key_from_payload(self._payload())
-            path = save_resume_state(key, payload["state"])
-            self._append_log(f"재개 상태 저장: {path}")
+            if self._active_state_key:
+                path = save_resume_state(self._active_state_key, payload["state"])
+                self._append_log(f"재개 상태 저장: {path}")
+            else:
+                self._append_log("재개 상태 저장 실패: 활성 작업 상태 키가 없습니다.")
         schema = schema_from_inspect_result(payload)
         if schema is not None:
             self.txt_schema.setPlainText(json.dumps(schema, ensure_ascii=False, indent=2))
@@ -1049,11 +1044,6 @@ class CrossEngineMigrationDialog(QDialog):
             self._append_log(json.dumps(payload, ensure_ascii=False, indent=2))
         self._refresh_navigation_state()
 
-        if payload.get("command") == "inspect" and payload.get("success") and self._pending_after_inspect:
-            next_command = self._pending_after_inspect
-            self._pending_after_inspect = None
-            QTimer.singleShot(0, lambda: self._start_command(next_command, workflow=self._workflow_active))
-
     def _append_readiness_summary(self, payload: Dict):
         selected = self._selected_direction_result(payload)
         if not selected:
@@ -1095,6 +1085,13 @@ class CrossEngineMigrationDialog(QDialog):
             return
         self.worker = None
         self._set_running(False)
+        if finished_command == "inspect" and success and self._pending_after_inspect:
+            next_command = self._pending_after_inspect
+            pending_workflow = self._workflow_active
+            self._pending_after_inspect = None
+            self._append_log(f"[inspect] 완료 후 {next_command} 실행")
+            self._start_command(next_command, workflow=pending_workflow)
+            return
         if finished_command == "preflight":
             self._finish_safety_activity(success)
         if finished_command == "plan" and not success:
@@ -1109,13 +1106,6 @@ class CrossEngineMigrationDialog(QDialog):
                 self.lbl_migration_result.setText("DB 변경 실패: Rust Core가 상세 실패 원인을 반환하지 않았습니다.")
                 self.lbl_migration_result.show()
                 self.btn_cleanup_failed.show()
-        if finished_command == "cleanup" and success:
-            self.btn_cleanup_failed.hide()
-            self.lbl_migration_result.setText("실패한 전환 정리가 완료되었습니다. 전환 가능 여부 점검을 다시 실행하세요.")
-            self.lbl_migration_result.show()
-            self.lbl_safety_summary.setText("Target 정리 완료: 전환 가능 여부 점검을 다시 실행하세요.")
-            self.lbl_target_safety.setText("Target 정리가 완료되었습니다. 다시 점검해 빈 Target 상태를 확인하세요.")
-            self._append_safety_log("Target 정리 완료")
         self._append_log("완료" if success else "실패")
         if self._workflow_active and finished_command:
             next_command = next_workflow_command(finished_command, success)
@@ -1124,8 +1114,6 @@ class CrossEngineMigrationDialog(QDialog):
             else:
                 self._workflow_active = False
                 self._current_command = None
-        elif finished_command == "cleanup":
-            self._current_command = None
         self._refresh_navigation_state()
 
     def _wait_for_worker_finish(self) -> bool:
@@ -1213,35 +1201,40 @@ class CrossEngineMigrationDialog(QDialog):
             self.btn_full_run,
             self.btn_auto_inspect,
             self.btn_inspect,
-            self.btn_preflight,
-            self.btn_readiness,
             self.btn_run_safety,
             self.btn_guide,
             self.btn_plan,
-            self.btn_migrate,
             self.btn_resume,
             self.btn_cleanup_failed,
             self.btn_verify,
             self.btn_close,
         ):
             button.setEnabled(not running)
-        self._update_execution_state(running)
+        self._set_input_controls_enabled(not running)
+        self._update_execution_state()
         self.btn_cancel.setEnabled(running)
         if hasattr(self, "btn_previous"):
             self.btn_previous.setEnabled((not running) and self._current_step_index() > 0)
         if hasattr(self, "btn_next"):
             self.btn_next.setEnabled((not running) and self._next_enabled_for_current_step())
 
+    def _set_input_controls_enabled(self, enabled: bool):
+        self.source_form.set_inputs_enabled(enabled)
+        self.target_form.set_inputs_enabled(enabled)
+        self.txt_schema.setEnabled(enabled)
+        self.btn_load_schema.setEnabled(enabled)
+        self.chk_show_schema_json.setEnabled(enabled)
+        self.chk_create_only.setEnabled(enabled)
+        self.spin_chunk_size.setEnabled(enabled)
+        self.spin_guide_row_limit.setEnabled(enabled)
+        self.chk_cleanup_before_migrate.setEnabled(enabled)
+        self.input_approval_schema.setEnabled(enabled)
+
     def _set_execution_unlocked(self, unlocked: bool):
         self._execution_unlocked = unlocked
-        running = bool(self.worker and self.worker.isRunning())
-        self._update_execution_state(running)
+        self._update_execution_state()
 
-    def _update_execution_state(self, running: bool):
-        approved = self._approval_matches_target_schema() if hasattr(self, "input_approval_schema") else True
-        can_execute = (not running) and self._execution_unlocked and approved
-        if hasattr(self, "btn_migrate"):
-            self.btn_migrate.setEnabled(can_execute)
+    def _update_execution_state(self):
         if hasattr(self, "lbl_execution_lock"):
             if self._execution_unlocked:
                 self.lbl_execution_lock.setText(
@@ -1265,9 +1258,8 @@ class CrossEngineMigrationDialog(QDialog):
         return self.input_approval_schema.text().strip() == self._target_approval_schema()
 
     def _update_execution_state_from_approval(self):
-        self._update_execution_state(bool(self.worker and self.worker.isRunning()))
-        if hasattr(self, "btn_next"):
-            self.btn_next.setEnabled(self._next_enabled_for_current_step())
+        self._update_execution_state()
+        self._refresh_navigation_state()
 
     def _on_phase_changed(self, phase: str, message: str):
         self.lbl_execution_phase.setText(message or phase)
@@ -1311,8 +1303,8 @@ class CrossEngineMigrationDialog(QDialog):
         self._append_log(f"[rows:{table}] {rows}/{total if total is not None else '?'}")
 
     def _reset_command_ui(self, command: str):
-        if command in ("migrate", "cleanup"):
-            self.lbl_execution_phase.setText("DB 변경 준비 중" if command == "migrate" else "정리 준비 중")
+        if command == "migrate":
+            self.lbl_execution_phase.setText("DB 변경 준비 중")
             self.lbl_current_table.setText("현재 테이블: -")
             self.lbl_current_rows.setText("현재 rows: -")
             self.lbl_migration_result.clear()
@@ -1729,6 +1721,26 @@ class EndpointForm(QGroupBox):
         self.input_user.setReadOnly(True)
         self.input_password.setReadOnly(True)
         self.input_database.setReadOnly(True)
+
+    def set_inputs_enabled(self, enabled: bool):
+        """Lock/unlock the mutable inputs while a worker is running.
+
+        `combo_engine` is intentionally excluded: it stays permanently disabled
+        (auto-detected from the tunnel). For tunnel-only forms, host/port/user/
+        password/database are already read-only/disabled via
+        `_apply_tunnel_only_state` and must stay that way even after
+        re-enabling; only `combo_tunnel` and `input_schema` are interactive.
+        """
+        self.combo_tunnel.setEnabled(enabled)
+        if self.require_tunnel:
+            self.input_schema.setEnabled(enabled)
+        else:
+            self.input_host.setEnabled(enabled)
+            self.input_port.setEnabled(enabled)
+            self.input_user.setEnabled(enabled)
+            self.input_password.setEnabled(enabled)
+            self.input_database.setEnabled(enabled)
+            self.input_schema.setEnabled(enabled)
 
     def _prepare_selected_tunnel(self):
         data = self.combo_tunnel.currentData()

--- a/tests/test_cross_engine_migration_dialog.py
+++ b/tests/test_cross_engine_migration_dialog.py
@@ -174,7 +174,6 @@ def test_dialog_initial_button_states_and_running_toggle():
     try:
         assert not dialog.btn_save_report.isEnabled()
         assert not dialog.btn_cancel.isEnabled()
-        assert not dialog.btn_migrate.isEnabled()
         assert not dialog.btn_full_run.isVisible()
         assert not dialog.source_form.combo_engine.isEnabled()
         assert not dialog.target_form.combo_engine.isEnabled()
@@ -188,20 +187,51 @@ def test_dialog_initial_button_states_and_running_toggle():
         dialog._set_running(True)
 
         assert not dialog.btn_inspect.isEnabled()
-        assert not dialog.btn_preflight.isEnabled()
         assert not dialog.btn_plan.isEnabled()
-        assert not dialog.btn_migrate.isEnabled()
         assert dialog.btn_cancel.isEnabled()
         assert not dialog.btn_next.isEnabled()
 
         dialog._set_running(False)
 
         assert dialog.btn_inspect.isEnabled()
-        assert dialog.btn_preflight.isEnabled()
         assert dialog.btn_plan.isEnabled()
-        assert not dialog.btn_migrate.isEnabled()
         assert not dialog.btn_cancel.isEnabled()
         assert dialog.btn_next.isEnabled()
+    finally:
+        dialog.close()
+
+
+def test_set_running_locks_and_unlocks_mutable_input_controls():
+    dialog = make_dialog()
+    try:
+        assert dialog.source_form.combo_tunnel.isEnabled()
+        assert dialog.source_form.input_schema.isEnabled()
+        assert dialog.txt_schema.isEnabled()
+        assert dialog.input_approval_schema.isEnabled()
+
+        dialog._set_running(True)
+
+        assert not dialog.source_form.combo_tunnel.isEnabled()
+        assert not dialog.source_form.input_schema.isEnabled()
+        assert not dialog.target_form.combo_tunnel.isEnabled()
+        assert not dialog.txt_schema.isEnabled()
+        assert not dialog.chk_show_schema_json.isEnabled()
+        assert not dialog.input_approval_schema.isEnabled()
+        # Tunnel-only endpoint fields keep their locked state either way;
+        # combo_engine is permanently disabled regardless of running state.
+        assert dialog.source_form.input_host.isReadOnly()
+        assert not dialog.source_form.input_port.isEnabled()
+        assert not dialog.source_form.combo_engine.isEnabled()
+
+        dialog._set_running(False)
+
+        assert dialog.source_form.combo_tunnel.isEnabled()
+        assert dialog.source_form.input_schema.isEnabled()
+        assert dialog.txt_schema.isEnabled()
+        assert dialog.input_approval_schema.isEnabled()
+        assert dialog.source_form.input_host.isReadOnly()
+        assert not dialog.source_form.input_port.isEnabled()
+        assert not dialog.source_form.combo_engine.isEnabled()
     finally:
         dialog.close()
 
@@ -268,7 +298,6 @@ def test_wizard_next_requires_current_step_completion():
 
         dialog._show_step("execute")
         dialog.input_approval_schema.setText("target_db")
-        assert dialog.btn_migrate.isEnabled()
         assert dialog.btn_next.isEnabled()
         assert dialog.btn_next.text() == "DB 변경 실행"
 
@@ -714,10 +743,6 @@ def test_empty_schema_runs_inspect_before_requested_plan(monkeypatch):
     }
 
     monkeypatch.setattr(
-        "src.ui.dialogs.cross_engine_migration_dialog.QTimer.singleShot",
-        lambda _msec, callback: callback(),
-    )
-    monkeypatch.setattr(
         dialog,
         "_start_command_with_payload",
         lambda command, payload, workflow=False: started.append((command, payload, workflow)),
@@ -735,9 +760,17 @@ def test_empty_schema_runs_inspect_before_requested_plan(monkeypatch):
             "schema": schema,
         })
 
+        # The pending command must not be dispatched from _on_result anymore.
+        assert len(started) == 1
+        assert dialog._pending_after_inspect == "plan"
+        assert "Rust Core 검사 완료" in dialog.lbl_schema_status.text()
+
+        dialog._current_command = "inspect"
+        dialog._on_finished(True, {"command": "inspect", "success": True, "schema": schema})
+
         assert started[1][0] == "plan"
         assert started[1][1]["schema"] == schema
-        assert "Rust Core 검사 완료" in dialog.lbl_schema_status.text()
+        assert dialog._pending_after_inspect is None
     finally:
         dialog.close()
 
@@ -756,8 +789,13 @@ def test_migrate_result_saves_resume_state(monkeypatch, tmp_path):
     )
 
     dialog = make_dialog()
+    dialog._active_state_key = "cached-worker-start-key"
     state = {"tables": [{"table": "users", "completed": False, "rows_copied": 5000}]}
     try:
+        # Live UI is mutated to an invalid schema after the worker started; the
+        # migrate-result save must use the cached key, not recompute _payload().
+        dialog.txt_schema.setPlainText("not valid json")
+
         dialog._on_result({
             "event": "result",
             "command": "migrate",
@@ -766,8 +804,94 @@ def test_migrate_result_saves_resume_state(monkeypatch, tmp_path):
         })
 
         assert saved["state"] == state
-        assert saved["key"]
+        assert saved["key"] == "cached-worker-start-key"
         assert "재개 상태 저장" in dialog.txt_log.toPlainText()
+    finally:
+        dialog.close()
+
+
+def test_on_result_migrate_without_cached_state_key_logs_failure_and_skips_save(monkeypatch):
+    saved = []
+    monkeypatch.setattr(
+        "src.ui.dialogs.cross_engine_migration_dialog.save_resume_state",
+        lambda key, state: saved.append((key, state)),
+    )
+
+    dialog = make_dialog()
+    try:
+        dialog._on_result({
+            "event": "result",
+            "command": "migrate",
+            "success": False,
+            "state": {"tables": []},
+        })
+
+        assert saved == []
+        assert "재개 상태 저장 실패" in dialog.txt_log.toPlainText()
+    finally:
+        dialog.close()
+
+
+class _NoOpSignal:
+    """Stand-in for a pyqtSignal that just swallows connect() calls."""
+
+    def connect(self, *args, **kwargs):
+        pass
+
+
+class FakeCrossEngineMigrationWorker:
+    """Non-blocking stand-in for CrossEngineMigrationWorker.
+
+    Never spawns a real QThread/subprocess so tests can exercise
+    `_start_command_with_payload` without hanging on tunnelforge-core.
+    """
+
+    def __init__(self, command, payload):
+        self.command = command
+        self.payload = payload
+        self.phase_changed = _NoOpSignal()
+        self.table_progress = _NoOpSignal()
+        self.row_progress = _NoOpSignal()
+        self.checkpoint = _NoOpSignal()
+        self.issue = _NoOpSignal()
+        self.log_message = _NoOpSignal()
+        self.failed = _NoOpSignal()
+        self.result = _NoOpSignal()
+        self.finished = _NoOpSignal()
+
+    def start(self):
+        pass
+
+    def isRunning(self):
+        return False
+
+
+def test_start_command_with_payload_caches_worker_start_state_key_for_checkpoint(monkeypatch):
+    monkeypatch.setattr(
+        "src.ui.dialogs.cross_engine_migration_dialog.CrossEngineMigrationWorker",
+        FakeCrossEngineMigrationWorker,
+    )
+    saved = {}
+    monkeypatch.setattr(
+        "src.ui.dialogs.cross_engine_migration_dialog.save_resume_state",
+        lambda key, state: saved.update(key=key, state=state),
+    )
+
+    dialog = make_dialog()
+    try:
+        payload = dialog._payload(prepare_tunnels=False)
+        dialog._start_command_with_payload("migrate", payload)
+
+        original_key = dialog._active_state_key
+        assert original_key
+
+        # Mutate live UI to invalid JSON after the worker has started; the
+        # checkpoint save must use the cached key, not recompute _payload().
+        dialog.txt_schema.setPlainText("not valid json")
+
+        dialog._save_checkpoint({"tables": []})
+
+        assert saved["key"] == original_key
     finally:
         dialog.close()
 
@@ -966,16 +1090,15 @@ def test_execute_requires_exact_target_schema_text_before_migrate(monkeypatch):
     try:
         dialog._show_step("execute")
 
-        assert not dialog.btn_migrate.isEnabled()
         assert not dialog.btn_next.isEnabled()
 
         dialog.input_approval_schema.setText("wrong")
 
-        assert not dialog.btn_migrate.isEnabled()
+        assert not dialog.btn_next.isEnabled()
 
         dialog.input_approval_schema.setText("target_db")
 
-        assert dialog.btn_migrate.isEnabled()
+        assert dialog.btn_next.isEnabled()
         dialog._start_command("migrate")
 
         assert started
@@ -994,12 +1117,10 @@ def test_execute_approval_uses_public_when_postgresql_target_schema_blank():
 
         dialog.input_approval_schema.setText("postgres")
 
-        assert not dialog.btn_migrate.isEnabled()
         assert not dialog.btn_next.isEnabled()
 
         dialog.input_approval_schema.setText("public")
 
-        assert dialog.btn_migrate.isEnabled()
         assert dialog.btn_next.isEnabled()
         assert dialog.btn_next.text() == "DB 변경 실행"
     finally:
@@ -1018,14 +1139,12 @@ def test_execute_approval_invalidates_when_target_schema_changes():
         })
         dialog.input_approval_schema.setText("target_db")
 
-        assert dialog.btn_migrate.isEnabled()
         assert dialog.btn_next.isEnabled()
         assert dialog.btn_next.text() == "DB 변경 실행"
 
         dialog.target_form.input_schema.setText("changed_target")
 
         assert not dialog._approval_matches_target_schema()
-        assert not dialog.btn_migrate.isEnabled()
         assert not dialog.btn_next.isEnabled()
     finally:
         dialog.close()
@@ -1134,7 +1253,8 @@ def test_verify_progress_updates_status_panel():
 def test_db_change_unlocks_after_preflight_success_and_locks_on_input_change():
     dialog = make_dialog()
     try:
-        assert not dialog.btn_migrate.isEnabled()
+        dialog._show_step("execute")
+        assert not dialog.btn_next.isEnabled()
 
         dialog._on_result({
             "event": "result",
@@ -1143,16 +1263,16 @@ def test_db_change_unlocks_after_preflight_success_and_locks_on_input_change():
             "issues": [],
         })
 
-        assert not dialog.btn_migrate.isEnabled()
+        assert not dialog.btn_next.isEnabled()
         assert "Target schema 이름 입력 후" in dialog.lbl_execution_lock.text()
 
         dialog.input_approval_schema.setText("target_db")
 
-        assert dialog.btn_migrate.isEnabled()
+        assert dialog.btn_next.isEnabled()
 
         dialog.source_form.input_database.setText("changed_schema")
 
-        assert not dialog.btn_migrate.isEnabled()
+        assert not dialog.btn_next.isEnabled()
         assert "사전 점검 또는 계획 생성 성공 후" in dialog.lbl_execution_lock.text()
     finally:
         dialog.close()
@@ -1161,6 +1281,7 @@ def test_db_change_unlocks_after_preflight_success_and_locks_on_input_change():
 def test_plan_failure_keeps_db_change_locked():
     dialog = make_dialog()
     try:
+        dialog._show_step("execute")
         dialog._on_result({
             "event": "result",
             "command": "plan",
@@ -1168,7 +1289,7 @@ def test_plan_failure_keeps_db_change_locked():
             "issues": [{"blocking": True}],
         })
 
-        assert not dialog.btn_migrate.isEnabled()
+        assert not dialog.btn_next.isEnabled()
         assert "차단 이슈가 있어" in dialog.txt_log.toPlainText()
     finally:
         dialog.close()
@@ -1385,13 +1506,13 @@ def test_preflight_blocks_execution_when_target_is_not_empty():
                 {
                     "severity": "error",
                     "location": "target.public",
-                    "message": "target schema is not empty",
+                    "issue_type": "target_not_empty",
+                    "message": "대상 스키마에 12개 테이블이 있습니다",
                     "blocking": True,
                 }
             ],
         })
 
-        assert not dialog.btn_migrate.isEnabled()
         assert "점검 실패" in dialog.lbl_safety_summary.text()
         assert "차단 이슈 1개" in dialog.lbl_safety_summary.text()
         assert "아직 전환 가능 여부를 점검하지 않았습니다" not in dialog.lbl_safety_summary.text()
@@ -1401,9 +1522,34 @@ def test_preflight_blocks_execution_when_target_is_not_empty():
         dialog.close()
 
 
+def test_preflight_target_message_without_stable_issue_type_does_not_unlock_cleanup():
+    dialog = make_dialog()
+    try:
+        dialog._on_result({
+            "event": "result",
+            "command": "preflight",
+            "success": False,
+            "issues": [
+                {
+                    "severity": "error",
+                    "location": "target.public",
+                    "message": "target schema is not empty",
+                    "blocking": True,
+                }
+            ],
+        })
+
+        assert "점검 실패" in dialog.lbl_safety_summary.text()
+        assert not dialog.btn_target_advanced.isVisible()
+        assert "기존 테이블 또는 데이터 차단 이슈가 없습니다" in dialog.lbl_target_safety.text()
+    finally:
+        dialog.close()
+
+
 def test_preflight_success_with_nonblocking_target_warning_unlocks_execution():
     dialog = make_dialog()
     try:
+        dialog._show_step("execute")
         dialog._on_result({
             "event": "result",
             "command": "preflight",
@@ -1418,10 +1564,10 @@ def test_preflight_success_with_nonblocking_target_warning_unlocks_execution():
             ],
         })
 
-        assert not dialog.btn_migrate.isEnabled()
+        assert not dialog.btn_next.isEnabled()
         dialog.input_approval_schema.setText("target_db")
 
-        assert dialog.btn_migrate.isEnabled()
+        assert dialog.btn_next.isEnabled()
         assert "점검 통과" in dialog.lbl_safety_summary.text()
         assert "경고 1개" in dialog.lbl_safety_summary.text()
         assert "기존 테이블 또는 데이터 차단 이슈가 없습니다" in dialog.lbl_target_safety.text()
@@ -1443,6 +1589,7 @@ def test_target_advanced_button_expands_inline_without_leaving_safety_step():
                 {
                     "severity": "error",
                     "location": "target.public",
+                    "issue_type": "target_not_empty",
                     "message": "target schema is not empty",
                     "blocking": True,
                 }
@@ -1484,6 +1631,7 @@ def test_safety_advanced_cleanup_is_planned_not_executed(monkeypatch):
                 {
                     "severity": "error",
                     "location": "target.public",
+                    "issue_type": "target_not_empty",
                     "message": "target schema is not empty",
                     "blocking": True,
                 }
@@ -1561,7 +1709,7 @@ def test_execute_step_uses_bottom_next_button_as_db_change_cta(monkeypatch):
         dialog._set_execution_unlocked(True)
         dialog._show_step("execute")
 
-        assert not dialog.btn_migrate.isVisible()
+        assert not hasattr(dialog, "btn_migrate")
         assert dialog.btn_next.text() == "DB 변경 실행"
         assert not dialog.btn_next.isEnabled()
 
@@ -1572,6 +1720,19 @@ def test_execute_step_uses_bottom_next_button_as_db_change_cta(monkeypatch):
 
         assert started[0][0] == "migrate"
         assert dialog.current_step_id == "execute"
+    finally:
+        dialog.close()
+
+
+def test_execute_step_hint_prompts_execution_not_generic_next_step():
+    dialog = make_dialog()
+    try:
+        dialog._set_execution_unlocked(True)
+        dialog._show_step("execute")
+        dialog.input_approval_schema.setText("target_db")
+
+        assert dialog.btn_next.text() == "DB 변경 실행"
+        assert dialog.lbl_next_hint.text() == "DB 변경 실행 버튼을 누르면 전환이 시작됩니다."
     finally:
         dialog.close()
 
@@ -1642,10 +1803,9 @@ def test_safety_step_exposes_only_primary_preflight_action_by_default():
         assert all("양방향" not in text for text in visible_button_texts)
         assert dialog.btn_run_safety.isVisible()
         assert_widget_reachable(dialog.btn_run_safety, dialog)
-        assert not dialog.btn_readiness.isVisible()
-        assert dialog.btn_readiness.parentWidget() is None
-        assert not dialog.btn_preflight.isVisible()
-        assert dialog.btn_preflight.parentWidget() is None
+        assert not hasattr(dialog, "btn_readiness")
+        assert not hasattr(dialog, "btn_preflight")
+        assert not hasattr(dialog, "btn_migrate")
     finally:
         dialog.close()
 

--- a/tests/test_cross_engine_migration_protocol.py
+++ b/tests/test_cross_engine_migration_protocol.py
@@ -61,6 +61,22 @@ def test_parse_issue_event():
     assert event.issue.location == "direction"
 
 
+def test_parse_issue_event_preserves_stable_issue_type_in_raw_payload():
+    event = parse_helper_event(json.dumps({
+        "event": "issue",
+        "issue": {
+            "issue_type": "target_not_empty",
+            "severity": "error",
+            "location": "target.public",
+            "message": "대상 스키마에 12개 테이블이 있습니다",
+            "blocking": True,
+        },
+    }))
+    assert event.payload["issue"]["issue_type"] == "target_not_empty"
+    assert event.issue is not None
+    assert event.issue.blocking is True
+
+
 def test_parse_result_event_keeps_payload():
     event = parse_helper_event('{"event":"result","success":true,"plan":{"ddl":[]}}')
     assert event.event == "result"


### PR DESCRIPTION
## Summary

- `_is_target_non_empty_issue`가 영어 message/location substring 매칭 대신 Rust가 내려주는 안정적인 `issue_type == "target_not_empty"` 코드로만 target-not-empty 여부를 판정하도록 변경. Rust `preflight_issues`/`create_only_issues_with_adapter`가 이 코드를 실제로 채우도록 `target_not_empty_issue()` 헬퍼를 도입.
- Execute 단계 다음-힌트(`_next_hint_text`)가 실행 대기 상태에서도 일반적인 "다음 단계로 이동" 문구를 먼저 매칭해버리던 순서 버그를 고쳐, DB 변경 실행 버튼을 누르면 전환이 시작된다는 문구를 정확히 보여주도록 수정. 승인 스키마 입력 변경 시 힌트가 갱신되지 않던 부수 결함도 함께 수정.
- 워커 시작 시점의 payload/상태 키(`_active_payload`/`_active_state_key`)를 캐시해, 체크포인트 저장(`_save_checkpoint`)과 migrate 결과 상태 저장이 워커 실행 중 UI 입력이 바뀌어도 흔들리지 않게 함.
- 워커 실행 중에는 연결 폼/스키마/승인 입력 등 입력 컨트롤을 잠그는 `_set_input_controls_enabled`/`EndpointForm.set_inputs_enabled`를 추가.
- Pending inspect 체이닝을 `_on_result`의 `QTimer.singleShot` 경합 지점에서 `_on_finished`(워커 정리 이후)로 이동해 안전하게 처리.
- 절대 도달하지 않는 `cleanup` 커맨드 분기(`_on_finished`, `_reset_command_ui`)와 숨겨진 orphan 버튼(`btn_preflight`, `btn_readiness`, `btn_migrate`)을 제거.

## Test plan

- [x] `py_compile` (3개 대상 Python 파일)
- [x] `pytest tests/test_cross_engine_migration_dialog.py tests/test_cross_engine_migration_protocol.py` — 82 passed
- [x] `cargo test --manifest-path migration_core/Cargo.toml` — 216 passed (신규 issue_type 테스트 포함)
- [x] `cargo build --manifest-path migration_core/Cargo.toml --release` — 성공
- [x] 전체 `pytest` — 2040 passed, 1 failed (macOS GitHub-CI 전용 flaky 테스트, WP-3.3과 무관, 기존에도 로컬에서 항상 실패)

🤖 Generated with [Claude Code](https://claude.com/claude-code)