### PR TITLE
refactor(sql-validator): sql_validator.py 4개 모듈 분할 + SYSTEM_SCHEMAS 단일화

### DIFF
--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -15,4 +15,5 @@ SYSTEM_SCHEMAS = frozenset({
     'mysql',
     'performance_schema',
     'sys',
+    'ndbinfo',
 })

--- a/src/core/sql_autocompleter.py
+++ b/src/core/sql_autocompleter.py
@@ -1,0 +1,204 @@
+"""
+SQL 자동완성 제공자
+- 커서 위치 기반 컨텍스트 분석 (테이블/컬럼/키워드)
+- 정규식 기반 파싱 (의존성 없음)
+"""
+import re
+from typing import Dict, List
+
+from src.core.sql_metadata import SchemaMetadata, SchemaMetadataProvider
+from src.core.sql_identifier_utils import (
+    extract_cte_names, extract_derived_table_aliases, extract_table_aliases,
+)
+
+
+class SQLAutoCompleter:
+    """SQL 자동완성 제공자"""
+
+    SQL_KEYWORDS = [
+        'SELECT', 'FROM', 'WHERE', 'AND', 'OR', 'NOT', 'IN', 'LIKE', 'BETWEEN',
+        'INSERT', 'INTO', 'VALUES', 'UPDATE', 'SET', 'DELETE',
+        'CREATE', 'ALTER', 'DROP', 'TABLE', 'INDEX', 'VIEW', 'DATABASE',
+        'JOIN', 'INNER', 'LEFT', 'RIGHT', 'OUTER', 'FULL', 'CROSS', 'ON',
+        'GROUP', 'BY', 'ORDER', 'ASC', 'DESC', 'HAVING', 'LIMIT', 'OFFSET',
+        'UNION', 'ALL', 'DISTINCT', 'AS', 'CASE', 'WHEN', 'THEN', 'ELSE', 'END',
+        'NULL', 'IS', 'EXISTS', 'PRIMARY', 'KEY', 'FOREIGN', 'REFERENCES',
+        'CONSTRAINT', 'DEFAULT', 'AUTO_INCREMENT', 'TRUNCATE',
+        'BEGIN', 'COMMIT', 'ROLLBACK', 'TRANSACTION',
+    ]
+
+    SQL_FUNCTIONS = [
+        'COUNT', 'SUM', 'AVG', 'MIN', 'MAX', 'COALESCE', 'IFNULL', 'NULLIF',
+        'CONCAT', 'SUBSTRING', 'LENGTH', 'TRIM', 'UPPER', 'LOWER', 'REPLACE',
+        'NOW', 'DATE', 'TIME', 'DATETIME', 'TIMESTAMP', 'YEAR', 'MONTH', 'DAY',
+        'HOUR', 'MINUTE', 'SECOND', 'DATEDIFF', 'DATE_ADD', 'DATE_SUB',
+        'CAST', 'CONVERT', 'ROUND', 'FLOOR', 'CEIL', 'ABS', 'MOD', 'POWER',
+        'GROUP_CONCAT', 'JSON_EXTRACT', 'JSON_ARRAY', 'JSON_OBJECT',
+    ]
+
+    def __init__(self, metadata_provider: SchemaMetadataProvider = None):
+        self.metadata_provider = metadata_provider or SchemaMetadataProvider()
+
+    def get_completions(self, sql: str, cursor_pos: int, schema: str = None) -> List[Dict]:
+        """커서 위치에서 자동완성 목록 반환
+
+        Args:
+            sql: SQL 쿼리 문자열
+            cursor_pos: 커서 위치
+            schema: 대상 스키마
+
+        Returns:
+            자동완성 항목 목록 [{label, type, detail}, ...]
+        """
+        completions = []
+        metadata = self.metadata_provider.get_metadata(schema)
+
+        # 커서 앞 텍스트 분석
+        text_before = sql[:cursor_pos]
+        context = self._analyze_context(text_before)
+        prefix = self._get_current_word(text_before)
+
+        if context['type'] == 'table':
+            completions.extend(self._complete_tables(metadata, prefix))
+        elif context['type'] == 'column':
+            target_table = context.get('table')
+            if target_table:
+                completions.extend(self._complete_columns_for_table(sql, metadata, target_table, prefix))
+            else:
+                completions.extend(self._complete_columns_from_from_clause(sql, metadata, prefix))
+
+        # table. 뒤가 아닌 경우에만 키워드/함수 추가
+        # (table. 뒤에서는 해당 테이블 컬럼만 제안)
+        if not context.get('table'):
+            completions.extend(self._complete_keywords_and_functions(context, prefix))
+
+        return completions
+
+    def _complete_tables(self, metadata: SchemaMetadata, prefix: str) -> List[Dict]:
+        """FROM/JOIN 뒤 → 테이블 목록"""
+        completions = []
+        for table in sorted(metadata.tables):
+            if self._matches_prefix(table, prefix):
+                completions.append({
+                    'label': table,
+                    'type': 'table',
+                    'detail': '테이블'
+                })
+        return completions
+
+    def _complete_columns_for_table(self, sql: str, metadata: SchemaMetadata,
+                                     target_table: str, prefix: str) -> List[Dict]:
+        """table. 또는 alias. 뒤 → 해당 테이블의 컬럼 목록"""
+        completions = []
+        # 별칭 → 실제 테이블명 변환은 조회 전에 수행
+        aliases = extract_table_aliases(sql, metadata)
+        resolved_table = aliases.get(target_table.lower(), target_table)
+        real_table = metadata.get_table_name(resolved_table)
+        if real_table and real_table in metadata.columns:
+            for col in sorted(metadata.columns[real_table]):
+                if self._matches_prefix(col, prefix):
+                    completions.append({
+                        'label': col,
+                        'type': 'column',
+                        'detail': f'{real_table} 컬럼'
+                    })
+        return completions
+
+    def _complete_columns_from_from_clause(self, sql: str, metadata: SchemaMetadata,
+                                            prefix: str) -> List[Dict]:
+        """SELECT/WHERE 등 뒤 (테이블 미지정) → FROM 절의 모든 테이블 컬럼"""
+        completions = []
+        from_tables = self._extract_from_tables(sql, metadata)
+        for table in from_tables:
+            if table in metadata.columns:
+                for col in sorted(metadata.columns[table]):
+                    if self._matches_prefix(col, prefix):
+                        completions.append({
+                            'label': col,
+                            'type': 'column',
+                            'detail': f'{table}'
+                        })
+        return completions
+
+    def _complete_keywords_and_functions(self, context: Dict, prefix: str) -> List[Dict]:
+        """키워드/함수 완성 (keyword 또는 column 컨텍스트에서만)"""
+        completions = []
+
+        if context['type'] in ('keyword', 'column'):
+            for kw in self.SQL_KEYWORDS:
+                if self._matches_prefix(kw, prefix):
+                    completions.append({
+                        'label': kw,
+                        'type': 'keyword',
+                        'detail': 'SQL 키워드'
+                    })
+
+        if context['type'] in ('keyword', 'column'):
+            for func in self.SQL_FUNCTIONS:
+                if self._matches_prefix(func, prefix):
+                    completions.append({
+                        'label': f'{func}()',
+                        'type': 'function',
+                        'detail': 'SQL 함수'
+                    })
+
+        return completions
+
+    def _analyze_context(self, text_before: str) -> Dict:
+        """커서 앞 컨텍스트 분석"""
+        text_upper = text_before.upper()
+
+        # FROM schema. / JOIN schema. 뒤에서는 schema-qualified table 이름을 제안
+        if re.search(r'\b(FROM|JOIN)\s+`?\w+`?\.\w*$', text_upper):
+            return {'type': 'table'}
+
+        if re.search(r'\b(LEFT|RIGHT|INNER|OUTER|CROSS)\s+JOIN\s+`?\w+`?\.\w*$', text_upper):
+            return {'type': 'table'}
+
+        # table. 뒤인지 확인 (table.col 입력 중)
+        dot_match = re.search(r'`?(\w+)`?\.\w*$', text_before)
+        if dot_match:
+            return {'type': 'column', 'table': dot_match.group(1)}
+
+        # FROM/JOIN 뒤인지 확인 (FROM table 또는 FROM 직후)
+        # \w*$로 현재 입력 중인 단어까지 포함
+        if re.search(r'\b(FROM|JOIN)\s+\w*$', text_upper):
+            return {'type': 'table'}
+
+        # LEFT/RIGHT/INNER/OUTER/CROSS JOIN 뒤인지 확인
+        if re.search(r'\b(LEFT|RIGHT|INNER|OUTER|CROSS)\s+JOIN\s+\w*$', text_upper):
+            return {'type': 'table'}
+
+        # SELECT/WHERE/ORDER BY 등 뒤인지 확인
+        if re.search(r'\b(SELECT|WHERE|AND|OR|ORDER\s+BY|GROUP\s+BY|HAVING|SET)\s+\w*$', text_upper):
+            return {'type': 'column'}
+
+        # 기본값: 키워드
+        return {'type': 'keyword'}
+
+    def _get_current_word(self, text: str) -> str:
+        """현재 입력 중인 단어 추출"""
+        match = re.search(r'(\w*)$', text)
+        return match.group(1) if match else ''
+
+    def _matches_prefix(self, item: str, prefix: str) -> bool:
+        """접두사 매칭 (대소문자 무시)"""
+        if not prefix:
+            return True
+        return item.lower().startswith(prefix.lower())
+
+    def _extract_from_tables(self, sql: str, metadata: SchemaMetadata) -> List[str]:
+        """FROM 절에서 테이블 추출 (CTE 이름 / 파생 테이블 별칭은 제외)"""
+        tables = []
+        virtual_tables = extract_cte_names(sql) | extract_derived_table_aliases(sql)
+        pattern = r'\b(?:FROM|JOIN)\s+(?:`?(\w+)`?\.)?`?(\w+)`?'
+
+        for match in re.finditer(pattern, sql, re.IGNORECASE):
+            table = match.group(2)
+            if table.lower() in virtual_tables:
+                continue
+            real_table = metadata.get_table_name(table)
+            if real_table and real_table not in tables:
+                tables.append(real_table)
+
+        return tables

