### PR TITLE
fix(migration-dialogs): terminate 제거 + FK 트리 렌더 + 마크다운 수정 (WP-3.6)

### DIFF
--- a/src/ui/dialogs/migration_dialogs.py
+++ b/src/ui/dialogs/migration_dialogs.py
@@ -7,6 +7,9 @@
 import os
 import json
 import shutil
+import html
+import re
+import threading
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QFormLayout,
     QLabel, QLineEdit, QSpinBox, QPushButton, QComboBox,
@@ -38,6 +41,106 @@ LEGACY_CLEANUP_EXECUTION_DISABLED_TOOLTIP = (
     "현재는 Dry-Run과 SQL 미리보기만 사용할 수 있습니다."
 )
 
+# 다이얼로그가 닫힌 뒤에도 백그라운드에서 계속 실행 중인 Worker (강제 종료 대신 완료까지 추적)
+_DETACHED_MIGRATION_WORKERS = set()
+
+
+def _disconnect_connector_in_background(connector) -> None:
+    """DB 커넥터 연결 해제를 백그라운드 스레드에서 수행 (UI 스레드 블로킹 방지)"""
+    if not connector:
+        return
+
+    def _run():
+        try:
+            connector.disconnect()
+            logger.info("✅ 백그라운드에서 DB 커넥터 연결 해제 완료")
+        except Exception as e:
+            logger.error(f"백그라운드 커넥터 연결 해제 오류: {e}", exc_info=True)
+
+    threading.Thread(target=_run, daemon=True).start()
+
+
+def _detach_workers_until_finished(workers, connector) -> None:
+    """다이얼로그가 닫힌 뒤 실행 중인 Worker를 강제 종료하지 않고 백그라운드에서 계속 실행시킨다.
+
+    모든 Worker가 완료되면 커넥터를 백그라운드에서 정리한다. UI 스레드를 블로킹하지 않는다.
+    """
+    remaining = {id(worker): worker for worker in workers}
+    if not remaining:
+        _disconnect_connector_in_background(connector)
+        return
+
+    for worker in remaining.values():
+        _DETACHED_MIGRATION_WORKERS.add(worker)
+
+    def _make_on_finished(worker):
+        def _on_finished(*_args):
+            _DETACHED_MIGRATION_WORKERS.discard(worker)
+            remaining.pop(id(worker), None)
+            if not remaining:
+                _disconnect_connector_in_background(connector)
+        return _on_finished
+
+    for worker in list(remaining.values()):
+        try:
+            worker.finished.connect(_make_on_finished(worker))
+        except Exception as e:
+            logger.error(f"디태치 Worker 완료 신호 연결 오류: {e}", exc_info=True)
+            remaining.pop(id(worker), None)
+            _DETACHED_MIGRATION_WORKERS.discard(worker)
+
+    if not remaining:
+        _disconnect_connector_in_background(connector)
+
+
+def _safe_disconnect_all(signal) -> None:
+    """시그널에 연결된 모든 슬롯을 best-effort로 해제 (연결이 없어도 예외를 삼킨다)"""
+    if signal is None:
+        return
+    try:
+        signal.disconnect()
+    except (TypeError, RuntimeError):
+        pass
+
+
+def _format_fk_tree_text(fk_tree: Dict[str, List[str]]) -> str:
+    """FK 트리를 ASCII 텍스트로 변환하는 순수 포맷터 (DB 접근 없이 fk_tree 데이터만 사용)"""
+    if not fk_tree:
+        return "FK 관계가 없습니다."
+
+    all_children = set()
+    for children in fk_tree.values():
+        all_children.update(children)
+
+    root_tables = sorted(set(fk_tree.keys()) - all_children)
+    rendered: set = set()
+    lines = ["FK 관계 트리:"]
+
+    def _walk(table: str, prefix: str, visited: set):
+        rendered.add(table)
+        for i, child in enumerate(fk_tree.get(table, [])):
+            is_last = (i == len(fk_tree.get(table, [])) - 1)
+            branch = "└── " if is_last else "├── "
+            if child in visited:
+                lines.append(f"{prefix}{branch}🔄 {child} (순환 참조)")
+                continue
+            lines.append(f"{prefix}{branch}{child}")
+            next_prefix = prefix + ("    " if is_last else "│   ")
+            _walk(child, next_prefix, visited | {child})
+
+    for root in root_tables:
+        lines.append(f"📁 {root}")
+        _walk(root, "", {root})
+
+    # 루트에서 도달하지 못한 테이블(사이클 전용)도 최상위 진입점으로 렌더
+    for table in sorted(fk_tree.keys()):
+        if table in rendered:
+            continue
+        lines.append(f"📁 {table}")
+        _walk(table, "", {table})
+
+    return "\n".join(lines)
+
 
 class MigrationAnalyzerDialog(QDialog):
     """마이그레이션 분석 다이얼로그"""
