### PR TITLE
refactor(config-manager): 그룹 CRUD를 TunnelGroupManager로 분리

### DIFF
--- a/src/core/config_manager.py
+++ b/src/core/config_manager.py
@@ -11,6 +11,7 @@ from cryptography.fernet import Fernet
 from src.core.logger import get_logger
 from src.core.constants import DEFAULT_MYSQL_PORT
 from src.core.platform_paths import backups_dir, config_file, encryption_key_file, app_support_dir
+from src.core.group_manager import TunnelGroupManager
 
 logger = get_logger('config_manager')
 
@@ -19,6 +20,7 @@ CONFIG_FILE = str(config_file())
 KEY_FILE = str(encryption_key_file())
 BACKUP_DIR = str(backups_dir())
 MAX_BACKUPS = 5
+FILE_ATTRIBUTE_HIDDEN = 0x02  # Win32 SetFileAttributesW 플래그: 숨김 파일 속성
 
 # load_config/save_config를 여러 스레드(스케줄러, UI)가 동시에 호출해도
 # 설정 파일이 중간 상태로 노출되지 않도록 보호하는 프로세스 전역 락.
@@ -63,7 +65,7 @@ class CredentialEncryptor:
             # Windows 숨김 파일 설정
             if os.name == 'nt':
                 import ctypes
-                ctypes.windll.kernel32.SetFileAttributesW(KEY_FILE, 0x02)
+                ctypes.windll.kernel32.SetFileAttributesW(KEY_FILE, FILE_ATTRIBUTE_HIDDEN)
 
         with open(KEY_FILE, 'rb') as f:
             self._fernet = Fernet(f.read())
@@ -87,6 +89,7 @@ class CredentialEncryptor:
 class ConfigManager:
     def __init__(self):
         self._encryptor = None
+        self._group_manager = None
         self._ensure_config_exists()
 
     def _default_config(self) -> dict:
@@ -270,6 +273,20 @@ class ConfigManager:
         """설정 데이터를 파일에 저장합니다."""
         with _CONFIG_LOCK:
             self._save_config_unlocked(data)
+
+    def _mutate_config(self, mutator):
+        """config를 로드 -> mutator로 변경 -> 필요 시에만 저장하는 공통 헬퍼.
+
+        mutator는 config(dict)를 받아 (should_save: bool, result) 튜플을 반환하는
+        콜러블이다. should_save가 False면 save_config를 호출하지 않는다 (조기 실패
+        반환 시 백업 로테이션/리비전 갱신이 일어나지 않던 기존 동작을 보존하기 위함).
+        """
+        with _CONFIG_LOCK:
+            config = self.load_config()
+            should_save, result = mutator(config)
+            if should_save:
+                self.save_config(config)
+            return result
 
     def _create_backup(self, exclude_paths: Optional[set] = None):
         """설정 변경 전 자동 백업.
@@ -572,12 +589,13 @@ class ConfigManager:
 
     def set_app_setting(self, key, value):
         """앱 설정 값 저장 (기존 설정 유지)"""
-        with _CONFIG_LOCK:
-            config = self.load_config()
+        def mutator(config):
             if 'settings' not in config:
                 config['settings'] = {}
             config['settings'][key] = value
-            self.save_config(config)
+            return True, None
+
+        self._mutate_config(mutator)
 
     @property
     def encryptor(self):
@@ -585,6 +603,13 @@ class ConfigManager:
         if self._encryptor is None:
             self._encryptor = CredentialEncryptor()
         return self._encryptor
+
+    @property
+    def group_manager(self) -> TunnelGroupManager:
+        """TunnelGroupManager 인스턴스 (lazy initialization)"""
+        if self._group_manager is None:
+            self._group_manager = TunnelGroupManager(self)
+        return self._group_manager
 
     def get_tunnel_credentials(self, tunnel_id: str) -> tuple:
         """터널의 MySQL 자격 증명 조회 -> (user, password)"""
@@ -599,10 +624,11 @@ class ConfigManager:
 
     def save_active_tunnels(self, tunnel_ids: list):
         """종료 시 활성화된 터널 ID 목록 저장"""
-        with _CONFIG_LOCK:
-            config = self.load_config()
+        def mutator(config):
             config['last_active_tunnels'] = tunnel_ids
-            self.save_config(config)
+            return True, None
+
+        self._mutate_config(mutator)
         logger.info(f"활성 터널 상태 저장: {len(tunnel_ids)}개")
 
     def get_last_active_tunnels(self) -> list:
@@ -615,16 +641,15 @@ class ConfigManager:
     # =========================================================================
 
     def get_groups(self) -> List[dict]:
-        """모든 그룹 목록 반환
+        """모든 그룹 목록 반환 (TunnelGroupManager 위임)
 
         Returns:
             그룹 목록: [{"id", "name", "color", "collapsed", "tunnel_ids"}, ...]
         """
