### PR TITLE
fix(github-reporter): auth 실패 감지 후 헤더 refresh + 재시도 (WP-3.10)

### DIFF
--- a/src/core/github_issue_reporter.py
+++ b/src/core/github_issue_reporter.py
@@ -38,6 +38,7 @@ class GitHubIssueReporter:
         self.token = token
         self.repo = repo
         self._github_app = None  # GitHub App 인스턴스 (동적 토큰 갱신용)
+        self._last_error_status: Optional[int] = None  # 마지막 API 실패의 HTTP status (재시도 판단용)
 
         if headers:
             self._headers = headers
@@ -302,6 +303,7 @@ class GitHubIssueReporter:
             return None
 
         except requests.RequestException as e:
+            self._last_error_status = self._extract_status_code(e)
             print(f"GitHub API 오류 (이슈 검색): {e}")
             return None
 
@@ -348,6 +350,7 @@ class GitHubIssueReporter:
             return True, f"이슈 #{issue_number} 생성됨: {issue_url}", issue_number
 
         except requests.RequestException as e:
+            self._last_error_status = self._extract_status_code(e)
             error_msg = str(e)
             if hasattr(e, 'response') and e.response is not None:
                 try:
@@ -400,13 +403,19 @@ class GitHubIssueReporter:
             return True, f"이슈 #{issue_number}에 코멘트 추가됨"
 
         except requests.RequestException as e:
+            self._last_error_status = self._extract_status_code(e)
             return False, f"코멘트 추가 실패: {str(e)}"
+
+    @staticmethod
+    def _extract_status_code(exc: Exception) -> Optional[int]:
+        """예외에서 HTTP status code 추출 (response가 없으면 None)"""
+        if hasattr(exc, 'response') and exc.response is not None:
+            return getattr(exc.response, 'status_code', None)
+        return None
 
     def _is_auth_error(self, exc: Exception) -> bool:
         """401/403 인증 오류인지 확인"""
-        if hasattr(exc, 'response') and exc.response is not None:
-            return exc.response.status_code in (401, 403)
-        return False
+        return self._extract_status_code(exc) in (401, 403)
 
     def report_error(self, error_type: str, error_message: str,
                      context: Optional[Dict] = None) -> Tuple[bool, str]:
@@ -417,6 +426,11 @@ class GitHubIssueReporter:
         2. 유사 이슈 검색
         3. 없으면 생성, 있으면 코멘트 추가
         4. 401/403 시 토큰 갱신 후 1회 재시도
+
+        주의: find_similar_issue/create_issue/add_comment는 모두 RequestException을
+        내부에서 잡아 (False, msg) 형태의 반환값으로 바꾸므로, 여기서 RequestException을
+        캐치하는 경로는 정상적으로는 도달하지 않는다. 따라서 auth 실패 감지는 각 메서드가
+        기록한 self._last_error_status(반환된 status)를 검사해서 판단한다.
 
         Args:
             error_type: "export" 또는 "import"
@@ -434,9 +448,20 @@ class GitHubIssueReporter:
             return False, "GitHub App이 설정되지 않았습니다"
 
         try:
-            return self._do_report(error_type, error_message, context)
+            self._last_error_status = None
+            success, msg = self._do_report(error_type, error_message, context)
+
+            if not success and self._github_app and self._last_error_status in (401, 403):
+                try:
+                    self._refresh_headers_if_needed(force=True)
+                    self._last_error_status = None
+                    return self._do_report(error_type, error_message, context)
+                except Exception as retry_e:
+                    return False, f"토큰 갱신 후 재시도 실패: {str(retry_e)}"
+
+            return success, msg
         except requests.RequestException as e:
-            # 401/403 인증 오류 시 토큰 갱신 후 1회 재시도
+            # 안전망: 향후 변경으로 예외가 실제로 전파되는 경우를 대비
             if self._github_app and self._is_auth_error(e):
                 try:
                     self._refresh_headers_if_needed(force=True)

--- a/tests/test_github_issue_reporter.py
+++ b/tests/test_github_issue_reporter.py
@@ -581,6 +581,111 @@ class TestReportError:
 
 
 # ============================================================
