### PR TITLE
fix(tunnel-config): 테스트 워커 생명주기 + 중복 자격증명 관리 통합 (WP-3.9)

### DIFF
--- a/src/ui/dialogs/tunnel_config.py
+++ b/src/ui/dialogs/tunnel_config.py
@@ -13,6 +13,53 @@ from src.ui.workers.test_worker import ConnectionTestWorker, TestType
 from src.ui.dialogs.test_dialogs import TestProgressDialog
 
 
+class _RunningTestProgressDialog(TestProgressDialog):
+    """테스트 실행 중에는 ESC/닫기로 dismiss될 수 없는 진행 다이얼로그.
+
+    ConnectionTestWorker(QThread) 실행 중 reject()가 호출되면(ESC 키,
+    Alt+F4 등 QDialog.closeEvent도 내부적으로 reject()를 호출한다)
+    exec()가 즉시 반환되어 로컬 worker 참조가 사라지고, 실행 중인 QThread의
+    마지막 파이썬 참조가 사라져 크래시로 이어진다(WP-3.9 Finding 1).
+    allow_dismiss()가 호출되기 전까지는 reject 경로를 막는다.
+    """
+
+    def __init__(self, parent, title: str = "연결 테스트"):
+        super().__init__(parent, title)
+        self._dismissable = False
+
+    def allow_dismiss(self):
+        """워커의 내장 QThread.finished()가 발화한 뒤에만 호출해야 한다."""
+        self._dismissable = True
+
+    def reject(self):
+        if not self._dismissable:
+            return
+        super().reject()
+
+
+class _TempCredentials:
+    """DB 테스트용 임시 자격 증명 제공자.
+
+    ConfigManager와 동일한 get_tunnel_credentials(tunnel_id) 인터페이스를
+    제공해 ConnectionTestWorker가 실제 ConfigManager와 구분 없이 사용할 수
+    있게 한다. _test_db_only/_test_integrated에 각각 인라인으로 중복
+    정의되어 있던 동일한 클래스를 하나로 통합했다(WP-3.9 Finding 2).
+    """
+
+    def __init__(self, user, password, encrypted_password, encryptor):
+        self._user = user
+        self._password = password
+        self._encrypted = encrypted_password
+        self._encryptor = encryptor
+
+    def get_tunnel_credentials(self, tunnel_id):
+        if self._password:
+            return self._user, self._password
+        elif self._encrypted and self._encryptor:
+            return self._user, self._encryptor.decrypt(self._encrypted)
+        return self._user, None
+
+
 class TunnelConfigDialog(QDialog):
     def __init__(self, parent=None, tunnel_data=None, tunnel_engine=None):
         super().__init__(parent)
@@ -21,6 +68,11 @@ class TunnelConfigDialog(QDialog):
 
         # 엔진 인스턴스 저장 (테스트 연결용)
         self.engine = tunnel_engine
+
+        # 현재 실행 중인 ConnectionTestWorker(QThread) 참조.
+        # 내장 QThread.finished()가 발화하기 전까지는 절대 None으로 해제하지
+        # 않는다 (WP-3.9 Finding 1).
+        self._test_worker = None
 
         # 수정 모드일 경우 기존 데이터, 아니면 빈 딕셔너리
         self.tunnel_data = tunnel_data or {}
@@ -396,11 +448,10 @@ class TunnelConfigDialog(QDialog):
             )
             return
 
-        dialog = TestProgressDialog(self, f"터널 테스트 - {temp_config.get('name', 'Unknown')}")
-        worker = ConnectionTestWorker(TestType.TUNNEL_ONLY, temp_config, self.engine, None)
-        worker.progress.connect(dialog.update_progress)
-        worker.finished.connect(lambda s, m: self._on_test_finished(dialog, s, m))
-        worker.start()
+        dialog = self._start_connection_test(
+            TestType.TUNNEL_ONLY, temp_config, None,
+            f"터널 테스트 - {temp_config.get('name', 'Unknown')}"
+        )
         dialog.exec()
 
     def _test_db_only(self):