--- a/src/core/sql_identifier_utils.py
+++ b/src/core/sql_identifier_utils.py
@@ -1,0 +1,220 @@
+"""
+SQL 식별자 파싱 유틸리티
+- 별칭/CTE/파생 테이블 이름 추출
+- 정규식 기반 파싱 (의존성 없음)
+"""
+import re
+from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.core.sql_metadata import SchemaMetadata
+
+
+# 별칭/CTE 파싱에서 공통으로 사용하는 예약어 스킵 목록
+ALIAS_STOP_WORDS = {
+    'WHERE', 'ON', 'AND', 'OR', 'SET', 'VALUES',
+    'LEFT', 'RIGHT', 'INNER', 'OUTER', 'CROSS', 'FULL',
+    'JOIN', 'ORDER', 'GROUP', 'HAVING', 'LIMIT', 'OFFSET',
+    'UNION', 'ALL', 'SELECT', 'FROM', 'BY', 'AS',
+}
+
+
+def _normalize_identifier(identifier: str) -> str:
+    """식별자를 감싸는 백틱 한 겹 제거 (없으면 그대로 반환)"""
+    if len(identifier) >= 2 and identifier[0] == '`' and identifier[-1] == '`':
+        return identifier[1:-1]
+    return identifier
+
+
+def _read_identifier(sql: str, pos: int) -> Tuple[Optional[str], int]:
+    """pos 위치(앞쪽 공백 허용)부터 식별자 하나를 읽는다.
+
+    백틱 식별자(`name`)와 일반 \\w+ 식별자를 모두 지원한다.
+
+    Returns:
+        (식별자, 다음 위치) 또는 식별자를 읽지 못하면 (None, pos)
+    """
+    length = len(sql)
+    i = pos
+    while i < length and sql[i].isspace():
+        i += 1
+
+    if i >= length:
+        return None, pos
+
+    if sql[i] == '`':
+        end = sql.find('`', i + 1)
+        if end == -1:
+            return None, pos
+        return sql[i + 1:end], end + 1
+
+    match = re.match(r'\w+', sql[i:])
+    if not match:
+        return None, pos
+    return match.group(0), i + match.end()
+
+
+def _skip_balanced_parentheses(sql: str, open_pos: int) -> int:
+    """open_pos가 가리키는 '('과 짝이 맞는 ')' 바로 다음 위치를 반환한다.
+
+    문자열 리터럴(작은따옴표/큰따옴표) 내부의 괄호는 무시하며,
+    이스케이프 처리는 `_find_string_regions`와 동일하게 따옴표 2개 연속을 이스케이프로 본다.
+    짝이 맞지 않으면 len(sql)을 반환한다.
+    """
+    length = len(sql)
+    if open_pos >= length or sql[open_pos] != '(':
+        return open_pos
+
+    depth = 0
+    in_string = False
+    string_char = None
+    i = open_pos
+
+    while i < length:
+        char = sql[i]
+
+        if in_string:
+            if char == string_char:
+                if i + 1 < length and sql[i + 1] == string_char:
+                    i += 1  # 이스케이프된 따옴표 스킵
+                else:
+                    in_string = False
+                    string_char = None
+        else:
+            if char in ("'", '"'):
+                in_string = True
+                string_char = char
+            elif char == '(':
+                depth += 1
+            elif char == ')':
+                depth -= 1
+                if depth == 0:
+                    return i + 1
+
+        i += 1
+
+    return length
+
+
+def extract_cte_names(sql: str) -> Set[str]:
+    """WITH 절에 정의된 CTE 이름 목록 추출 (테이블 존재 검증 제외용)
+
+    지원 형태:
+        WITH cte AS (...) SELECT * FROM cte
+        WITH a AS (...), b AS (...) SELECT * FROM b
+        WITH RECURSIVE cte AS (...) SELECT * FROM cte
+        WITH `cte` AS (...) SELECT * FROM `cte`
+    """
+    names: Set[str] = set()
+
+    with_match = re.search(r'\bWITH\b', sql, re.IGNORECASE)
+    if not with_match:
+        return names
+
+    length = len(sql)
+    pos = with_match.end()
+
+    recursive_match = re.match(r'\s+RECURSIVE\b', sql[pos:], re.IGNORECASE)
+    if recursive_match:
+        pos += recursive_match.end()
+
+    while True:
+        name, pos = _read_identifier(sql, pos)
+        if not name:
+            break
+        names.add(_normalize_identifier(name).lower())
+
+        while pos < length and sql[pos].isspace():
+            pos += 1
+
+        # 선택적 컬럼 목록: cte(col1, col2)
+        if pos < length and sql[pos] == '(':
+            pos = _skip_balanced_parentheses(sql, pos)
+            while pos < length and sql[pos].isspace():
+                pos += 1
+
+        as_match = re.match(r'AS\b', sql[pos:], re.IGNORECASE)
+        if not as_match:
+            break
+        pos += as_match.end()
+
+        while pos < length and sql[pos].isspace():
+            pos += 1
+
+        if pos >= length or sql[pos] != '(':
+            break
+        pos = _skip_balanced_parentheses(sql, pos)
+
+        while pos < length and sql[pos].isspace():
+            pos += 1
+
+        if pos < length and sql[pos] == ',':
+            pos += 1
+            continue
+        break
+
+    return names
+
+
+def extract_derived_table_aliases(sql: str) -> Set[str]:
+    """FROM (...) AS alias / JOIN (...) AS alias 형태의 파생 테이블 별칭 추출
+
+    파생 테이블 별칭은 실제 테이블이 아니므로, 테이블 존재 검증에서 제외하기 위한
+    스킵 목록으로만 사용한다 (메타데이터 조회용이 아님).
+    """
+    aliases: Set[str] = set()
+    length = len(sql)
+
+    for match in re.finditer(r'\b(?:FROM|JOIN)\s*\(', sql, re.IGNORECASE):
+        open_pos = match.end() - 1
+        pos = _skip_balanced_parentheses(sql, open_pos)
+
+        while pos < length and sql[pos].isspace():
+            pos += 1
+
+        as_match = re.match(r'AS\b', sql[pos:], re.IGNORECASE)
+        if as_match:
+            pos += as_match.end()
+
+        alias, _ = _read_identifier(sql, pos)
+        if not alias:
+            continue
+
+        normalized = _normalize_identifier(alias)
+        if normalized.upper() not in ALIAS_STOP_WORDS:
+            aliases.add(normalized.lower())
+
+    return aliases
+
+
+def extract_table_aliases(sql: str, metadata: 'SchemaMetadata') -> Dict[str, str]:
+    """FROM/JOIN 절의 실제 테이블 참조에서 별칭(별칭 → 테이블명) 추출
+
+    CTE 이름과 파생 테이블(서브쿼리)은 실제 테이블이 아니므로 별칭 매핑에서 제외한다.
+    Validator와 AutoCompleter가 공용으로 사용하는 단일 파서다.
+    """
+    aliases: Dict[str, str] = {}
+    cte_names = extract_cte_names(sql)
+
+    # FROM/JOIN 뒤가 '('인 경우(파생 테이블)는 이 패턴에서 제외
+    pattern = r'\b(?:FROM|JOIN)\s+(?!\()(?:`?(\w+)`?\.)?`?(\w+)`?(?:\s+(?:AS\s+)?`?(\w+)`?)?'
+
+    for match in re.finditer(pattern, sql, re.IGNORECASE):
+        table = match.group(2)
+        alias = match.group(3)
+
+        # CTE 이름이면서 실제 메타데이터 테이블이 아니면 별칭 소스로 사용하지 않음
+        if table.lower() in cte_names and not metadata.has_table(table):
+            continue
+
+        if alias and alias.upper() in ALIAS_STOP_WORDS:
+            alias = None
+
+        if alias:
+            aliases[alias.lower()] = table
+
+    # 테이블 자체도 추가 (self-reference)
+    for real_table in metadata.tables:
+        aliases[real_table.lower()] = real_table
+
+    return aliases