-        config = self.load_config()
-        return config.get('tunnel_groups', [])
+        return self.group_manager.get_groups()
 
     def add_group(self, name: str, color: str = "#3498db") -> Tuple[bool, str, Optional[str]]:
-        """새 그룹 생성
+        """새 그룹 생성 (TunnelGroupManager 위임)
 
         Args:
             name: 그룹 이름
@@ -633,33 +658,10 @@ class ConfigManager:
         Returns:
             (success, message, group_id) 튜플
         """
-        with _CONFIG_LOCK:
-            config = self.load_config()
-
-            if 'tunnel_groups' not in config:
-                config['tunnel_groups'] = []
-
-            # 중복 이름 확인
-            for group in config['tunnel_groups']:
-                if group['name'] == name:
-                    return False, f"이미 존재하는 그룹 이름입니다: {name}", None
-
-            group_id = str(uuid.uuid4())
-            new_group = {
-                "id": group_id,
-                "name": name,
-                "color": color,
-                "collapsed": False,
-                "tunnel_ids": []
-            }
-
-            config['tunnel_groups'].append(new_group)
-            self.save_config(config)
-        logger.info(f"그룹 생성: {name} (ID: {group_id})")
-        return True, f"그룹이 생성되었습니다: {name}", group_id
+        return self.group_manager.add_group(name, color)
 
     def update_group(self, group_id: str, data: dict) -> Tuple[bool, str]:
-        """그룹 정보 수정
+        """그룹 정보 수정 (TunnelGroupManager 위임)
 
         Args:
             group_id: 수정할 그룹 ID
@@ -668,31 +670,10 @@ class ConfigManager:
         Returns:
             (success, message) 튜플
         """
-        with _CONFIG_LOCK:
-            config = self.load_config()
-            groups = config.get('tunnel_groups', [])
-
-            for group in groups:
-                if group['id'] == group_id:
-                    # 이름 변경 시 중복 확인
-                    if 'name' in data and data['name'] != group['name']:
-                        for other in groups:
-                            if other['id'] != group_id and other['name'] == data['name']:
-                                return False, f"이미 존재하는 그룹 이름입니다: {data['name']}"
-
-                    # 허용된 필드만 업데이트
-                    for key in ['name', 'color', 'collapsed']:
-                        if key in data:
-                            group[key] = data[key]
-
-                    self.save_config(config)
-                    logger.info(f"그룹 수정: {group_id}")
-                    return True, "그룹이 수정되었습니다."
-
-            return False, f"그룹을 찾을 수 없습니다: {group_id}"
+        return self.group_manager.update_group(group_id, data)
 
     def delete_group(self, group_id: str) -> Tuple[bool, str]:
-        """그룹 삭제 (터널은 그룹 없음으로 이동)
+        """그룹 삭제 (TunnelGroupManager 위임, 터널은 그룹 없음으로 이동)
 
         Args:
             group_id: 삭제할 그룹 ID
@@ -700,29 +681,10 @@ class ConfigManager:
         Returns:
             (success, message) 튜플
         """
-        with _CONFIG_LOCK:
-            config = self.load_config()
-            groups = config.get('tunnel_groups', [])
-
-            for i, group in enumerate(groups):
-                if group['id'] == group_id:
-                    group_name = group['name']
-
-                    # 그룹에 속한 터널들을 ungrouped_order로 이동
-                    if 'ungrouped_order' not in config:
-                        config['ungrouped_order'] = []
-                    config['ungrouped_order'].extend(group.get('tunnel_ids', []))
-
-                    # 그룹 삭제
-                    groups.pop(i)
-                    self.save_config(config)
-                    logger.info(f"그룹 삭제: {group_name} (ID: {group_id})")
-                    return True, f"그룹이 삭제되었습니다: {group_name}"
-
-            return False, f"그룹을 찾을 수 없습니다: {group_id}"
+        return self.group_manager.delete_group(group_id)
 
     def move_tunnel_to_group(self, tunnel_id: str, group_id: Optional[str]) -> Tuple[bool, str]:
-        """터널을 그룹으로 이동
+        """터널을 그룹으로 이동 (TunnelGroupManager 위임)
 
         Args:
             tunnel_id: 이동할 터널 ID
@@ -731,46 +693,10 @@ class ConfigManager:
         Returns:
             (success, message) 튜플
         """
