### PR TITLE
fix(migration-fix-wizard): stray @dataclass 데코레이터 6개 제거

### DIFF
--- a/src/core/migration_fix_wizard.py
+++ b/src/core/migration_fix_wizard.py
@@ -27,25 +27,6 @@ from src.core.migration_fix_models import (
 from src.core.migration_rollback_sql_generator import RollbackSQLGenerator
 
 
-
-
-@dataclass
-
-
-@dataclass
-
-
-@dataclass
-
-
-@dataclass
-
-
-@dataclass
-
-
-
-
 class SmartFixGenerator:
     """컨텍스트 인식 Fix 옵션 생성기
 
@@ -1304,11 +1285,6 @@ class BatchFixExecutor:
                 sql_executed=sql,
                 error=str(e)
             )
-
-
-
-
-@dataclass
 
 
 class CharsetFixPlanBuilder:


### PR DESCRIPTION
## 배경
Codex에게 PR #208~#215(대형 파일 분해 시리즈)의 안전성 검증을 요청한 결과, PR #212(migration_fix_wizard.py 분해)에서 실제 버그를 발견했습니다.

## 문제
PR #212에서 `migration_fix_models.py`로 dataclass 6개(`FKDefinition`, `FixOption`, `FixWizardStep`, `FixExecutionResult`, `BatchExecutionResult`, `CharsetTableInfo`)를 옮길 때, 클래스 본문은 새 파일로 옮겼지만 **원본 파사드 파일에서 각 클래스의 `@dataclass` 데코레이터 줄만 지우지 않고 남겨뒀습니다**. 그 결과 파일 안에서 뒤이어 나오는 일반 클래스 `SmartFixGenerator`(데코레이터 5개 누적)와 `CharsetFixPlanBuilder`(데코레이터 1개)가 의도치 않게 dataclass 취급을 받게 됐습니다.

## 영향
dataclass가 아니던 두 클래스가 필드 없는 dataclass 취급을 받아:
- 서로 다른 인스턴스라도 `==` 비교 시 항상 `True` 반환
- `hash()` 호출 시 `TypeError` 발생

둘 다 이 코드베이스에서 현재 실제로 트리거되는 동작은 아니었으나, 잠재적 버그였습니다.

## 수정
두 클래스 앞의 stray `@dataclass` 줄 6개(및 주변 중복 빈 줄)만 제거. 클래스 본문은 전혀 건드리지 않았습니다.

## 검증
- [x] 관련 pytest(`test_migration_fix_wizard.py`): 93 passed
- [x] 전체 `pytest -q`: 1809 passed, 1 known-flaky(macOS CI 의존)
- [x] `python -m py_compile` 통과
- [x] `dataclasses.is_dataclass(SmartFixGenerator)` / `is_dataclass(CharsetFixPlanBuilder)` 둘 다 `False`로 직접 확인
- [x] 앱 스모크 체크: `success: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)