--- a/src/core/sql_metadata.py
+++ b/src/core/sql_metadata.py
@@ -1,0 +1,154 @@
+"""
+SQL 스키마 메타데이터
+- 테이블/컬럼 존재 여부 조회, 유사 이름 제안
+- 스키마별 인메모리 캐시 제공자
+"""
+import threading
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set, Tuple
+from difflib import get_close_matches
+
+
+# get_close_matches 유사 이름 제안 시 사용하는 최소 유사도 기준값 (0~1)
+FUZZY_MATCH_CUTOFF = 0.5
+
+
+def _schema_key(schema: Optional[str]) -> Optional[str]:
+    """스키마명을 캐시 키로 정규화 (None/빈 문자열/공백만 있으면 None)"""
+    if schema is None:
+        return None
+    stripped = schema.strip()
+    return stripped or None
+
+
+@dataclass
+class SchemaMetadata:
+    """스키마 메타데이터"""
+    tables: Set[str] = field(default_factory=set)
+    columns: Dict[str, Set[str]] = field(default_factory=dict)  # table -> columns
+    db_version: Tuple[int, int, int] = (0, 0, 0)
+
+    def has_table(self, table: str) -> bool:
+        """테이블 존재 여부 (대소문자 무시)"""
+        return table.lower() in {t.lower() for t in self.tables}
+
+    def get_table_name(self, table: str) -> Optional[str]:
+        """실제 테이블명 반환 (대소문자 매칭)"""
+        table_lower = table.lower()
+        for t in self.tables:
+            if t.lower() == table_lower:
+                return t
+        return None
+
+    def has_column(self, table: str, column: str) -> bool:
+        """컬럼 존재 여부 (대소문자 무시)"""
+        real_table = self.get_table_name(table)
+        if not real_table or real_table not in self.columns:
+            return False
+        return column.lower() in {c.lower() for c in self.columns[real_table]}
+
+    def get_column_name(self, table: str, column: str) -> Optional[str]:
+        """실제 컬럼명 반환"""
+        real_table = self.get_table_name(table)
+        if not real_table or real_table not in self.columns:
+            return None
+        col_lower = column.lower()
+        for c in self.columns[real_table]:
+            if c.lower() == col_lower:
+                return c
+        return None
+
+    def get_similar_tables(self, table: str, n: int = 3) -> List[str]:
+        """유사한 테이블명 제안"""
+        return get_close_matches(table.lower(), [t.lower() for t in self.tables], n=n, cutoff=FUZZY_MATCH_CUTOFF)
+
+    def get_similar_columns(self, table: str, column: str, n: int = 3) -> List[str]:
+        """유사한 컬럼명 제안"""
+        real_table = self.get_table_name(table)
+        if not real_table or real_table not in self.columns:
+            return []
+        return get_close_matches(column.lower(), [c.lower() for c in self.columns[real_table]], n=n, cutoff=FUZZY_MATCH_CUTOFF)
+
+
+class SchemaMetadataProvider:
+    """스키마 메타데이터 제공자 (스키마별 인메모리 캐시)
+
+    Python 쪽에서는 동기 DB 조회를 하지 않는다. 메타데이터는 반드시
+    `set_metadata()` (또는 호환용 `_metadata` 직접 대입)로 채워져야 하며,
+    캐시 미스 시에는 커넥터를 호출하지 않고 빈 SchemaMetadata를 반환한다.
+    이는 ValidationWorker가 MetadataLoadWorker와 같은 커넥터를 두고
+    경쟁(race)하는 것을 방지하기 위함이다.
+    """
+
+    def __init__(self):
+        self._metadata_by_schema: Dict[Optional[str], SchemaMetadata] = {}
+        self._active_schema_key: Optional[str] = None
+        self._connector = None
+        self._lock = threading.RLock()
+
+    @property
+    def _metadata(self) -> Optional[SchemaMetadata]:
+        """호환용 속성 (UI 등 외부에서 `_metadata`를 직접 읽는 경우 대응)"""
+        with self._lock:
+            if self._active_schema_key in self._metadata_by_schema:
+                return self._metadata_by_schema[self._active_schema_key]
+            return self._metadata_by_schema.get(None)
+
+    @_metadata.setter
+    def _metadata(self, value: Optional[SchemaMetadata]):
+        """호환용 속성 (UI 등 외부에서 `_metadata`를 직접 대입하는 경우 대응)
+
+        `set_connector(connector)` 직후 활성 스키마(`connector.database`)에
+        매핑해 저장한다. 신규 코드는 `set_metadata(schema, metadata)`를 사용할 것.
+        """
+        with self._lock:
+            if value is None:
+                if self._active_schema_key is not None:
+                    self._metadata_by_schema.pop(self._active_schema_key, None)
+                else:
+                    self._metadata_by_schema.clear()
+                return
+            self._metadata_by_schema[self._active_schema_key] = value
+
+    def set_connector(self, connector):
+        """DB 커넥터 설정
+
+        커넥터가 바뀌면 이전 캐시가 다른 연결의 것일 수 있으므로 무효화한다.
+        여기서는 DB에 동기 조회를 하지 않는다.
+        """
+        with self._lock:
+            self._connector = connector
+            self._active_schema_key = _schema_key(getattr(connector, "database", None))
+            self._metadata_by_schema.clear()
+
+    def set_metadata(self, schema: str, metadata: SchemaMetadata):
+        """스키마에 대한 메타데이터를 캐시에 저장 (백그라운드 로드 완료 후 호출)"""
+        if metadata is None:
+            raise ValueError("metadata는 None일 수 없습니다")
+
+        key = _schema_key(schema)
+        with self._lock:
+            self._metadata_by_schema[key] = metadata
+            self._active_schema_key = key
+
+    def get_metadata(self, schema: str = None) -> SchemaMetadata:
+        """메타데이터 조회 (캐시 히트만 반환, 캐시 미스 시 커넥터 조회하지 않음)"""
+        key = _schema_key(schema)
+        with self._lock:
+            if key in self._metadata_by_schema:
+                return self._metadata_by_schema[key]
+            if key is None and None in self._metadata_by_schema:
+                return self._metadata_by_schema[None]
+            return SchemaMetadata()
+
+    def invalidate(self, schema: str = None):
+        """캐시 무효화
+
+        Args:
+            schema: 지정하면 해당 스키마만 무효화, None이면 전체 무효화
+        """
+        with self._lock:
+            if schema is None:
+                self._metadata_by_schema.clear()
+            else:
+                self._metadata_by_schema.pop(_schema_key(schema), None)