-        with _CONFIG_LOCK:
-            config = self.load_config()
-
-            # 터널 존재 확인
-            tunnel_exists = any(t['id'] == tunnel_id for t in config.get('tunnels', []))
-            if not tunnel_exists:
-                return False, f"터널을 찾을 수 없습니다: {tunnel_id}"
-
-            # ungrouped_order 초기화
-            if 'ungrouped_order' not in config:
-                config['ungrouped_order'] = []
-
-            # 기존 그룹에서 터널 제거
-            for group in config.get('tunnel_groups', []):
-                if tunnel_id in group.get('tunnel_ids', []):
-                    group['tunnel_ids'].remove(tunnel_id)
-
-            # ungrouped_order에서도 제거
-            if tunnel_id in config['ungrouped_order']:
-                config['ungrouped_order'].remove(tunnel_id)
-
-            # 새 그룹에 추가 또는 ungrouped로 이동
-            if group_id is None:
-                config['ungrouped_order'].append(tunnel_id)
-            else:
-                for group in config.get('tunnel_groups', []):
-                    if group['id'] == group_id:
-                        if 'tunnel_ids' not in group:
-                            group['tunnel_ids'] = []
-                        group['tunnel_ids'].append(tunnel_id)
-                        break
-                else:
-                    return False, f"대상 그룹을 찾을 수 없습니다: {group_id}"
-
-            self.save_config(config)
-        logger.debug(f"터널 이동: {tunnel_id} -> 그룹 {group_id or '(없음)'}")
-        return True, "터널이 이동되었습니다."
+        return self.group_manager.move_tunnel_to_group(tunnel_id, group_id)
 
     def get_tunnel_group(self, tunnel_id: str) -> Optional[str]:
-        """터널이 속한 그룹 ID 반환
+        """터널이 속한 그룹 ID 반환 (TunnelGroupManager 위임)
 
         Args:
             tunnel_id: 터널 ID
@@ -778,16 +704,10 @@ class ConfigManager:
         Returns:
             그룹 ID (그룹 없으면 None)
         """
-        config = self.load_config()
-
-        for group in config.get('tunnel_groups', []):
-            if tunnel_id in group.get('tunnel_ids', []):
-                return group['id']
-
-        return None
+        return self.group_manager.get_tunnel_group(tunnel_id)
 
     def save_group_collapsed_state(self, group_id: str, collapsed: bool) -> bool:
-        """그룹 접기/펼치기 상태 저장
+        """그룹 접기/펼치기 상태 저장 (TunnelGroupManager 위임)
 
         Args:
             group_id: 그룹 ID
@@ -796,13 +716,4 @@ class ConfigManager:
         Returns:
             성공 여부
         """
-        with _CONFIG_LOCK:
-            config = self.load_config()
-
-            for group in config.get('tunnel_groups', []):
-                if group['id'] == group_id:
-                    group['collapsed'] = collapsed
-                    self.save_config(config)
-                    return True
-
-            return False
+        return self.group_manager.save_group_collapsed_state(group_id, collapsed)