@@ -54,12 +157,18 @@ class MigrationAnalyzerDialog(QDialog):
         self.cleanup_worker: Optional[CleanupWorker] = None
         self._is_closing = False  # 닫기 진행 중 플래그
         self._auto_saved_path: Optional[str] = None  # 자동 저장 경로
+        self._disconnect_deferred_to_worker_completion = False  # 커넥터 해제를 Worker 완료로 위임했는지 여부
 
         self.init_ui()
         self.load_schemas()
 
+    @property
+    def disconnect_deferred_to_worker_completion(self) -> bool:
+        """닫기 시 커넥터 연결 해제가 백그라운드 Worker 완료 시점으로 지연되었는지 여부"""
+        return self._disconnect_deferred_to_worker_completion
+
     def closeEvent(self, event):
-        """다이얼로그 닫기 이벤트 - Worker 정리"""
+        """다이얼로그 닫기 이벤트 - 실행 중인 Worker를 강제 종료하지 않고 백그라운드로 분리"""
         self._is_closing = True
 
         # 실행 중인 Worker가 있는지 확인
@@ -71,6 +180,8 @@ class MigrationAnalyzerDialog(QDialog):
 
         if workers_running:
             # 사용자에게 확인
+            # 주의: 이 문구는 src/core/i18n.py의 정규식 번역 항목과 정확히 일치해야 한다
+            # (i18n.py는 WP-3.6 허용 파일 범위 밖이라 문구를 변경하면 런타임 영어 번역이 깨진다).
             reply = QMessageBox.question(
                 self,
                 "작업 진행 중",
@@ -85,14 +196,26 @@ class MigrationAnalyzerDialog(QDialog):
                 event.ignore()
                 return
 
-            # Worker 종료 대기
+            # 닫힌 다이얼로그가 이후 완료 신호로 UI를 건드리지 않도록 결과 슬롯 연결을 먼저 해제
+            if self.worker:
+                _safe_disconnect_all(self.worker.progress)
+                _safe_disconnect_all(self.worker.analysis_complete)
+                _safe_disconnect_all(self.worker.finished)
+            if self.cleanup_worker:
+                _safe_disconnect_all(self.cleanup_worker.progress)
+                _safe_disconnect_all(self.cleanup_worker.action_complete)
+                _safe_disconnect_all(self.cleanup_worker.finished)
+
             for name, worker in workers_running:
-                logger.info(f"🛑 {name} Worker 종료 대기 중...")
-                worker.quit()
-                if not worker.wait(3000):  # 3초 대기
-                    logger.warning(f"⚠️ {name} Worker가 시간 내에 종료되지 않음, 강제 종료")
-                    worker.terminate()
-                    worker.wait(1000)
+                logger.info(f"🔀 {name} Worker를 백그라운드로 분리하여 계속 실행합니다 (강제 종료하지 않음)")
+                request_interruption = getattr(worker, "requestInterruption", None)
+                if callable(request_interruption):
+                    request_interruption()
+
+            # quit()/wait()/terminate()로 블로킹하거나 강제 종료하지 않고,
+            # Worker가 스스로 끝날 때까지 백그라운드에서 추적한 뒤 커넥터를 정리한다.
+            self._disconnect_deferred_to_worker_completion = True
+            _detach_workers_until_finished([w for _, w in workers_running], self.connector)
 
         logger.info("✅ MigrationAnalyzerDialog 정상 종료")
         event.accept()
@@ -615,6 +738,8 @@ class MigrationAnalyzerDialog(QDialog):
 
     def on_analysis_complete(self, result: AnalysisResult):
         """분석 완료 시"""
+        if self._is_closing:
+            return
         try:
             self.analysis_result = result
             self.update_overview(result)
@@ -635,6 +760,8 @@ class MigrationAnalyzerDialog(QDialog):
 
     def on_analysis_finished(self, success: bool, message: str):
         """분석 종료 시"""
+        if self._is_closing:
+            return
         self.set_ui_enabled(True)
         self.progress_bar.setVisible(False)
 
@@ -777,7 +904,8 @@ class MigrationAnalyzerDialog(QDialog):
         self.table_issues.setUpdatesEnabled(True)
 
     def update_fk_tree(self, fk_tree: Dict[str, List[str]], schema: str):
-        """FK 트리 업데이트"""
+        """FK 트리 업데이트 (분석 결과 fk_tree 데이터만 사용, 동기 DB 재조회 없음)"""
+        # schema는 호출부 호환을 위해 유지되며 여기서는 사용하지 않는다 (DB 접근 금지)
         self.tree_fk.clear()
 
         if not fk_tree:
@@ -790,27 +918,33 @@ class MigrationAnalyzerDialog(QDialog):
             all_children.update(children)
 
         root_tables = set(fk_tree.keys()) - all_children
+        rendered: set = set()
 
         def add_tree_items(parent_item, table: str, visited: set):
-            if table in fk_tree:
-                for child in fk_tree[table]:
-                    # 순환 참조 방지
-                    if child in visited:
-                        child_item = QTreeWidgetItem(parent_item, [f"🔄 {child} (순환 참조)"])
-                        continue
-                    child_item = QTreeWidgetItem(parent_item, [f"└── {child}"])
-                    add_tree_items(child_item, child, visited | {child})
+            rendered.add(table)
+            for child in fk_tree.get(table, []):
+                # 순환 참조 방지
+                if child in visited:
+                    QTreeWidgetItem(parent_item, [f"🔄 {child} (순환 참조)"])
+                    continue
+                child_item = QTreeWidgetItem(parent_item, [f"└── {child}"])
+                add_tree_items(child_item, child, visited | {child})
 
         for root in sorted(root_tables):
             root_item = QTreeWidgetItem(self.tree_fk, [f"📁 {root}"])
             add_tree_items(root_item, root, {root})
 
+        # 루트에서 도달하지 못한 테이블(사이클 전용)도 최상위 진입점으로 렌더
+        for table in sorted(fk_tree.keys()):
+            if table in rendered:
+                continue
+            cycle_root_item = QTreeWidgetItem(self.tree_fk, [f"📁 {table}"])
+            add_tree_items(cycle_root_item, table, {table})
+
         self.tree_fk.expandAll()
 
-        # ASCII 트리 텍스트
-        analyzer = MigrationAnalyzer(self.connector)
-        tree_text = analyzer.get_fk_visualization(schema)
-        self.txt_fk_tree.setText(tree_text)
+        # ASCII 트리 텍스트 - 워커 분석 결과(fk_tree)만으로 렌더링, 동기 DB 재조회 없음
+        self.txt_fk_tree.setText(_format_fk_tree_text(fk_tree))
 
     def on_orphan_selected(self):
         """고아 레코드 선택 시"""
@@ -950,19 +1084,6 @@ WHERE c.`{orphan.child_column}` IS NOT NULL
             QMessageBox.warning(self, "선택 필요", "정리할 고아 레코드를 선택하세요.")
             return
 
-        # 실제 실행 시 확인
-        if not dry_run:
-            reply = QMessageBox.warning(
-                self,
-                "실행 확인",
-                f"선택된 {len(selected_rows)}개 항목에 대해 정리 작업을 실행합니다.\n\n"
-                "이 작업은 되돌릴 수 없습니다. 계속하시겠습니까?",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                QMessageBox.StandardButton.No
-            )
-            if reply != QMessageBox.StandardButton.Yes:
-                return
-
         # 정리 작업 목록 생성
         schema = self.analysis_result.schema
         action = ActionType.DELETE if self.radio_delete.isChecked() else ActionType.SET_NULL
@@ -1000,11 +1121,15 @@ WHERE c.`{orphan.child_column}` IS NOT NULL
 
     def on_action_complete(self, table: str, success: bool, message: str, affected: int):
         """개별 정리 작업 완료 시"""
+        if self._is_closing:
+            return
         status = "✅" if success else "❌"
         self.add_log(f"  {status} {table}: {message}")
 
     def on_cleanup_finished(self, success: bool, message: str, results: dict):
         """정리 작업 완료 시"""
+        if self._is_closing:
+            return
         self.btn_dry_run.setEnabled(True)
         self.btn_execute.setEnabled(False)
         self.progress_bar.setVisible(False)
@@ -1467,6 +1592,45 @@ class ManualGuideDialog(QDialog):
         if self.issues:
             self.issue_list.selectRow(0)
 
+    @staticmethod
+    def _markdown_to_safe_html(content: str) -> str:
+        """가이드 텍스트의 마크다운 서브셋(굵게/코드 펜스/구분선)을 안전한 HTML로 변환.
+
+        위치/설명 등 분석 결과에서 온 텍스트가 섞여 있을 수 있으므로 항상 먼저 이스케이프한다.
+        """
+        escaped = html.escape(content)
+
+        lines = []
+        in_fence = False
+        for raw_line in escaped.split("\n"):
+            stripped = raw_line.strip()
+            if stripped.startswith("```"):
+                if in_fence:
+                    lines.append("</code></pre>")
+                    in_fence = False
+                else:
+                    lines.append('<pre style="background-color:#f0f0f0; padding:8px;"><code>')
+                    in_fence = True
+                continue
+
+            if in_fence:
+                lines.append(raw_line)
+                continue
+
+            if stripped == "---":
+                lines.append("<hr>")
+                continue
+
+            lines.append(raw_line)
+
+        if in_fence:
+            # 닫히지 않은 펜스는 방어적으로 닫는다
+            lines.append("</code></pre>")
+
+        result = "\n".join(lines)
+        result = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", result)
+        return result.replace("\n", "<br>")
+
     def on_issue_selected(self):
         """이슈 선택 시 가이드 표시"""
         selected = self.issue_list.selectedItems()
@@ -1489,12 +1653,7 @@ class ManualGuideDialog(QDialog):
 
 {guide['solution']}
 """
-        # Markdown 스타일 적용 (간단한 변환)
-        content = content.replace("```sql", '<pre style="background-color:#f0f0f0; padding:8px;">')
-        content = content.replace("```", "</pre>")
-        content = content.replace("**", "<b>").replace("**", "</b>")
-
-        self.guide_content.setHtml(content.replace("\n", "<br>"))
+        self.guide_content.setHtml(self._markdown_to_safe_html(content))
 
 
 class MigrationWizard:
@@ -1525,11 +1684,14 @@ class MigrationWizard:
             return False
 
         # 2단계: 마이그레이션 분석 다이얼로그
+        analyzer_dialog = None
         try:
             analyzer_dialog = MigrationAnalyzerDialog(parent, connector, config_manager)
             analyzer_dialog.exec()
             return True
         finally:
-            # 연결 종료
-            if connector:
+            # 다이얼로그가 닫히면서 백그라운드 Worker 완료 시점으로 연결 해제를 위임한 경우,
+            # 여기서 다시 동기적으로 disconnect()하지 않는다 (이중 해제/경합 방지).
+            deferred = getattr(analyzer_dialog, "disconnect_deferred_to_worker_completion", False)
+            if connector and not deferred:
                 connector.disconnect()

--- a/tests/test_migration_worker.py
+++ b/tests/test_migration_worker.py
@@ -1,8 +1,23 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from types import SimpleNamespace
+
 import pytest
+from PyQt6.QtWidgets import QApplication, QDialog, QMessageBox
 
 from src.core.migration_analyzer import ActionType, CleanupAction
+from src.ui.dialogs import migration_dialogs
 from src.ui.workers.migration_worker import CleanupWorker
 from tests.conftest import FakeMySQLConnector
+
+# 모듈 레벨에서 QApplication을 생성하고 참조를 유지한다. 변수에 바인딩하지 않으면
+# (예: 단순히 `QApplication.instance() or QApplication([])`만 호출) 이 표현식 문이 끝나는
+# 즉시 파이썬 refcount가 0이 되어 새로 만든 QApplication이 즉시 파괴되고, 이후 이 프로세스에서
+# 첫 QWidget(다이얼로그)을 생성하는 테스트가 "Must construct a QApplication before a QWidget"로
+# 네이티브 크래시한다. 모듈이 살아있는 동안 참조를 붙잡아 두어야 한다.
+_APP = QApplication.instance() or QApplication([])
 
 
 def _cleanup_action() -> CleanupAction:
@@ -34,3 +49,249 @@ def test_cleanup_worker_allows_dry_run_mode():
     )
 
     assert worker.dry_run is True
+
+
+# ============================================================
+# migration_dialogs.py 회귀 테스트 (WP-3.6)
+# ============================================================
+
+class _FakeSignal:
+    """PyQt 시그널을 흉내내는 결정론적 페이크 (connect/disconnect/emit 지원)"""
+
+    def __init__(self):
+        self._slots = []
+
+    def connect(self, slot):
+        self._slots.append(slot)
+
+    def disconnect(self, slot=None):
+        if slot is None:
+            if not self._slots:
+                raise TypeError("disconnect() failed: no connections")
+            self._slots = []
+            return
+        if slot not in self._slots:
+            raise TypeError("disconnect() failed between signal and slot")
+        self._slots.remove(slot)
+
+    def emit(self, *args):
+        for slot in list(self._slots):
+            slot(*args)
+
+
+class _FakeAnalyzerWorker:
+    """closeEvent 검증용 페이크 Worker - quit()/wait()/terminate() 호출 시 즉시 실패"""
+
+    def __init__(self):
+        self.progress = _FakeSignal()
+        self.analysis_complete = _FakeSignal()
+        self.finished = _FakeSignal()
+
+    def isRunning(self):
+        return True
+
+    def quit(self):
+        raise AssertionError("quit()가 호출되어서는 안 됩니다 (Worker를 강제 종료하지 않음)")
+
+    def wait(self, *args, **kwargs):
+        raise AssertionError("wait()가 호출되어서는 안 됩니다 (UI 스레드를 블로킹하지 않음)")
+
+    def terminate(self):
+        raise AssertionError("terminate()가 호출되어서는 안 됩니다 (강제 종료 폴백 제거됨)")
+
+
+class _FakeCloseEvent:
+    def __init__(self):
+        self.accepted = False
+        self.ignored = False
+
+    def accept(self):
+        self.accepted = True
+
+    def ignore(self):
+        self.ignored = True
+
+
+def test_close_event_detaches_worker_without_terminate_or_wait(monkeypatch):
+    """closeEvent는 실행 중인 Worker를 강제 종료(quit/wait/terminate)하지 않고
+    백그라운드로 분리한 뒤, Worker가 스스로 끝나면 커넥터를 정리해야 한다."""
+    disconnect_calls = []
+    monkeypatch.setattr(
+        migration_dialogs,
+        "_disconnect_connector_in_background",
+        lambda connector: disconnect_calls.append(connector),
+    )
+    monkeypatch.setattr(
+        migration_dialogs.QMessageBox,
+        "question",
+        lambda *args, **kwargs: QMessageBox.StandardButton.Yes,
+    )
+
+    fake_worker = _FakeAnalyzerWorker()
+    connector = FakeMySQLConnector()
+
+    dialog = type("DummyMigrationDialog", (), {})()
+    dialog._is_closing = False
+    dialog._disconnect_deferred_to_worker_completion = False
+    dialog.worker = fake_worker
+    dialog.cleanup_worker = None
+    dialog.connector = connector
+
+    event = _FakeCloseEvent()
+    migration_dialogs.MigrationAnalyzerDialog.closeEvent(dialog, event)
+
+    assert event.accepted is True
+    assert event.ignored is False
+    assert dialog._disconnect_deferred_to_worker_completion is True
+    assert disconnect_calls == []  # Worker가 아직 끝나지 않았으므로 아직 정리되지 않음
+
+    # Worker가 스스로 끝나면 그제서야 백그라운드 커넥터 정리가 트리거되어야 한다
+    fake_worker.finished.emit(True, "분석 완료")
+
+    assert disconnect_calls == [connector]
+
+
+def test_migration_wizard_skips_final_disconnect_when_dialog_deferred(monkeypatch):
+    """다이얼로그가 연결 해제를 Worker 완료로 위임했다면(closeEvent 중 감지),
+    MigrationWizard.start()의 finally 블록이 다시 동기적으로 disconnect()하면 안 된다."""
+    import src.ui.dialogs.db_dialogs as db_dialogs
+
+    captured = {}
+
+    class _RecordingConnector:
+        def __init__(self):
+            self.disconnect_called = False
+
+        def disconnect(self):
+            self.disconnect_called = True
+
+    class _FakeDBConnectionDialog:
+        def __init__(self, parent, tunnel_engine, config_manager):
+            self.connector = _RecordingConnector()
+            captured["connector"] = self.connector
+
+        def exec(self):
+            return QDialog.DialogCode.Accepted
+
+    class _FakeDeferredAnalyzerDialog:
+        def __init__(self, parent, connector, config_manager):
+            self.connector = connector
+            self.disconnect_deferred_to_worker_completion = True
+
+        def exec(self):
+            return None
+
+    monkeypatch.setattr(db_dialogs, "DBConnectionDialog", _FakeDBConnectionDialog)
+    monkeypatch.setattr(migration_dialogs, "MigrationAnalyzerDialog", _FakeDeferredAnalyzerDialog)
+
+    result = migration_dialogs.MigrationWizard.start(None, tunnel_engine=None, config_manager=None)
+
+    assert result is True
+    assert captured["connector"].disconnect_called is False
+
+
+def test_update_fk_tree_renders_cycle_only_tables_without_db_query(monkeypatch):
+    """분석 결과의 fk_tree가 사이클로만 구성되어 있어도(고전적 루트가 없어도) 트리에 렌더되어야 하며,
+    이 과정에서 MigrationAnalyzer를 재생성해 DB를 다시 조회해서는 안 된다."""
+    QApplication.instance() or QApplication([])
+
+    monkeypatch.setattr(migration_dialogs.MigrationAnalyzerDialog, "load_schemas", lambda self: None)
+
+    def _fail_if_constructed(*args, **kwargs):
+        raise AssertionError("update_fk_tree는 MigrationAnalyzer를 생성하면 안 됩니다 (DB 재조회 금지)")
+
+    monkeypatch.setattr(migration_dialogs, "MigrationAnalyzer", _fail_if_constructed)
+
+    dialog = migration_dialogs.MigrationAnalyzerDialog(None, FakeMySQLConnector(), None)
+    try:
+        dialog.update_fk_tree({"employee": ["employee"]}, "loaded_schema")
+
+        assert dialog.tree_fk.topLevelItemCount() == 1
+
+        top_item = dialog.tree_fk.topLevelItem(0)
+        rendered_lines = []
+
+        def _collect(item):
+            rendered_lines.append(item.text(0))
+            for i in range(item.childCount()):
+                _collect(item.child(i))
+
+        _collect(top_item)
+        rendered_tree_text = "\n".join(rendered_lines)
+
+        assert "employee" in rendered_tree_text
+        assert "순환 참조" in rendered_tree_text
+
+        pane_text = dialog.txt_fk_tree.toPlainText()
+        assert "employee" in pane_text
+        assert "순환 참조" in pane_text
+        assert pane_text != "FK 관계가 없습니다."
+    finally:
+        dialog.close()
+
+
+def test_fk_tree_text_formats_roots_and_unvisited_cycles():
+    """_format_fk_tree_text는 정상 루트뿐 아니라 루트에서 도달 불가능한(사이클 전용) 테이블도
+    별도 진입점으로 렌더해야 한다."""
+    text = migration_dialogs._format_fk_tree_text(
+        {"root": ["child"], "child": [], "self_ref": ["self_ref"]}
+    )
+
+    assert "root" in text
+    assert "child" in text
+    assert "self_ref" in text
+    assert "순환 참조" in text
+
+
+def test_manual_guide_markdown_to_safe_html_balances_tags_and_fences():
+    """ManualGuideDialog._markdown_to_safe_html은 굵게/코드 펜스 태그를 항상 짝지어 생성해야 하고,
+    원본 마크다운 백틱이 결과에 남아있으면 안 되며, HTML 특수문자는 이스케이프되어야 한다."""
+    content = (
+        "**중요 안내**\n"
+        "\n"
+        "```sql\n"
+        "ALTER TABLE t ADD COLUMN c INT;\n"
+        "```\n"
+        "\n"
+        "```\n"
+        "plain fence content\n"
+        "```\n"
+        "\n"
+        "<script>alert(1)</script>\n"
+    )
+
+    result = migration_dialogs.ManualGuideDialog._markdown_to_safe_html(content)
+
+    assert result.count("<b>") == result.count("</b>")
+    assert result.count("<pre") == result.count("</pre>")
+    assert "```" not in result
+    assert "&lt;script&gt;" in result
+    assert "<script>" not in result
+
+
+def test_execute_cleanup_real_run_disabled_before_action_generation(monkeypatch):
+    """dry_run=False는 정리 작업 목록 생성/선택 행 조회 이전에 즉시 비활성화 안내 후 반환해야 하며,
+    (이전의 도달 불가능한 2차 확인 블록처럼) 이후 코드가 실행되면 안 된다."""
+    warnings = []
+    monkeypatch.setattr(
+        migration_dialogs.QMessageBox,
+        "warning",
+        lambda *args, **kwargs: warnings.append(args),
+    )
+
+    def _fail_if_called(*args, **kwargs):
+        raise AssertionError("generate_cleanup_sql은 호출되면 안 됩니다 (dry_run=False는 조기 반환해야 함)")
+
+    monkeypatch.setattr(migration_dialogs.MigrationAnalyzer, "generate_cleanup_sql", _fail_if_called)
+
+    dialog = type("DummyMigrationDialog", (), {})()
+    dialog.analysis_result = SimpleNamespace(schema="app", orphan_records=[])
+    dialog.cleanup_worker = None
+    dialog.table_orphans = None  # 접근되면 AttributeError로 실패 (도달 불가 코드 회귀 방지용 트립와이어)
+
+    migration_dialogs.MigrationAnalyzerDialog.execute_cleanup(dialog, dry_run=False)
+
+    assert dialog.cleanup_worker is None
+    assert len(warnings) == 1
+    assert "실행 비활성화" in warnings[0]
+    assert migration_dialogs.LEGACY_CLEANUP_EXECUTION_DISABLED_TOOLTIP in warnings[0]


### PR DESCRIPTION
## Summary
- `MigrationAnalyzerDialog.closeEvent`에서 `quit()`/`wait()`/`terminate()` 강제 종료 폴백을 제거하고, 실행 중인 Worker를 백그라운드로 분리해 스스로 끝나면 커넥터를 정리하도록 변경했습니다 (`MigrationWizard.start`도 지연된 해제 여부를 인지).
- `update_fk_tree`가 동기 DB 재조회(`MigrationAnalyzer.get_fk_visualization`) 없이 분석 결과(`fk_tree`)만으로 렌더링하도록 수정했습니다. 루트가 없는 사이클 전용 FK 테이블(예: 자기 참조)도 최상위 진입점으로 표시됩니다.
- `ManualGuideDialog`의 마크다운→HTML 변환에서 `**bold**`가 항상 `<b>` 여는 태그만 생성하고 닫는 태그는 전혀 생성되지 않던 버그와, 위치/설명 텍스트가 이스케이프 없이 그대로 HTML에 삽입되던 문제를 수정했습니다.
- `execute_cleanup`에서 `dry_run=False`는 최상단에서 이미 조기 반환되므로 도달 불가능했던 두 번째 실행 확인 블록을 제거했습니다.

## Test plan
- [x] `python -m py_compile src/ui/dialogs/migration_dialogs.py tests/test_migration_worker.py`
- [x] `pytest tests/test_migration_worker.py -q` — 8 passed
- [x] `pytest -q` (전체) — 2040 passed, 1 failed (`test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`, GitHub API/CI 의존 테스트로 로컬에서는 항상 실패하는 사전에 알려진 케이스)

🤖 Generated with [Claude Code](https://claude.com/claude-code)