--- a/src/core/sql_validator.py
+++ b/src/core/sql_validator.py
@@ -5,229 +5,30 @@ SQL 구문 Validator
 - 정규식 기반 파싱 (의존성 없음)
 """
 import re
-import threading
 from enum import Enum
 from dataclasses import dataclass, field
-from typing import List, Dict, Set, Optional, Tuple
-from difflib import get_close_matches
+from typing import List, Set, Optional, Tuple
 
+from src.core import constants
+from src.core.sql_identifier_utils import (
+    ALIAS_STOP_WORDS, _normalize_identifier, _read_identifier, _skip_balanced_parentheses,
+    extract_cte_names, extract_derived_table_aliases, extract_table_aliases,
+)
+from src.core.sql_metadata import (
+    _schema_key, FUZZY_MATCH_CUTOFF, SchemaMetadata, SchemaMetadataProvider,
+)
+from src.core.sql_autocompleter import SQLAutoCompleter
 
-# 별칭/CTE 파싱에서 공통으로 사용하는 예약어 스킵 목록
-ALIAS_STOP_WORDS = {
-    'WHERE', 'ON', 'AND', 'OR', 'SET', 'VALUES',
-    'LEFT', 'RIGHT', 'INNER', 'OUTER', 'CROSS', 'FULL',
-    'JOIN', 'ORDER', 'GROUP', 'HAVING', 'LIMIT', 'OFFSET',
-    'UNION', 'ALL', 'SELECT', 'FROM', 'BY', 'AS',
-}
-
-
-def _schema_key(schema: Optional[str]) -> Optional[str]:
-    """스키마명을 캐시 키로 정규화 (None/빈 문자열/공백만 있으면 None)"""
-    if schema is None:
-        return None
-    stripped = schema.strip()
-    return stripped or None
-
-
-def _normalize_identifier(identifier: str) -> str:
-    """식별자를 감싸는 백틱 한 겹 제거 (없으면 그대로 반환)"""
-    if len(identifier) >= 2 and identifier[0] == '`' and identifier[-1] == '`':
-        return identifier[1:-1]
-    return identifier
-
-
-def _read_identifier(sql: str, pos: int) -> Tuple[Optional[str], int]:
-    """pos 위치(앞쪽 공백 허용)부터 식별자 하나를 읽는다.
-
-    백틱 식별자(`name`)와 일반 \\w+ 식별자를 모두 지원한다.
-
-    Returns:
-        (식별자, 다음 위치) 또는 식별자를 읽지 못하면 (None, pos)
-    """
-    length = len(sql)
-    i = pos
-    while i < length and sql[i].isspace():
-        i += 1
-
-    if i >= length:
-        return None, pos
-
-    if sql[i] == '`':
-        end = sql.find('`', i + 1)
-        if end == -1:
-            return None, pos
-        return sql[i + 1:end], end + 1
-
-    match = re.match(r'\w+', sql[i:])
-    if not match:
-        return None, pos
-    return match.group(0), i + match.end()
-
-
-def _skip_balanced_parentheses(sql: str, open_pos: int) -> int:
-    """open_pos가 가리키는 '('과 짝이 맞는 ')' 바로 다음 위치를 반환한다.
-
-    문자열 리터럴(작은따옴표/큰따옴표) 내부의 괄호는 무시하며,
-    이스케이프 처리는 `_find_string_regions`와 동일하게 따옴표 2개 연속을 이스케이프로 본다.
-    짝이 맞지 않으면 len(sql)을 반환한다.
-    """
-    length = len(sql)
-    if open_pos >= length or sql[open_pos] != '(':
-        return open_pos
-
-    depth = 0
-    in_string = False
-    string_char = None
-    i = open_pos
-
-    while i < length:
-        char = sql[i]
-
-        if in_string:
-            if char == string_char:
-                if i + 1 < length and sql[i + 1] == string_char:
-                    i += 1  # 이스케이프된 따옴표 스킵
-                else:
-                    in_string = False
-                    string_char = None
-        else:
-            if char in ("'", '"'):
-                in_string = True
-                string_char = char
-            elif char == '(':
-                depth += 1
-            elif char == ')':
-                depth -= 1
-                if depth == 0:
-                    return i + 1
-
-        i += 1
-
-    return length
-
-
-def extract_cte_names(sql: str) -> Set[str]:
-    """WITH 절에 정의된 CTE 이름 목록 추출 (테이블 존재 검증 제외용)
-
-    지원 형태:
-        WITH cte AS (...) SELECT * FROM cte
-        WITH a AS (...), b AS (...) SELECT * FROM b
-        WITH RECURSIVE cte AS (...) SELECT * FROM cte
-        WITH `cte` AS (...) SELECT * FROM `cte`
-    """
-    names: Set[str] = set()
-
-    with_match = re.search(r'\bWITH\b', sql, re.IGNORECASE)
-    if not with_match:
-        return names
-
-    length = len(sql)
-    pos = with_match.end()
-
-    recursive_match = re.match(r'\s+RECURSIVE\b', sql[pos:], re.IGNORECASE)
-    if recursive_match:
-        pos += recursive_match.end()
-
-    while True:
-        name, pos = _read_identifier(sql, pos)
-        if not name:
-            break
-        names.add(_normalize_identifier(name).lower())
-
-        while pos < length and sql[pos].isspace():
-            pos += 1
-
-        # 선택적 컬럼 목록: cte(col1, col2)
-        if pos < length and sql[pos] == '(':
-            pos = _skip_balanced_parentheses(sql, pos)
-            while pos < length and sql[pos].isspace():
-                pos += 1
-
-        as_match = re.match(r'AS\b', sql[pos:], re.IGNORECASE)
-        if not as_match:
-            break
-        pos += as_match.end()
-
-        while pos < length and sql[pos].isspace():
-            pos += 1
-
-        if pos >= length or sql[pos] != '(':
-            break
-        pos = _skip_balanced_parentheses(sql, pos)
-
-        while pos < length and sql[pos].isspace():
-            pos += 1
-
-        if pos < length and sql[pos] == ',':
-            pos += 1
-            continue
-        break
-
-    return names
-
-
-def extract_derived_table_aliases(sql: str) -> Set[str]:
-    """FROM (...) AS alias / JOIN (...) AS alias 형태의 파생 테이블 별칭 추출
-
-    파생 테이블 별칭은 실제 테이블이 아니므로, 테이블 존재 검증에서 제외하기 위한
-    스킵 목록으로만 사용한다 (메타데이터 조회용이 아님).
-    """
-    aliases: Set[str] = set()
-    length = len(sql)
-
-    for match in re.finditer(r'\b(?:FROM|JOIN)\s*\(', sql, re.IGNORECASE):
-        open_pos = match.end() - 1
-        pos = _skip_balanced_parentheses(sql, open_pos)
-
-        while pos < length and sql[pos].isspace():
-            pos += 1
-
-        as_match = re.match(r'AS\b', sql[pos:], re.IGNORECASE)
-        if as_match:
-            pos += as_match.end()
-
-        alias, _ = _read_identifier(sql, pos)
-        if not alias:
-            continue
-
-        normalized = _normalize_identifier(alias)
-        if normalized.upper() not in ALIAS_STOP_WORDS:
-            aliases.add(normalized.lower())
-
-    return aliases
-
-
-def extract_table_aliases(sql: str, metadata: 'SchemaMetadata') -> Dict[str, str]:
-    """FROM/JOIN 절의 실제 테이블 참조에서 별칭(별칭 → 테이블명) 추출
-
-    CTE 이름과 파생 테이블(서브쿼리)은 실제 테이블이 아니므로 별칭 매핑에서 제외한다.
-    Validator와 AutoCompleter가 공용으로 사용하는 단일 파서다.
-    """
-    aliases: Dict[str, str] = {}
-    cte_names = extract_cte_names(sql)
-
-    # FROM/JOIN 뒤가 '('인 경우(파생 테이블)는 이 패턴에서 제외
-    pattern = r'\b(?:FROM|JOIN)\s+(?!\()(?:`?(\w+)`?\.)?`?(\w+)`?(?:\s+(?:AS\s+)?`?(\w+)`?)?'
-
-    for match in re.finditer(pattern, sql, re.IGNORECASE):
-        table = match.group(2)
-        alias = match.group(3)
-
-        # CTE 이름이면서 실제 메타데이터 테이블이 아니면 별칭 소스로 사용하지 않음
-        if table.lower() in cte_names and not metadata.has_table(table):
-            continue
-
-        if alias and alias.upper() in ALIAS_STOP_WORDS:
-            alias = None
-
-        if alias:
-            aliases[alias.lower()] = table
-
-    # 테이블 자체도 추가 (self-reference)
-    for real_table in metadata.tables:
-        aliases[real_table.lower()] = real_table
-
-    return aliases
+# 하위호환 재수출 — sql_validator.py 분할(sql_identifier_utils/sql_metadata/sql_autocompleter) 이후에도
+# 기존 소비자(src/core/__init__.py, src/ui/dialogs/sql_editor_dialog.py 등)가 old import path로
+# 계속 동작하도록 유지한다. 재수출 목록 변경 시 tests/test_sql_validator.py의 identity 가드 테스트 확인.
+__all__ = [
+    'ALIAS_STOP_WORDS', '_normalize_identifier', '_read_identifier', '_skip_balanced_parentheses',
+    'extract_cte_names', 'extract_derived_table_aliases', 'extract_table_aliases',
+    '_schema_key', 'FUZZY_MATCH_CUTOFF', 'SchemaMetadata', 'SchemaMetadataProvider',
+    'SQLAutoCompleter',
+    'IssueSeverity', 'ValidationIssue', 'SQLValidator',
+]
 
 
 class IssueSeverity(Enum):
@@ -253,139 +54,6 @@ class ValidationIssue:
         return self.end_column - self.column
 
 
-@dataclass
-class SchemaMetadata:
-    """스키마 메타데이터"""
-    tables: Set[str] = field(default_factory=set)
-    columns: Dict[str, Set[str]] = field(default_factory=dict)  # table -> columns
-    db_version: Tuple[int, int, int] = (0, 0, 0)
-
-    def has_table(self, table: str) -> bool:
-        """테이블 존재 여부 (대소문자 무시)"""
-        return table.lower() in {t.lower() for t in self.tables}
-
-    def get_table_name(self, table: str) -> Optional[str]:
-        """실제 테이블명 반환 (대소문자 매칭)"""
-        table_lower = table.lower()
-        for t in self.tables:
-            if t.lower() == table_lower:
-                return t
-        return None
-
-    def has_column(self, table: str, column: str) -> bool:
-        """컬럼 존재 여부 (대소문자 무시)"""
-        real_table = self.get_table_name(table)
-        if not real_table or real_table not in self.columns:
-            return False
-        return column.lower() in {c.lower() for c in self.columns[real_table]}
-
-    def get_column_name(self, table: str, column: str) -> Optional[str]:
-        """실제 컬럼명 반환"""
-        real_table = self.get_table_name(table)
-        if not real_table or real_table not in self.columns:
-            return None
-        col_lower = column.lower()
-        for c in self.columns[real_table]:
-            if c.lower() == col_lower:
-                return c
-        return None
-
-    def get_similar_tables(self, table: str, n: int = 3) -> List[str]:
-        """유사한 테이블명 제안"""
-        return get_close_matches(table.lower(), [t.lower() for t in self.tables], n=n, cutoff=0.5)
-
-    def get_similar_columns(self, table: str, column: str, n: int = 3) -> List[str]:
-        """유사한 컬럼명 제안"""
-        real_table = self.get_table_name(table)
-        if not real_table or real_table not in self.columns:
-            return []
-        return get_close_matches(column.lower(), [c.lower() for c in self.columns[real_table]], n=n, cutoff=0.5)
-
-
-class SchemaMetadataProvider:
-    """스키마 메타데이터 제공자 (스키마별 인메모리 캐시)
-
-    Python 쪽에서는 동기 DB 조회를 하지 않는다. 메타데이터는 반드시
-    `set_metadata()` (또는 호환용 `_metadata` 직접 대입)로 채워져야 하며,
-    캐시 미스 시에는 커넥터를 호출하지 않고 빈 SchemaMetadata를 반환한다.
-    이는 ValidationWorker가 MetadataLoadWorker와 같은 커넥터를 두고
-    경쟁(race)하는 것을 방지하기 위함이다.
-    """
-
-    def __init__(self):
-        self._metadata_by_schema: Dict[Optional[str], SchemaMetadata] = {}
-        self._active_schema_key: Optional[str] = None
-        self._connector = None
-        self._lock = threading.RLock()
-
-    @property
-    def _metadata(self) -> Optional[SchemaMetadata]:
-        """호환용 속성 (UI 등 외부에서 `_metadata`를 직접 읽는 경우 대응)"""
-        with self._lock:
-            if self._active_schema_key in self._metadata_by_schema:
-                return self._metadata_by_schema[self._active_schema_key]
-            return self._metadata_by_schema.get(None)
-
-    @_metadata.setter
-    def _metadata(self, value: Optional[SchemaMetadata]):
-        """호환용 속성 (UI 등 외부에서 `_metadata`를 직접 대입하는 경우 대응)
-
-        `set_connector(connector)` 직후 활성 스키마(`connector.database`)에
-        매핑해 저장한다. 신규 코드는 `set_metadata(schema, metadata)`를 사용할 것.
-        """
-        with self._lock:
-            if value is None:
-                if self._active_schema_key is not None:
-                    self._metadata_by_schema.pop(self._active_schema_key, None)
-                else:
-                    self._metadata_by_schema.clear()
-                return
-            self._metadata_by_schema[self._active_schema_key] = value
-
-    def set_connector(self, connector):
-        """DB 커넥터 설정
-
-        커넥터가 바뀌면 이전 캐시가 다른 연결의 것일 수 있으므로 무효화한다.
-        여기서는 DB에 동기 조회를 하지 않는다.
-        """
-        with self._lock:
-            self._connector = connector
-            self._active_schema_key = _schema_key(getattr(connector, "database", None))
-            self._metadata_by_schema.clear()
-
-    def set_metadata(self, schema: str, metadata: SchemaMetadata):
-        """스키마에 대한 메타데이터를 캐시에 저장 (백그라운드 로드 완료 후 호출)"""
-        if metadata is None:
-            raise ValueError("metadata는 None일 수 없습니다")
-
-        key = _schema_key(schema)
-        with self._lock:
-            self._metadata_by_schema[key] = metadata
-            self._active_schema_key = key
-
-    def get_metadata(self, schema: str = None) -> SchemaMetadata:
-        """메타데이터 조회 (캐시 히트만 반환, 캐시 미스 시 커넥터 조회하지 않음)"""
-        key = _schema_key(schema)
-        with self._lock:
-            if key in self._metadata_by_schema:
-                return self._metadata_by_schema[key]
-            if key is None and None in self._metadata_by_schema:
-                return self._metadata_by_schema[None]
-            return SchemaMetadata()
-
-    def invalidate(self, schema: str = None):
-        """캐시 무효화
-
-        Args:
-            schema: 지정하면 해당 스키마만 무효화, None이면 전체 무효화
-        """
-        with self._lock:
-            if schema is None:
-                self._metadata_by_schema.clear()
-            else:
-                self._metadata_by_schema.pop(_schema_key(schema), None)
-
-
 class SQLValidator:
     """SQL 구문 검증기"""
 
@@ -403,15 +71,9 @@ class SQLValidator:
         'BIN_TO_UUID', 'UUID_TO_BIN', 'IS_UUID'
     }
 
-    # 시스템 스키마 (검증 제외) - 대문자로 저장, 비교 시 upper()
+    # 시스템 스키마 (검증 제외) - constants.SYSTEM_SCHEMAS(소문자)의 대문자 파생 (단일 소스화)
     # https://dev.mysql.com/doc/refman/8.0/en/system-schema.html
-    SYSTEM_SCHEMAS = {
-        'INFORMATION_SCHEMA',  # 메타데이터
-        'MYSQL',               # 시스템 테이블 (권한, 설정 등)
-        'PERFORMANCE_SCHEMA',  # 성능 모니터링
-        'SYS',                 # Performance Schema 해석용 (5.7+)
-        'NDBINFO',             # NDB Cluster 정보 (NDB Cluster 전용)
-    }
+    SYSTEM_SCHEMAS = frozenset(s.upper() for s in constants.SYSTEM_SCHEMAS)
 
     # 테이블명 추출 패턴 (순서 중요: 더 구체적인 패턴 먼저)
     TABLE_PATTERNS = [
@@ -592,6 +254,34 @@ class SQLValidator:
 
         return issues
 
+    def _flag_unsupported_items(self, sql: str, items: Set[str], pattern_template: str,
+                                message_template: str, string_regions: List[Tuple[int, int]],
+                                line_offsets: List[int], major: int, minor: int) -> List[ValidationIssue]:
+        """MYSQL8_KEYWORDS/MYSQL8_FUNCTIONS 스캔 공통 로직
+
+        Args:
+            items: 스캔할 키워드 또는 함수명 집합
+            pattern_template: '{item}' 플레이스홀더를 포함하는 정규식 템플릿
+            message_template: '{item}', '{major}', '{minor}' 플레이스홀더를 포함하는 메시지 템플릿
+        """
+        issues = []
+        for item in items:
+            pattern = pattern_template.format(item=item)
+            for match in re.finditer(pattern, sql, re.IGNORECASE):
+                if self._is_in_string(match.start(), string_regions):
+                    continue
+
+                line, col = self._offset_to_line_col(match.start(), line_offsets)
+                issues.append(ValidationIssue(
+                    line=line,
+                    column=col,
+                    end_column=col + len(item),
+                    message=message_template.format(item=item, major=major, minor=minor),
+                    severity=IssueSeverity.WARNING,
+                    suggestions=[]
+                ))
+        return issues
+
     def _validate_version_compatibility(self, sql: str, metadata: SchemaMetadata,
                                         line_offsets: List[int]) -> List[ValidationIssue]:
         """DB 버전 호환성 검증"""
@@ -603,38 +293,18 @@ class SQLValidator:
             string_regions = self._find_string_regions(sql)
 
             # 키워드 체크
-            for keyword in self.MYSQL8_KEYWORDS:
-                pattern = rf'\b{keyword}\b'
-                for match in re.finditer(pattern, sql, re.IGNORECASE):
-                    if self._is_in_string(match.start(), string_regions):
-                        continue
-
-                    line, col = self._offset_to_line_col(match.start(), line_offsets)
-                    issues.append(ValidationIssue(
-                        line=line,
-                        column=col,
-                        end_column=col + len(keyword),
-                        message=f"'{keyword}'은(는) MySQL 8.0 이상에서만 지원됩니다 (현재: {major}.{minor})",
-                        severity=IssueSeverity.WARNING,
-                        suggestions=[]
-                    ))
+            issues.extend(self._flag_unsupported_items(
+                sql, self.MYSQL8_KEYWORDS, r'\b{item}\b',
+                "'{item}'은(는) MySQL 8.0 이상에서만 지원됩니다 (현재: {major}.{minor})",
+                string_regions, line_offsets, major, minor
+            ))
 
             # 함수 체크
-            for func in self.MYSQL8_FUNCTIONS:
-                pattern = rf'\b{func}\s*\('
-                for match in re.finditer(pattern, sql, re.IGNORECASE):
-                    if self._is_in_string(match.start(), string_regions):
-                        continue
-
-                    line, col = self._offset_to_line_col(match.start(), line_offsets)
-                    issues.append(ValidationIssue(
-                        line=line,
-                        column=col,
-                        end_column=col + len(func),
-                        message=f"함수 '{func}'은(는) MySQL 8.0 이상에서만 지원됩니다 (현재: {major}.{minor})",
-                        severity=IssueSeverity.WARNING,
-                        suggestions=[]
-                    ))
+            issues.extend(self._flag_unsupported_items(
+                sql, self.MYSQL8_FUNCTIONS, r'\b{item}\s*\(',
+                "함수 '{item}'은(는) MySQL 8.0 이상에서만 지원됩니다 (현재: {major}.{minor})",
+                string_regions, line_offsets, major, minor
+            ))
 
         return issues
 
@@ -695,174 +365,3 @@ class SQLValidator:
             if start <= pos < end:
                 return True
         return False
-
-
-class SQLAutoCompleter:
-    """SQL 자동완성 제공자"""
-
-    SQL_KEYWORDS = [
-        'SELECT', 'FROM', 'WHERE', 'AND', 'OR', 'NOT', 'IN', 'LIKE', 'BETWEEN',
-        'INSERT', 'INTO', 'VALUES', 'UPDATE', 'SET', 'DELETE',
-        'CREATE', 'ALTER', 'DROP', 'TABLE', 'INDEX', 'VIEW', 'DATABASE',
-        'JOIN', 'INNER', 'LEFT', 'RIGHT', 'OUTER', 'FULL', 'CROSS', 'ON',
-        'GROUP', 'BY', 'ORDER', 'ASC', 'DESC', 'HAVING', 'LIMIT', 'OFFSET',
-        'UNION', 'ALL', 'DISTINCT', 'AS', 'CASE', 'WHEN', 'THEN', 'ELSE', 'END',
-        'NULL', 'IS', 'EXISTS', 'PRIMARY', 'KEY', 'FOREIGN', 'REFERENCES',
-        'CONSTRAINT', 'DEFAULT', 'AUTO_INCREMENT', 'TRUNCATE',
-        'BEGIN', 'COMMIT', 'ROLLBACK', 'TRANSACTION',
-    ]
-
-    SQL_FUNCTIONS = [
-        'COUNT', 'SUM', 'AVG', 'MIN', 'MAX', 'COALESCE', 'IFNULL', 'NULLIF',
-        'CONCAT', 'SUBSTRING', 'LENGTH', 'TRIM', 'UPPER', 'LOWER', 'REPLACE',
-        'NOW', 'DATE', 'TIME', 'DATETIME', 'TIMESTAMP', 'YEAR', 'MONTH', 'DAY',
-        'HOUR', 'MINUTE', 'SECOND', 'DATEDIFF', 'DATE_ADD', 'DATE_SUB',
-        'CAST', 'CONVERT', 'ROUND', 'FLOOR', 'CEIL', 'ABS', 'MOD', 'POWER',
-        'GROUP_CONCAT', 'JSON_EXTRACT', 'JSON_ARRAY', 'JSON_OBJECT',
-    ]
-
-    def __init__(self, metadata_provider: SchemaMetadataProvider = None):
-        self.metadata_provider = metadata_provider or SchemaMetadataProvider()
-
-    def get_completions(self, sql: str, cursor_pos: int, schema: str = None) -> List[Dict]:
-        """커서 위치에서 자동완성 목록 반환
-
-        Args:
-            sql: SQL 쿼리 문자열
-            cursor_pos: 커서 위치
-            schema: 대상 스키마
-
-        Returns:
-            자동완성 항목 목록 [{label, type, detail}, ...]
-        """
-        completions = []
-        metadata = self.metadata_provider.get_metadata(schema)
-
-        # 커서 앞 텍스트 분석
-        text_before = sql[:cursor_pos]
-        context = self._analyze_context(text_before)
-        prefix = self._get_current_word(text_before)
-
-        if context['type'] == 'table':
-            # FROM/JOIN 뒤 → 테이블 목록
-            for table in sorted(metadata.tables):
-                if self._matches_prefix(table, prefix):
-                    completions.append({
-                        'label': table,
-                        'type': 'table',
-                        'detail': '테이블'
-                    })
-
-        elif context['type'] == 'column':
-            # SELECT/WHERE 뒤 또는 table. 뒤 → 컬럼 목록
-            target_table = context.get('table')
-
-            if target_table:
-                # 특정 테이블의 컬럼 (별칭 → 실제 테이블명 변환은 조회 전에 수행)
-                aliases = extract_table_aliases(sql, metadata)
-                resolved_table = aliases.get(target_table.lower(), target_table)
-                real_table = metadata.get_table_name(resolved_table)
-                if real_table and real_table in metadata.columns:
-                    for col in sorted(metadata.columns[real_table]):
-                        if self._matches_prefix(col, prefix):
-                            completions.append({
-                                'label': col,
-                                'type': 'column',
-                                'detail': f'{real_table} 컬럼'
-                            })
-            else:
-                # FROM 절의 모든 테이블 컬럼
-                from_tables = self._extract_from_tables(sql, metadata)
-                for table in from_tables:
-                    if table in metadata.columns:
-                        for col in sorted(metadata.columns[table]):
-                            if self._matches_prefix(col, prefix):
-                                completions.append({
-                                    'label': col,
-                                    'type': 'column',
-                                    'detail': f'{table}'
-                                })
-
-        # table. 뒤가 아닌 경우에만 키워드/함수 추가
-        # (table. 뒤에서는 해당 테이블 컬럼만 제안)
-        if not context.get('table'):
-            # 키워드 추가 (keyword 또는 column 컨텍스트)
-            if context['type'] in ('keyword', 'column'):
-                for kw in self.SQL_KEYWORDS:
-                    if self._matches_prefix(kw, prefix):
-                        completions.append({
-                            'label': kw,
-                            'type': 'keyword',
-                            'detail': 'SQL 키워드'
-                        })
-
-            # 함수 추가 (keyword 또는 column 컨텍스트)
-            if context['type'] in ('keyword', 'column'):
-                for func in self.SQL_FUNCTIONS:
-                    if self._matches_prefix(func, prefix):
-                        completions.append({
-                            'label': f'{func}()',
-                            'type': 'function',
-                            'detail': 'SQL 함수'
-                        })
-
-        return completions
-
-    def _analyze_context(self, text_before: str) -> Dict:
-        """커서 앞 컨텍스트 분석"""
-        text_upper = text_before.upper()
-
-        # FROM schema. / JOIN schema. 뒤에서는 schema-qualified table 이름을 제안
-        if re.search(r'\b(FROM|JOIN)\s+`?\w+`?\.\w*$', text_upper):
-            return {'type': 'table'}
-
-        if re.search(r'\b(LEFT|RIGHT|INNER|OUTER|CROSS)\s+JOIN\s+`?\w+`?\.\w*$', text_upper):
-            return {'type': 'table'}
-
-        # table. 뒤인지 확인 (table.col 입력 중)
-        dot_match = re.search(r'`?(\w+)`?\.\w*$', text_before)
-        if dot_match:
-            return {'type': 'column', 'table': dot_match.group(1)}
-
-        # FROM/JOIN 뒤인지 확인 (FROM table 또는 FROM 직후)
-        # \w*$로 현재 입력 중인 단어까지 포함
-        if re.search(r'\b(FROM|JOIN)\s+\w*$', text_upper):
-            return {'type': 'table'}
-
-        # LEFT/RIGHT/INNER/OUTER/CROSS JOIN 뒤인지 확인
-        if re.search(r'\b(LEFT|RIGHT|INNER|OUTER|CROSS)\s+JOIN\s+\w*$', text_upper):
-            return {'type': 'table'}
-
-        # SELECT/WHERE/ORDER BY 등 뒤인지 확인
-        if re.search(r'\b(SELECT|WHERE|AND|OR|ORDER\s+BY|GROUP\s+BY|HAVING|SET)\s+\w*$', text_upper):
-            return {'type': 'column'}
-
-        # 기본값: 키워드
-        return {'type': 'keyword'}
-
-    def _get_current_word(self, text: str) -> str:
-        """현재 입력 중인 단어 추출"""
-        match = re.search(r'(\w*)$', text)
-        return match.group(1) if match else ''
-
-    def _matches_prefix(self, item: str, prefix: str) -> bool:
-        """접두사 매칭 (대소문자 무시)"""
-        if not prefix:
-            return True
-        return item.lower().startswith(prefix.lower())
-
-    def _extract_from_tables(self, sql: str, metadata: SchemaMetadata) -> List[str]:
-        """FROM 절에서 테이블 추출 (CTE 이름 / 파생 테이블 별칭은 제외)"""
-        tables = []
-        virtual_tables = extract_cte_names(sql) | extract_derived_table_aliases(sql)
-        pattern = r'\b(?:FROM|JOIN)\s+(?:`?(\w+)`?\.)?`?(\w+)`?'
-
-        for match in re.finditer(pattern, sql, re.IGNORECASE):
-            table = match.group(2)
-            if table.lower() in virtual_tables:
-                continue
-            real_table = metadata.get_table_name(table)
-            if real_table and real_table not in tables:
-                tables.append(real_table)
-
-        return tables

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -15,6 +15,10 @@ from src.core.sql_validator import (
     SchemaMetadata, SchemaMetadataProvider, SQLValidator, SQLAutoCompleter,
     ValidationIssue, IssueSeverity, extract_table_aliases
 )
+from src.core import constants
+from src.core import sql_metadata as sql_metadata_module
+from src.core import sql_autocompleter as sql_autocompleter_module
+from src.core import sql_identifier_utils
 
 
 class TestSchemaMetadata(unittest.TestCase):
@@ -824,6 +828,26 @@ class TestEdgeCases(unittest.TestCase):
         issues = self.validator.validate(sql)
         # 문자열 내부는 무시
         self.assertEqual(len([i for i in issues if 'nonexistent' in i.message]), 0)
+
+
+class TestReExportsAndSystemSchemas(unittest.TestCase):
+    """[CC-002/CC-008] 분할 이후 old import path 재수출 + SYSTEM_SCHEMAS 단일 소스화 가드 테스트"""
+
+    def test_old_path_reexports_are_identical_objects(self):
+        """[SUCCESS] old path(src.core.sql_validator) 재수출 객체가 신규 모듈의 객체와 동일(is)함"""
+        self.assertIs(SchemaMetadata, sql_metadata_module.SchemaMetadata)
+        self.assertIs(SchemaMetadataProvider, sql_metadata_module.SchemaMetadataProvider)
+        self.assertIs(SQLAutoCompleter, sql_autocompleter_module.SQLAutoCompleter)
+        self.assertIs(extract_table_aliases, sql_identifier_utils.extract_table_aliases)
+
+    def test_system_schemas_derived_from_constants_upper(self):
+        """[SUCCESS] SQLValidator.SYSTEM_SCHEMAS는 constants.SYSTEM_SCHEMAS의 대문자 파생이다"""
+        expected = frozenset(s.upper() for s in constants.SYSTEM_SCHEMAS)
+        self.assertEqual(SQLValidator.SYSTEM_SCHEMAS, expected)
+
+    def test_system_schemas_includes_ndbinfo(self):
+        """[SUCCESS] SYSTEM_SCHEMAS에 'NDBINFO'가 포함된다"""
+        self.assertIn('NDBINFO', SQLValidator.SYSTEM_SCHEMAS)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 요약

Clean Code 리팩토링 Round 1 [WP-1.2]. `src/core/sql_validator.py` (869줄, god file)를 순수 동작 보존 방식으로 4개 모듈로 분할했다.

**Findings 반영**: CC-002, CC-008, CC-009, CC-010, CC-016

## 변경 내용

- **`src/core/sql_identifier_utils.py` (신규)**: `ALIAS_STOP_WORDS`, `_normalize_identifier`, `_read_identifier`, `_skip_balanced_parentheses`, `extract_cte_names`, `extract_derived_table_aliases`, `extract_table_aliases`를 코드 변경 없이 이동. `extract_table_aliases`의 `SchemaMetadata` 타입힌트는 문자열 어노테이션 + `TYPE_CHECKING` 가드로 처리해 런타임 순환참조를 제거했다.
- **`src/core/sql_metadata.py` (신규)**: `_schema_key`, `SchemaMetadata`, `SchemaMetadataProvider`를 이동하고 `FUZZY_MATCH_CUTOFF = 0.5` 상수를 신설해 `get_similar_tables`/`get_similar_columns`의 하드코딩된 `cutoff=0.5`를 대체했다 (CC-016).
  - 원 계획은 3파일 분할이었으나, `sql_validator`가 `SQLAutoCompleter`를 재수출해야 하고 `SQLAutoCompleter`는 `SchemaMetadataProvider`를 필요로 하는 순환참조 위험이 있어, 메타데이터 계층을 4번째 모듈로 분리해 의존 방향을 `sql_identifier_utils`/`sql_metadata` → `sql_validator`/`sql_autocompleter` 단방향으로 고정했다.
- **`src/core/sql_autocompleter.py` (신규)**: `SQLAutoCompleter` 클래스를 이동하고 `get_completions`를 `_complete_tables`, `_complete_columns_for_table`, `_complete_columns_from_from_clause`, `_complete_keywords_and_functions` 4개 사설 헬퍼로 분해했다 (CC-010). public 시그니처와 반환 순서/형태는 완전히 동일하게 유지했다.
- **`src/core/sql_validator.py`**: `IssueSeverity`, `ValidationIssue`, `SQLValidator`만 남기고, 파일 상단에 하위호환 재수출 블록(`__all__` 포함)을 추가했다. `_validate_version_compatibility`의 중복 스캔 루프(키워드/함수)를 `_flag_unsupported_items` 사설 메서드로 통합했다 (CC-009). 메시지 문자열, severity, `end_column` 계산은 완전히 동일하게 유지된다.
- **`src/core/constants.py`**: `SYSTEM_SCHEMAS`에 `'ndbinfo'` 추가 (finding 권고에 따른 단일 소스화). `SQLValidator.SYSTEM_SCHEMAS`는 이제 `frozenset(s.upper() for s in constants.SYSTEM_SCHEMAS)`로 파생되어 두 상수 간 드리프트가 원천 차단된다 (CC-008).
- **`tests/test_sql_validator.py`**: 가드 테스트 3개 추가 — (1) old import path 재수출 객체가 신규 모듈 객체와 `is` 동일한지, (2) `SQLValidator.SYSTEM_SCHEMAS`가 `constants.SYSTEM_SCHEMAS` 대문자 파생인지, (3) `'NDBINFO'` 포함 여부.

기존 소비자 6곳(`src/core/__init__.py`, `src/ui/dialogs/sql_editor_dialog.py`, `src/ui/dialogs/sql_editor_highlighters.py`, `src/ui/workers/validation_worker.py`, `tests/test_sql_editor_dialog.py` 등)은 재수출로 무수정.

## 검증 결과

| 명령 | 결과 |
|------|------|
| `py_compile` (5개 파일) | 통과 |
| `import src.core.sql_autocompleter` (단독, 순환참조 검증) | 통과 |
| `import src.core.sql_validator` + 재수출 표면 전체 import | 통과 |
| `pytest tests/test_sql_validator.py -q` | 73 passed |
| `pytest tests/test_sql_editor_dialog.py tests/test_db_core_service.py tests/test_db_connector.py -q` | 111 passed |
| `pytest -q` (전체 회귀) | 1812 passed, 1 failed (macOS validation CI 의존 테스트 — 로컬 상시 실패 베이스라인, 회귀 아님) |

## 리스크

- `constants.SYSTEM_SCHEMAS`에 `ndbinfo` 추가로 `db_connector.py`/`db_core_service.py`의 DB 목록 필터링도 `ndbinfo`를 제외하게 됨 (NDB Cluster 환경에서만 관측되는 의도된 미세 동작 변화, finding 권고 명시). `tests/test_db_core_service.py`는 `SYSTEM_SCHEMAS`를 monkeypatch하므로 영향 없음.
- 버전 bump 없음. Python DB 드라이버 hot path 재도입 없음 (순수 파싱/검증 로직만 다룸).

🤖 Generated with [Claude Code](https://claude.com/claude-code)