+# 401/403 인증 실패 후 헤더 refresh + 1회 재시도 (report_error)
+#
+# find_similar_issue/create_issue/add_comment는 RequestException을 내부에서
+# 잡아 반환값으로 바꾸므로, report_error의 except RequestException 경로는
+# 도달하지 않는다. 대신 각 메서드가 기록하는 self._last_error_status(반환된
+# status)로 auth 실패를 감지해 재시도해야 한다.
+# ============================================================
+
+class TestReportErrorAuthRetry:
+
+    def test_retries_after_auth_failure_via_returned_status(self, reporter_with_app):
+        import requests as real_requests
+
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = []  # 유사 이슈 없음
+
+        error_response = MagicMock()
+        error_response.status_code = 401
+        auth_error = real_requests.HTTPError(response=error_response)
+
+        success_response = MagicMock()
+        success_response.json.return_value = {
+            'number': 5,
+            'html_url': 'https://github.com/owner/repo/issues/5'
+        }
+
+        with patch('src.core.github_issue_reporter.HAS_REQUESTS', True), \
+             patch('src.core.github_issue_reporter.requests') as mock_requests:
+            mock_requests.RequestException = real_requests.RequestException
+            mock_requests.get.return_value = mock_get_response
+            mock_requests.post.side_effect = [auth_error, success_response]
+
+            ok, msg = reporter_with_app.report_error("export", "ERROR 1045: Access denied")
+
+        assert ok is True
+        assert '#5' in msg
+        assert mock_requests.post.call_count == 2
+        reporter_with_app._github_app.get_installation_token.assert_called_with(force_refresh=True)
+
+    def test_no_retry_without_github_app(self, reporter):
+        import requests as real_requests
+
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = []
+
+        error_response = MagicMock()
+        error_response.status_code = 401
+        auth_error = real_requests.HTTPError(response=error_response)
+
+        with patch('src.core.github_issue_reporter.HAS_REQUESTS', True), \
+             patch('src.core.github_issue_reporter.requests') as mock_requests:
+            mock_requests.RequestException = real_requests.RequestException
+            mock_requests.get.return_value = mock_get_response
+            mock_requests.post.side_effect = auth_error
+
+            ok, msg = reporter.report_error("export", "some error")
+
+        assert ok is False
+        assert mock_requests.post.call_count == 1
+
+    def test_no_retry_on_non_auth_failure(self, reporter_with_app):
+        import requests as real_requests
+
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = []
+
+        error_response = MagicMock()
+        error_response.status_code = 500
+        server_error = real_requests.HTTPError(response=error_response)
+
+        with patch('src.core.github_issue_reporter.HAS_REQUESTS', True), \
+             patch('src.core.github_issue_reporter.requests') as mock_requests:
+            mock_requests.RequestException = real_requests.RequestException
+            mock_requests.get.return_value = mock_get_response
+            mock_requests.post.side_effect = server_error
+
+            ok, msg = reporter_with_app.report_error("export", "some error")
+
+        assert ok is False
+        assert mock_requests.post.call_count == 1
+
+    def test_retry_failure_after_refresh_reports_message(self, reporter_with_app):
+        import requests as real_requests
+
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = []
+
+        error_response = MagicMock()
+        error_response.status_code = 401
+        auth_error = real_requests.HTTPError(response=error_response)
+
+        with patch('src.core.github_issue_reporter.HAS_REQUESTS', True), \
+             patch('src.core.github_issue_reporter.requests') as mock_requests:
+            mock_requests.RequestException = real_requests.RequestException
+            mock_requests.get.return_value = mock_get_response
+            # 재시도 후에도 계속 401
+            mock_requests.post.side_effect = [auth_error, auth_error]
+
+            ok, msg = reporter_with_app.report_error("export", "some error")
+
+        assert ok is False
+        assert mock_requests.post.call_count == 2
+
+
+# ============================================================
 # from_github_app
 # ============================================================
 


### PR DESCRIPTION
## 요약
- `find_similar_issue`/`create_issue`/`add_comment`가 `requests.RequestException`을 내부에서 잡아 `(False, msg)` 형태의 반환값으로 바꾸기 때문에, `report_error()`의 `except requests.RequestException` 재시도 경로가 실질적으로 도달 불가능했습니다 (401/403이 나도 재시도가 절대 실행되지 않음).
- 각 메서드가 마지막 실패의 HTTP status code를 `self._last_error_status`에 기록하도록 하고, `report_error()`가 반환값(`success`)과 `self._last_error_status`를 검사해 401/403이면 `_refresh_headers_if_needed(force=True)`로 헤더를 갱신한 뒤 1회 재시도하도록 수정했습니다.
- 기존 `except requests.RequestException` 블록은 향후 변경으로 예외가 실제로 전파되는 경우를 대비한 안전망으로 남겨두었습니다.

## 변경 파일
- `src/core/github_issue_reporter.py`
- `tests/test_github_issue_reporter.py`

## 테스트
- `TestReportErrorAuthRetry` 클래스 신규 추가:
  - `test_retries_after_auth_failure_via_returned_status`: 401 발생 후 헤더 refresh + 재시도로 성공하는 경로 검증
  - `test_no_retry_without_github_app`: PAT 모드에서는 재시도하지 않음을 검증
  - `test_no_retry_on_non_auth_failure`: 500 등 non-auth 실패는 재시도하지 않음을 검증
  - `test_retry_failure_after_refresh_reports_message`: 재시도 후에도 실패하면 실패로 종료됨을 검증

## Test plan
- [x] `py_compile` (github_issue_reporter.py, test_github_issue_reporter.py)
- [x] `pytest tests/test_github_issue_reporter.py -q` — 63 passed
- [x] 전체 `pytest -q` — 2038 passed, 1 failed (macOS validation artifact 테스트, GitHub CI 의존 로컬 상시 실패 — 회귀 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)