@@ -427,38 +478,21 @@ class TunnelConfigDialog(QDialog):
             QMessageBox.warning(self, "경고", "DB 비밀번호를 입력해주세요.")
             return
 
-        dialog = TestProgressDialog(self, f"DB 인증 테스트 - {temp_config.get('name', 'Unknown')}")
-
-        # DB 테스트용 임시 ConfigManager 생성 (현재 입력값 사용)
-        class TempConfigManager:
-            def __init__(self, user, password, encrypted_password, encryptor):
-                self._user = user
-                self._password = password
-                self._encrypted = encrypted_password
-                self._encryptor = encryptor
-
-            def get_tunnel_credentials(self, tunnel_id):
-                if self._password:
-                    return self._user, self._password
-                elif self._encrypted and self._encryptor:
-                    return self._user, self._encryptor.decrypt(self._encrypted)
-                return self._user, None
-
         # 부모 창(main_window)에서 encryptor 가져오기
         encryptor = None
         if hasattr(self.parent(), 'config_mgr'):
             encryptor = self.parent().config_mgr.encryptor
 
-        temp_config_mgr = TempConfigManager(
+        temp_config_mgr = _TempCredentials(
             db_user, db_password,
             self.tunnel_data.get('db_password_encrypted'),
             encryptor
         )
 
-        worker = ConnectionTestWorker(TestType.DB_ONLY, temp_config, self.engine, temp_config_mgr)
-        worker.progress.connect(dialog.update_progress)
-        worker.finished.connect(lambda s, m: self._on_test_finished(dialog, s, m))
-        worker.start()
+        dialog = self._start_connection_test(
+            TestType.DB_ONLY, temp_config, temp_config_mgr,
+            f"DB 인증 테스트 - {temp_config.get('name', 'Unknown')}"
+        )
         dialog.exec()
 
     def _test_integrated(self):
@@ -471,42 +505,53 @@ class TunnelConfigDialog(QDialog):
         if not temp_config.get('db_engine'):
             QMessageBox.warning(self, "필수 항목 누락", "DB Engine을 먼저 선택해주세요.")
             return
-        dialog = TestProgressDialog(self, f"통합 테스트 - {temp_config.get('name', 'Unknown')}")
 
         # DB 자격 증명 확인 (선택 사항)
         db_user = self.input_db_user.text() if self.chk_save_credentials.isChecked() else None
         db_password = self.input_db_password.text() if self.chk_save_credentials.isChecked() else None
 
-        # 임시 ConfigManager
-        class TempConfigManager:
-            def __init__(self, user, password, encrypted_password, encryptor):
-                self._user = user
-                self._password = password
-                self._encrypted = encrypted_password
-                self._encryptor = encryptor
-
-            def get_tunnel_credentials(self, tunnel_id):
-                if self._password:
-                    return self._user, self._password
-                elif self._encrypted and self._encryptor:
-                    return self._user, self._encryptor.decrypt(self._encrypted)
-                return self._user, None
-
         encryptor = None
         if hasattr(self.parent(), 'config_mgr'):
             encryptor = self.parent().config_mgr.encryptor
 
-        temp_config_mgr = TempConfigManager(
+        temp_config_mgr = _TempCredentials(
             db_user, db_password,
             self.tunnel_data.get('db_password_encrypted') if db_user else None,
             encryptor
         )
 
-        worker = ConnectionTestWorker(TestType.INTEGRATED, temp_config, self.engine, temp_config_mgr)
-        worker.progress.connect(dialog.update_progress)
-        worker.finished.connect(lambda s, m: self._on_test_finished(dialog, s, m))
-        worker.start()
+        dialog = self._start_connection_test(
+            TestType.INTEGRATED, temp_config, temp_config_mgr,
+            f"통합 테스트 - {temp_config.get('name', 'Unknown')}"
+        )
         dialog.exec()
 
-    def _on_test_finished(self, dialog, success: bool, message: str):
+    def _start_connection_test(self, test_type: TestType, temp_config: dict,
+                                config_mgr, title: str) -> "_RunningTestProgressDialog":
+        """ConnectionTestWorker를 생성해 진행 다이얼로그와 연결한 뒤 시작한다.
+
+        worker는 self._test_worker에 보관해 로컬 변수 스코프가 끝나도 참조가
+        사라지지 않게 하고, 내장 QThread.finished()가 발화하기 전까지는
+        해제하지 않는다. 반환된 dialog는 호출자가 exec()해야 한다
+        (WP-3.9 Finding 1).
+        """
+        dialog = _RunningTestProgressDialog(self, title)
+        worker = ConnectionTestWorker(test_type, temp_config, self.engine, config_mgr)
+        self._test_worker = worker
+
+        worker.progress.connect(dialog.update_progress)
+        worker.test_finished.connect(lambda s, m: self._on_test_result(dialog, s, m))
+        # 내장 QThread.finished()(무인자) — 실제로 스레드가 정지한 뒤에만 발화.
+        # 이 시점에야 dialog dismiss를 허용하고 worker 참조를 해제한다.
+        worker.finished.connect(lambda: self._on_test_worker_thread_finished(dialog))
+
+        worker.start()
+        return dialog
+
+    def _on_test_result(self, dialog, success: bool, message: str):
         dialog.show_result(success, message)
+
+    def _on_test_worker_thread_finished(self, dialog):
+        """내장 QThread.finished() 핸들러. worker가 실제로 정지한 뒤 호출된다."""
+        dialog.allow_dismiss()
+        self._test_worker = None

--- a/src/ui/workers/test_worker.py
+++ b/src/ui/workers/test_worker.py
@@ -18,7 +18,11 @@ class TestType(Enum):
 class ConnectionTestWorker(QThread):
     """연결 테스트 Worker"""
     progress = pyqtSignal(str)          # 진행 메시지
-    finished = pyqtSignal(bool, str)    # (성공여부, 결과메시지)
+    # ⛔ 이름을 "finished"로 두면 QThread 내장 finished() 시그널(스레드가 실제로
+    # 정지했을 때 발화)을 shadow해서 더 이상 접근할 수 없게 된다. 결과 전달용
+    # 시그널은 별도 이름(test_finished)을 쓰고, 호출자는 worker 참조 해제를
+    # 반드시 내장 finished()를 받은 뒤에만 하도록 한다(WP-3.9 Finding 1).
+    test_finished = pyqtSignal(bool, str)    # (성공여부, 결과메시지)
 
     def __init__(self, test_type: TestType, tunnel_config: dict,
                  tunnel_engine, config_manager, parent=None):
@@ -37,13 +41,13 @@ class ConnectionTestWorker(QThread):
             else:
                 self._test_integrated()
         except Exception as e:
-            self.finished.emit(False, f"테스트 중 오류 발생: {str(e)}")
+            self.test_finished.emit(False, f"테스트 중 오류 발생: {str(e)}")
 
     def _test_tunnel(self):
         """SSH 터널 연결만 테스트"""
         self.progress.emit("🔗 SSH 터널 연결 테스트 중...")
         success, msg = self.engine.test_connection(self.config)
-        self.finished.emit(success, msg)
+        self.test_finished.emit(success, msg)
 
     def _test_db(self):
         """DB 인증 테스트 (터널 경유)"""
@@ -134,7 +138,7 @@ class ConnectionTestWorker(QThread):
                 self.engine.close_temp_tunnel(temp_server)
 
             # 모든 정리 후 결과 전달
-            self.finished.emit(result_success, result_msg)
+            self.test_finished.emit(result_success, result_msg)
 
     def _test_integrated(self):
         """통합 테스트 (터널 + DB)"""
@@ -223,7 +227,7 @@ class ConnectionTestWorker(QThread):
                 self.engine.close_temp_tunnel(temp_server)
 
             # 모든 정리 후 결과 전달
-            self.finished.emit(result_success, result_msg)
+            self.test_finished.emit(result_success, result_msg)
 
     def _resolve_db_engine(self, host: str, port: int) -> str:
         engine = self.config.get('db_engine')

--- a/tests/test_connection_test_worker.py
+++ b/tests/test_connection_test_worker.py
@@ -88,3 +88,29 @@ def test_mysql_core_connector_uses_default_database(monkeypatch):
     assert captured["engine"] == "mysql"
     assert captured["database"] == "tf_source84"
     assert captured["schema"] == ""
+
+
+def test_connection_test_worker_does_not_shadow_builtin_finished_signal():
+    """WP-3.9 Finding 1 회귀: 결과 전달용 시그널이 QThread 내장 finished()를
+    shadow하면 worker 참조 해제 타이밍을 "스레드가 실제로 정지한 뒤"로 안전하게
+    잡을 방법이 없어진다. test_finished(bool, str)와 내장 finished()가 서로
+    독립적으로 동작해야 한다. 실제 QThread는 절대 start()하지 않고 시그널만
+    직접 emit해서 검증한다.
+    """
+    worker = ConnectionTestWorker(
+        TestType.TUNNEL_ONLY, {}, tunnel_engine=None, config_manager=None,
+    )
+
+    test_finished_calls = []
+    thread_finished_calls = []
+    worker.test_finished.connect(lambda success, msg: test_finished_calls.append((success, msg)))
+    worker.finished.connect(lambda: thread_finished_calls.append(True))
+
+    worker.test_finished.emit(True, "ok")
+    assert test_finished_calls == [(True, "ok")]
+    assert thread_finished_calls == []  # 결과 시그널만으로는 스레드 종료 시그널이 울리면 안 된다
+
+    worker.finished.emit()
+    assert thread_finished_calls == [True]
+    # 내장 finished()는 인자를 받지 않는다 (test_finished와 시그니처가 다름을 재확인)
+    assert test_finished_calls == [(True, "ok")]

--- a/tests/test_tunnel_config_dialog.py
+++ b/tests/test_tunnel_config_dialog.py
@@ -1,11 +1,17 @@
+import inspect
 import os
 import sys
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-from PyQt6.QtWidgets import QApplication, QWidget
+from PyQt6.QtWidgets import QApplication, QDialog, QWidget
 
-from src.ui.dialogs.tunnel_config import TunnelConfigDialog
+from src.ui.dialogs.tunnel_config import (
+    TunnelConfigDialog,
+    _RunningTestProgressDialog,
+    _TempCredentials,
+)
+from src.ui.workers.test_worker import ConnectionTestWorker, TestType
 
 
 app = QApplication.instance() or QApplication(sys.argv)
@@ -100,3 +106,99 @@ def test_db_engine_is_manual_select_field():
     finally:
         dialog.close()
         parent.close()
+
+
+def test_running_test_progress_dialog_blocks_reject_until_allowed():
+    """WP-3.9 Finding 1 회귀: 테스트가 실행 중일 때는 ESC 등으로 트리거되는
+    reject()가 완전히 무시되어야 한다. accept()는 별도 경로(닫기 버튼)이므로
+    항상 정상 동작해야 한다 - 이를 기준선으로 삼아 reject() 차단 여부를
+    간접 검증한다(QDialog의 기본 result()가 이미 Rejected이므로 accept() 후
+    비교해야 신뢰할 수 있다).
+    """
+    parent = QWidget()
+    dialog = _RunningTestProgressDialog(parent, "테스트")
+    try:
+        dialog.accept()
+        assert dialog.result() == QDialog.DialogCode.Accepted
+
+        # 실행 중 reject()는 완전히 무시되어야 한다
+        dialog.reject()
+        assert dialog.result() == QDialog.DialogCode.Accepted
+
+        # 내장 QThread.finished() 이후에만 reject()가 허용된다
+        dialog.allow_dismiss()
+        dialog.reject()
+        assert dialog.result() == QDialog.DialogCode.Rejected
+    finally:
+        dialog.close()
+        parent.close()
+
+
+def test_start_connection_test_retains_worker_until_thread_finished(monkeypatch):
+    """WP-3.9 Finding 1 회귀: worker는 self._test_worker에 보관되어야 하고,
+    결과 시그널(test_finished)만으로는 해제되면 안 되며, 내장 QThread.finished()
+    발화 이후에만 참조를 해제하고 dialog dismiss를 허용해야 한다.
+
+    실제 QThread를 실행하면 HANG/크래시 위험이 있으므로 start()를 no-op으로
+    교체하고 시그널만 직접 emit한다.
+    """
+    monkeypatch.setattr(ConnectionTestWorker, "start", lambda self: None)
+
+    parent = ParentWithTunnels()
+    dialog = TunnelConfigDialog(parent, tunnel_data={"id": "current"}, tunnel_engine=object())
+    progress_dialog = None
+    try:
+        progress_dialog = dialog._start_connection_test(
+            TestType.TUNNEL_ONLY, {"name": "t"}, None, "터널 테스트"
+        )
+
+        worker = dialog._test_worker
+        assert worker is not None
+        assert progress_dialog._dismissable is False
+
+        # 결과 시그널만으로는 아직 참조를 해제하면 안 된다
+        worker.test_finished.emit(True, "ok")
+        assert dialog._test_worker is worker
+        assert progress_dialog._dismissable is False
+
+        # 내장 QThread.finished()가 발화한 뒤에만 참조 해제 + dismiss 허용
+        worker.finished.emit()
+        assert dialog._test_worker is None
+        assert progress_dialog._dismissable is True
+    finally:
+        if progress_dialog is not None:
+            progress_dialog.close()
+        dialog.close()
+        parent.close()
+
+
+def test_temp_credentials_prefers_plain_password_then_encrypted_fallback():
+    """WP-3.9 Finding 2 회귀: _test_db_only/_test_integrated에 각각 인라인으로
+    중복 정의되어 있던 임시 자격증명 클래스를 하나로 통합한 _TempCredentials가
+    기존 우선순위(평문 > 암호화+encryptor > None)를 그대로 보존해야 한다.
+    """
+
+    class FakeEncryptor:
+        def decrypt(self, value):
+            return f"decrypted:{value}"
+
+    plain = _TempCredentials("alice", "plainpw", None, None)
+    assert plain.get_tunnel_credentials("any-id") == ("alice", "plainpw")
+
+    encrypted_only = _TempCredentials("bob", "", "enc-blob", FakeEncryptor())
+    assert encrypted_only.get_tunnel_credentials("any-id") == ("bob", "decrypted:enc-blob")
+
+    neither = _TempCredentials("carol", "", None, None)
+    assert neither.get_tunnel_credentials("any-id") == ("carol", None)
+
+
+def test_test_db_only_and_test_integrated_share_temp_credentials_class():
+    """WP-3.9 Finding 2 회귀: 두 테스트 플로우가 더 이상 각자 인라인 클래스를
+    재정의하지 않고 동일한 모듈 레벨 _TempCredentials를 공유해야 한다.
+    """
+    db_only_src = inspect.getsource(TunnelConfigDialog._test_db_only)
+    integrated_src = inspect.getsource(TunnelConfigDialog._test_integrated)
+
+    for src in (db_only_src, integrated_src):
+        assert "class " not in src, "임시 자격증명 클래스가 인라인으로 재정의되면 안 된다"
+        assert "_TempCredentials(" in src


### PR DESCRIPTION
## 요약

WP-3.9 감사 finding 2건 수정 (`src/ui/dialogs/tunnel_config.py`).

### Finding 1 [MED][concurrency] - ConnectionTestWorker(QThread) 생명주기

`_test_tunnel_only` / `_test_db_only` / `_test_integrated` 세 곳 모두 `ConnectionTestWorker(QThread)`를 로컬 변수로만 잡고 `TestProgressDialog.exec()`를 돌았다. 테스트 실행 중 `TestProgressDialog`는 닫기 버튼이 숨겨져 있지만 ESC 키(및 Alt+F4 등 `QDialog.closeEvent`도 내부적으로 `reject()`를 호출)로 `reject()`가 트리거되면 `exec()`가 즉시 반환되고, 메서드가 반환되며 로컬 `worker` 참조 카운트가 0이 되어 **실행 중인 QThread가 파괴되는 하드 크래시**("QThread: Destroyed while thread is still running")로 이어졌다.

추가로 `ConnectionTestWorker`가 결과 전달용 `finished = pyqtSignal(bool, str)`로 `QThread` 내장 `finished()` 시그널을 **shadow**하고 있어, "스레드가 실제로 정지했다"는 신호를 별도로 받을 방법이 없었다.

**수정**:
- `ConnectionTestWorker`의 결과 시그널을 `test_finished(bool, str)`로 분리 — 내장 `QThread.finished()`를 더 이상 shadow하지 않음
- `TunnelConfigDialog.__init__`에 `self._test_worker`를 추가해 워커를 인스턴스에 보관
- `_RunningTestProgressDialog`(`TestProgressDialog` 서브클래스)를 도입해 워커가 완전히 정지(`allow_dismiss()` 호출)하기 전까지 `reject()`를 차단
- worker 참조 해제(`self._test_worker = None`)와 `allow_dismiss()`는 **내장 `QThread.finished()`**(무인자, shadow되지 않은 진짜 시그널)가 발화한 뒤에만 수행
- 세 테스트 메서드의 공통 로직을 `_start_connection_test` 헬퍼로 통합해 3곳 모두 동일 패턴 적용

### Finding 2 [LOW][duplication] - 임시 자격증명 클래스 중복

동일한 `TempConfigManager` 클래스가 `_test_db_only`와 `_test_integrated` 안에 인라인으로 두 번 정의되어 있었다 (자격증명 해석 로직 복붙 — 한쪽만 수정되면 두 흐름이 조용히 발산할 위험).

**수정**: 모듈 레벨 `_TempCredentials` 클래스로 hoist해서 두 플로우가 공유하도록 통합.

## 회귀 테스트

- `tests/test_connection_test_worker.py`: `test_finished`와 내장 `finished()`가 서로 독립적으로 동작함을 검증
- `tests/test_tunnel_config_dialog.py`:
  - `_RunningTestProgressDialog`가 `allow_dismiss()` 전까지 `reject()`를 차단하는지 검증
  - `_start_connection_test`가 worker를 `self._test_worker`에 보관하고, 결과 시그널만으로는 해제하지 않으며, 내장 `QThread.finished()` 이후에만 해제 + dismiss 허용하는지 검증
  - `_TempCredentials`의 우선순위(평문 > 암호화+encryptor > None) 검증
  - `_test_db_only`/`_test_integrated`가 더 이상 인라인 클래스를 재정의하지 않고 `_TempCredentials`를 공유하는지 소스 검사로 검증

모든 신규 테스트는 실제 `QThread`를 실행하지 않고 `start()`를 no-op으로 교체한 뒤 시그널만 직접 emit하는 방식으로 작성해 HANG/크래시 위험을 없앴다.

## 검증

- `python -m py_compile` (4개 대상 파일): 통과
- `pytest tests/test_tunnel_config_dialog.py tests/test_connection_test_worker.py -q`: 11 passed
- `pytest -q` (전체): 2039 passed, 1 failed — `test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`는 GitHub CI 상태에 의존하는 알려진 로컬 플레이키 테스트로 이번 변경과 무관

## Test plan

- [x] `py_compile` 통과
- [x] 대상 테스트 단독 실행 통과 (11 passed)
- [x] 전체 테스트 스위트 실행 (2039 passed, 1 known-flaky failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)