--- a/src/core/group_manager.py
+++ b/src/core/group_manager.py
@@ -1,0 +1,218 @@
+"""
+터널 그룹 관리 - TunnelGroupManager
+
+ConfigManager로부터 주입받아 그룹 CRUD(생성/수정/삭제/이동/조회/접기상태)를 담당한다.
+읽기는 config_manager.load_config(), 쓰기는 config_manager._mutate_config(...)를 통해서만
+수행하며, 모듈 레벨 경로/락 상수는 두지 않는다 (ConfigManager가 reload로 테스트 격리를
+하므로, 상태는 반드시 주입된 인스턴스를 통해서만 접근해야 한다).
+"""
+import uuid
+from typing import List, Optional, Tuple, TYPE_CHECKING
+
+from src.core.logger import get_logger
+
+if TYPE_CHECKING:
+    from src.core.config_manager import ConfigManager
+
+logger = get_logger('group_manager')
+
+
+class TunnelGroupManager:
+    """터널 그룹 CRUD 담당. config_manager 인스턴스를 주입받아 load/save를 위임한다."""
+
+    def __init__(self, config_manager: "ConfigManager"):
+        self._config = config_manager
+
+    def get_groups(self) -> List[dict]:
+        """모든 그룹 목록 반환
+
+        Returns:
+            그룹 목록: [{"id", "name", "color", "collapsed", "tunnel_ids"}, ...]
+        """
+        config = self._config.load_config()
+        return config.get('tunnel_groups', [])
+
+    def add_group(self, name: str, color: str = "#3498db") -> Tuple[bool, str, Optional[str]]:
+        """새 그룹 생성
+
+        Args:
+            name: 그룹 이름
+            color: 그룹 색상 (hex 코드)
+
+        Returns:
+            (success, message, group_id) 튜플
+        """
+        def mutator(config):
+            if 'tunnel_groups' not in config:
+                config['tunnel_groups'] = []
+
+            # 중복 이름 확인
+            for group in config['tunnel_groups']:
+                if group['name'] == name:
+                    return False, (False, f"이미 존재하는 그룹 이름입니다: {name}", None)
+
+            group_id = str(uuid.uuid4())
+            new_group = {
+                "id": group_id,
+                "name": name,
+                "color": color,
+                "collapsed": False,
+                "tunnel_ids": []
+            }
+
+            config['tunnel_groups'].append(new_group)
+            return True, (True, f"그룹이 생성되었습니다: {name}", group_id)
+
+        success, message, group_id = self._config._mutate_config(mutator)
+        if success:
+            logger.info(f"그룹 생성: {name} (ID: {group_id})")
+        return success, message, group_id
+
+    def update_group(self, group_id: str, data: dict) -> Tuple[bool, str]:
+        """그룹 정보 수정
+
+        Args:
+            group_id: 수정할 그룹 ID
+            data: 수정할 필드들 {"name", "color", "collapsed"}
+
+        Returns:
+            (success, message) 튜플
+        """
+        def mutator(config):
+            groups = config.get('tunnel_groups', [])
+
+            for group in groups:
+                if group['id'] == group_id:
+                    # 이름 변경 시 중복 확인
+                    if 'name' in data and data['name'] != group['name']:
+                        for other in groups:
+                            if other['id'] != group_id and other['name'] == data['name']:
+                                return False, (False, f"이미 존재하는 그룹 이름입니다: {data['name']}")
+
+                    # 허용된 필드만 업데이트
+                    for key in ['name', 'color', 'collapsed']:
+                        if key in data:
+                            group[key] = data[key]
+
+                    logger.info(f"그룹 수정: {group_id}")
+                    return True, (True, "그룹이 수정되었습니다.")
+
+            return False, (False, f"그룹을 찾을 수 없습니다: {group_id}")
+
+        return self._config._mutate_config(mutator)
+
+    def delete_group(self, group_id: str) -> Tuple[bool, str]:
+        """그룹 삭제 (터널은 그룹 없음으로 이동)
+
+        Args:
+            group_id: 삭제할 그룹 ID
+
+        Returns:
+            (success, message) 튜플
+        """
+        def mutator(config):
+            groups = config.get('tunnel_groups', [])
+
+            for i, group in enumerate(groups):
+                if group['id'] == group_id:
+                    group_name = group['name']
+
+                    # 그룹에 속한 터널들을 ungrouped_order로 이동
+                    if 'ungrouped_order' not in config:
+                        config['ungrouped_order'] = []
+                    config['ungrouped_order'].extend(group.get('tunnel_ids', []))
+
+                    # 그룹 삭제
+                    groups.pop(i)
+                    logger.info(f"그룹 삭제: {group_name} (ID: {group_id})")
+                    return True, (True, f"그룹이 삭제되었습니다: {group_name}")
+
+            return False, (False, f"그룹을 찾을 수 없습니다: {group_id}")
+
+        return self._config._mutate_config(mutator)
+
+    def move_tunnel_to_group(self, tunnel_id: str, group_id: Optional[str]) -> Tuple[bool, str]:
+        """터널을 그룹으로 이동
+
+        Args:
+            tunnel_id: 이동할 터널 ID
+            group_id: 대상 그룹 ID (None이면 그룹 없음으로 이동)
+
+        Returns:
+            (success, message) 튜플
+        """
+        def mutator(config):
+            # 터널 존재 확인
+            tunnel_exists = any(t['id'] == tunnel_id for t in config.get('tunnels', []))
+            if not tunnel_exists:
+                return False, (False, f"터널을 찾을 수 없습니다: {tunnel_id}")
+
+            # ungrouped_order 초기화
+            if 'ungrouped_order' not in config:
+                config['ungrouped_order'] = []
+
+            # 기존 그룹에서 터널 제거
+            for group in config.get('tunnel_groups', []):
+                if tunnel_id in group.get('tunnel_ids', []):
+                    group['tunnel_ids'].remove(tunnel_id)
+
+            # ungrouped_order에서도 제거
+            if tunnel_id in config['ungrouped_order']:
+                config['ungrouped_order'].remove(tunnel_id)
+
+            # 새 그룹에 추가 또는 ungrouped로 이동
+            if group_id is None:
+                config['ungrouped_order'].append(tunnel_id)
+            else:
+                for group in config.get('tunnel_groups', []):
+                    if group['id'] == group_id:
+                        if 'tunnel_ids' not in group:
+                            group['tunnel_ids'] = []
+                        group['tunnel_ids'].append(tunnel_id)
+                        break
+                else:
+                    return False, (False, f"대상 그룹을 찾을 수 없습니다: {group_id}")
+
+            return True, (True, "터널이 이동되었습니다.")
+
+        success, message = self._config._mutate_config(mutator)
+        if success:
+            logger.debug(f"터널 이동: {tunnel_id} -> 그룹 {group_id or '(없음)'}")
+        return success, message
+
+    def get_tunnel_group(self, tunnel_id: str) -> Optional[str]:
+        """터널이 속한 그룹 ID 반환
+
+        Args:
+            tunnel_id: 터널 ID
+
+        Returns:
+            그룹 ID (그룹 없으면 None)
+        """
+        config = self._config.load_config()
+
+        for group in config.get('tunnel_groups', []):
+            if tunnel_id in group.get('tunnel_ids', []):
+                return group['id']
+
+        return None
+
+    def save_group_collapsed_state(self, group_id: str, collapsed: bool) -> bool:
+        """그룹 접기/펼치기 상태 저장
+
+        Args:
+            group_id: 그룹 ID
+            collapsed: 접힘 상태
+
+        Returns:
+            성공 여부
+        """
+        def mutator(config):
+            for group in config.get('tunnel_groups', []):
+                if group['id'] == group_id:
+                    group['collapsed'] = collapsed
+                    return True, True
+
+            return False, False
+
+        return self._config._mutate_config(mutator)

--- a/tests/test_group_manager.py
+++ b/tests/test_group_manager.py
@@ -1,0 +1,254 @@
+"""
+TunnelGroupManager 테스트
+"""
+import pytest
+import os
+import importlib
+from unittest.mock import patch
+
+# 실제 패키지로 import해둔다. 각 테스트는 patch.dict(os.environ, ...)를 적용한
+# 뒤 이 모듈을 reload해서 모듈 레벨 경로 상수를 그 테스트의 임시 디렉토리
+# 기준으로 다시 계산하게 만든다. (tests/test_config_manager.py와 동일 패턴)
+import src.core.config_manager as _config_manager_module
+
+
+def _load_config_manager_module():
+    """환경변수(LOCALAPPDATA/HOME) 패치가 적용된 상태에서 config_manager를 reload한다."""
+    return importlib.reload(_config_manager_module)
+
+
+class TestTunnelGroupManager:
+    """TunnelGroupManager 클래스 테스트"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        """각 테스트 전 임시 디렉토리로 환경 설정"""
+        self.test_dir = tmp_path / 'TunnelForge'
+        self.test_dir.mkdir()
+
+        self.env_patch = patch.dict(
+            os.environ,
+            {'LOCALAPPDATA': str(tmp_path), 'HOME': str(tmp_path)}
+        )
+        self.env_patch.start()
+
+        config_module = _load_config_manager_module()
+        self.config_module = config_module
+        self.config_mgr = config_module.ConfigManager()
+        self.group_mgr = self.config_mgr.group_manager
+
+    def teardown_method(self):
+        self.env_patch.stop()
+
+    # -- add_group -----------------------------------------------------
+
+    def test_add_group_success(self):
+        """정상적인 그룹 생성"""
+        success, msg, group_id = self.group_mgr.add_group("운영 서버", "#ff0000")
+
+        assert success is True
+        assert "생성" in msg
+        assert group_id is not None
+
+        groups = self.group_mgr.get_groups()
+        assert len(groups) == 1
+        assert groups[0]['id'] == group_id
+        assert groups[0]['name'] == "운영 서버"
+        assert groups[0]['color'] == "#ff0000"
+        assert groups[0]['collapsed'] is False
+        assert groups[0]['tunnel_ids'] == []
+
+    def test_add_group_duplicate_name_rejected_without_save(self):
+        """중복된 그룹 이름은 거부되고 저장도 되지 않아야 한다"""
+        self.group_mgr.add_group("운영 서버")
+
+        backups_before = self.config_mgr.list_backups()
+
+        success, msg, group_id = self.group_mgr.add_group("운영 서버")
+
+        assert success is False
+        assert "이미 존재하는" in msg
+        assert group_id is None
+
+        groups = self.group_mgr.get_groups()
+        assert len(groups) == 1
+
+        # 조기 실패 반환이므로 저장(백업 생성)이 일어나지 않아야 한다
+        backups_after = self.config_mgr.list_backups()
+        assert len(backups_after) == len(backups_before)
+
+    # -- update_group ----------------------------------------------------
+
+    def test_update_group_not_found(self):
+        """존재하지 않는 그룹 수정 시 실패"""
+        success, msg = self.group_mgr.update_group("no-such-id", {"name": "new"})
+
+        assert success is False
+        assert "찾을 수 없습니다" in msg
+
+    def test_update_group_rename_duplicate_rejected(self):
+        """다른 그룹과 이름이 겹치는 rename은 거부되어야 한다"""
+        _, _, group_id_a = self.group_mgr.add_group("그룹 A")
+        _, _, group_id_b = self.group_mgr.add_group("그룹 B")
+
+        success, msg = self.group_mgr.update_group(group_id_b, {"name": "그룹 A"})
+
+        assert success is False
+        assert "이미 존재하는" in msg
+
+        groups = {g['id']: g for g in self.group_mgr.get_groups()}
+        assert groups[group_id_b]['name'] == "그룹 B"
+
+    def test_update_group_success(self):
+        """정상적인 그룹 수정"""
+        _, _, group_id = self.group_mgr.add_group("그룹 A", "#111111")
+
+        success, msg = self.group_mgr.update_group(
+            group_id, {"name": "그룹 A2", "color": "#222222", "collapsed": True}
+        )
+
+        assert success is True
+        assert "수정" in msg
+
+        groups = {g['id']: g for g in self.group_mgr.get_groups()}
+        assert groups[group_id]['name'] == "그룹 A2"
+        assert groups[group_id]['color'] == "#222222"
+        assert groups[group_id]['collapsed'] is True
+
+    # -- delete_group ----------------------------------------------------
+
+    def test_delete_group_moves_tunnels_to_ungrouped_order(self):
+        """그룹 삭제 시 tunnel_ids가 ungrouped_order로 이동해야 한다"""
+        _, _, group_id = self.group_mgr.add_group("그룹 A")
+
+        # delete_group은 group.tunnel_ids를 그대로 옮기므로, move_tunnel_to_group을
+        # 거치지 않고 config에 직접 tunnel_ids를 채워 시나리오를 구성한다.
+        config = self.config_mgr.load_config()
+        for group in config['tunnel_groups']:
+            if group['id'] == group_id:
+                group['tunnel_ids'] = ["tunnel-1", "tunnel-2"]
+        self.config_mgr.save_config(config)
+
+        success, msg = self.group_mgr.delete_group(group_id)
+
+        assert success is True
+        assert "삭제" in msg
+        assert self.group_mgr.get_groups() == []
+
+        config = self.config_mgr.load_config()
+        assert set(config.get('ungrouped_order', [])) == {"tunnel-1", "tunnel-2"}
+
+    def test_delete_group_not_found(self):
+        """존재하지 않는 그룹 삭제 시 실패"""
+        success, msg = self.group_mgr.delete_group("no-such-id")
+
+        assert success is False
+        assert "찾을 수 없습니다" in msg
+
+    # -- move_tunnel_to_group ---------------------------------------------
+
+    def test_move_tunnel_to_group_tunnel_not_found(self):
+        """존재하지 않는 터널을 이동하려 하면 실패"""
+        _, _, group_id = self.group_mgr.add_group("그룹 A")
+
+        sample_config_data = self.config_mgr.load_config()
+        sample_config_data['tunnels'] = []
+        self.config_mgr.save_config(sample_config_data)
+
+        success, msg = self.group_mgr.move_tunnel_to_group("no-such-tunnel", group_id)
+
+        assert success is False
+        assert "터널을 찾을 수 없습니다" in msg
+
+    def test_move_tunnel_to_group_target_group_not_found(self, sample_config_data):
+        """존재하지 않는 대상 그룹으로 이동하려 하면 실패"""
+        self.config_mgr.save_config(sample_config_data)
+
+        success, msg = self.group_mgr.move_tunnel_to_group("test-001", "no-such-group")
+
+        assert success is False
+        assert "대상 그룹을 찾을 수 없습니다" in msg
+
+    def test_move_tunnel_to_group_none_moves_to_ungrouped(self, sample_config_data):
+        """group_id=None이면 그룹 없음(ungrouped_order)으로 이동해야 한다"""
+        self.config_mgr.save_config(sample_config_data)
+        _, _, group_id = self.group_mgr.add_group("그룹 A")
+        self.group_mgr.move_tunnel_to_group("test-001", group_id)
+
+        success, msg = self.group_mgr.move_tunnel_to_group("test-001", None)
+
+        assert success is True
+        assert self.group_mgr.get_tunnel_group("test-001") is None
+
+        config = self.config_mgr.load_config()
+        assert "test-001" in config.get('ungrouped_order', [])
+
+    def test_move_tunnel_to_group_between_groups(self, sample_config_data):
+        """터널을 한 그룹에서 다른 그룹으로 이동하면 이전 그룹에서 제거되어야 한다"""
+        self.config_mgr.save_config(sample_config_data)
+        _, _, group_id_a = self.group_mgr.add_group("그룹 A")
+        _, _, group_id_b = self.group_mgr.add_group("그룹 B")
+
+        self.group_mgr.move_tunnel_to_group("test-001", group_id_a)
+        success, msg = self.group_mgr.move_tunnel_to_group("test-001", group_id_b)
+
+        assert success is True
+        assert self.group_mgr.get_tunnel_group("test-001") == group_id_b
+
+        groups = {g['id']: g for g in self.group_mgr.get_groups()}
+        assert "test-001" not in groups[group_id_a]['tunnel_ids']
+        assert "test-001" in groups[group_id_b]['tunnel_ids']
+
+    # -- get_tunnel_group --------------------------------------------------
+
+    def test_get_tunnel_group_none_when_ungrouped(self, sample_config_data):
+        """그룹에 속하지 않은 터널은 None을 반환해야 한다"""
+        self.config_mgr.save_config(sample_config_data)
+
+        assert self.group_mgr.get_tunnel_group("test-001") is None
+
+    # -- save_group_collapsed_state ------------------------------------------
+
+    def test_save_group_collapsed_state_success(self):
+        """그룹 접기 상태 저장 성공"""
+        _, _, group_id = self.group_mgr.add_group("그룹 A")
+
+        result = self.group_mgr.save_group_collapsed_state(group_id, True)
+
+        assert result is True
+        groups = {g['id']: g for g in self.group_mgr.get_groups()}
+        assert groups[group_id]['collapsed'] is True
+
+    def test_save_group_collapsed_state_not_found(self):
+        """존재하지 않는 그룹의 접기 상태 저장은 실패해야 한다"""
+        result = self.group_mgr.save_group_collapsed_state("no-such-id", True)
+
+        assert result is False
+
+    # -- ConfigManager facade 위임 회귀 테스트 --------------------------------
+
+    def test_config_manager_facade_delegates_to_group_manager(self):
+        """ConfigManager의 그룹 메서드 호출이 여전히 동작해야 한다 (facade 위임)"""
+        success, msg, group_id = self.config_mgr.add_group("파사드 그룹", "#abcdef")
+        assert success is True
+
+        groups = self.config_mgr.get_groups()
+        assert any(g['id'] == group_id for g in groups)
+
+        success, msg = self.config_mgr.update_group(group_id, {"name": "파사드 그룹 2"})
+        assert success is True
+
+        assert self.config_mgr.save_group_collapsed_state(group_id, True) is True
+
+        # 이동 동작도 facade를 통해 확인
+        cfg = self.config_mgr.load_config()
+        cfg['tunnels'] = [{'id': 'facade-tunnel', 'name': 't', 'remote_host': 'h', 'remote_port': 3306}]
+        self.config_mgr.save_config(cfg)
+
+        success, msg = self.config_mgr.move_tunnel_to_group('facade-tunnel', group_id)
+        assert success is True
+        assert self.config_mgr.get_tunnel_group('facade-tunnel') == group_id
+
+        success, msg = self.config_mgr.delete_group(group_id)
+        assert success is True
+        assert self.config_mgr.get_groups() == []


### PR DESCRIPTION
## 요약

Clean Code 리팩토링 Round 1 [WP-1.3] — `src/core/config_manager.py`의 그룹 관리 책임을 `src/core/group_manager.py`의 `TunnelGroupManager`로 분리하는 순수 동작 보존 리팩토링입니다.

## Covered Findings

- **CC-000** (`config_manager.py:87`): `TunnelGroupManager` 신설, ConfigManager는 lazy `group_manager` 프로퍼티(기존 `encryptor` 프로퍼티 패턴과 동일)로 위임하는 facade 메서드 7개만 유지. `main_window.py`(8개 호출부)와 `tunnel_tree.py`(1개 호출부)는 시그니처 동일하게 유지되어 수정 불필요.
- **CC-003** (`config_manager.py:573`): `lock → load → mutate → save` 7회 반복 패턴을 `ConfigManager._mutate_config(mutator)` 헬퍼로 통합. `mutator`는 `(should_save, result)` 튜플을 반환하며, 조기 실패(중복 이름/미발견 등) 시에는 저장하지 않는 기존 동작을 그대로 보존합니다.
- **CC-017** (`config_manager.py:63`): `CredentialEncryptor._ensure_key_exists`의 매직 넘버 `0x02`를 `FILE_ATTRIBUTE_HIDDEN` 상수(Win32 `SetFileAttributesW` 플래그 주석 포함)로 교체.

## 설계 메모

- `group_manager.py`는 `config_manager`를 모듈 레벨에서 import하지 않습니다 (순환 import 회피, `TYPE_CHECKING` 전용 타입 힌트). 모듈 레벨 경로/락 상수도 두지 않아 `tests/test_config_manager.py`의 `importlib.reload` 기반 테스트 격리가 깨지지 않습니다.
- 로그 호출 위치는 기존과 동일하게 보존했습니다: `add_group`/`move_tunnel_to_group`은 락 해제 후(성공 시에만) 로깅, `update_group`/`delete_group`은 mutator 클로저 내부(락 안)에서 로깅합니다.
- `src/core/__init__.py`는 동일 라운드 다른 WP와의 파일 충돌을 피하기 위해 수정하지 않았습니다.

## 변경 파일

- `src/core/config_manager.py` (수정)
- `src/core/group_manager.py` (신규)
- `tests/test_group_manager.py` (신규 — 그룹 CRUD 유닛 테스트 부재 해소)

## 검증 결과

- `python -m py_compile src/core/config_manager.py src/core/group_manager.py` → 통과
- `python -m pytest tests/test_config_manager.py tests/test_group_manager.py -q` → 45 passed
- `python -m pytest -q` (전체) → 1824 passed, 1 failed
  - 실패 1건은 `test_rust_core_packaging.py::test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`로, GitHub CI 아티팩트에 의존하는 로컬 환경 flaky 테스트이며 이번 변경과 무관합니다 (기존에도 항상 실패).

🤖 Generated with [Claude Code](https://claude.com/claude-code)