### PR TITLE
refactor(migration): 마이그레이션 공유 상수/표시 라벨 단일 소스로 통합

### DIFF
--- a/src/core/migration_analyzer.py
+++ b/src/core/migration_analyzer.py
@@ -18,6 +18,7 @@ from src.core.db_connector import MySQLConnector
 # ============================================================
 from src.core.migration_constants import (
     ALL_REMOVED_FUNCTIONS,
+    ALL_RESERVED_KEYWORDS,
     DEPRECATED_FUNCTIONS_84,
     OBSOLETE_SQL_MODES,
     IssueType,
@@ -174,16 +175,6 @@ class MigrationAnalyzer:
     DEPRECATED_FUNCTIONS = list(ALL_REMOVED_FUNCTIONS)
     # deprecated만 (경고 수준 차등화용)
     _DEPRECATED_ONLY = set(DEPRECATED_FUNCTIONS_84)
-
-    # MySQL 8.4에서 새로운 예약어들 (기존 22개 + 8.4 추가 4개)
-    NEW_RESERVED_KEYWORDS = [
-        'CUME_DIST', 'DENSE_RANK', 'EMPTY', 'EXCEPT', 'FIRST_VALUE',
-        'GROUPING', 'GROUPS', 'JSON_TABLE', 'LAG', 'LAST_VALUE', 'LATERAL',
-        'LEAD', 'NTH_VALUE', 'NTILE', 'OF', 'OVER', 'PERCENT_RANK',
-        'RANK', 'RECURSIVE', 'ROW_NUMBER', 'SYSTEM', 'WINDOW',
-        # MySQL 8.4 추가 예약어
-        'MANUAL', 'PARALLEL', 'QUALIFY', 'TABLESAMPLE'
-    ]
 
     def __init__(self, connector: MySQLConnector):
         self.connector = connector
@@ -419,7 +410,7 @@ class MigrationAnalyzer:
         self._log("🔍 예약어 충돌 확인 중...")
 
         issues = []
-        keywords_upper = set(k.upper() for k in self.NEW_RESERVED_KEYWORDS)
+        keywords_upper = set(k.upper() for k in ALL_RESERVED_KEYWORDS)
 
         # 테이블명 확인
         tables = self.connector.get_tables(schema)

--- a/src/core/migration_constants.py
+++ b/src/core/migration_constants.py
@@ -7,7 +7,14 @@ MySQL 8.0.x → 8.4.x 업그레이드 호환성 검사에 사용.
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
+
+from src.core.migration_identifier_matchers import (
+    DOLLAR_SIGN_PATTERN,
+    TRAILING_SPACE_PATTERN,
+    CONTROL_CHAR_PATTERN,
+    INVALID_57_NAME_MULTIPLE_DOTS_PATTERN,
+)
 
 # ============================================================
 # MySQL 8.4에서 제거된 시스템 변수 (47개)
@@ -299,7 +306,7 @@ ENGINE_POLICIES: Dict[str, Dict[str, str]] = {
     },
 }
 
-STORAGE_ENGINE_STATUS: Dict[str, any] = {
+STORAGE_ENGINE_STATUS: Dict[str, Any] = {
     # ENGINE_POLICIES에 정의된 엔진 = deprecated 취급 대상 (단일 소스에서 파생)
     'deprecated': list(ENGINE_POLICIES.keys()),
     'recommended': 'InnoDB',
@@ -422,94 +429,10 @@ class CompatibilityIssue:
 # ============================================================
 # 식별자 이슈 탐지용 컨텍스트 제한 매처
 # ============================================================
-# 배경: 단순 `[^`]*\$[^`]*` 형태의 raw 정규식은 백틱이 짝을 이루는지
-# 확인하지 않아, 인접한 두 식별자 사이의 텍스트(따옴표 문자열 리터럴 포함)를
-# 하나의 식별자로 오인해 대량의 오탐을 만들었다. 아래 헬퍼는 완전한 백틱
-# 토큰(여는/닫는 백틱이 한 쌍인 구간) 단위로만 술어를 검사하고, 문자열
-# 리터럴은 스캔 전에 마스킹하여 데이터 영역의 `$`/제어문자를 식별자 문제로
-# 오인하지 않도록 한다. `.search()`/`.finditer()`는 기존 `re.Pattern`과
-# 동일하게 실제 `re.Match` 객체를 반환하므로 호출부(`schema_rules.py`,
-# 테스트)의 `match.group(0)` 사용은 변경 없이 그대로 동작한다.
-class _IdentifierIssuePattern:
-    """DDL 식별자 컨텍스트 안의 완전한 백틱 토큰만 검사하는 패턴 매처"""
-
-    # CREATE/ALTER/DROP/RENAME TABLE, CREATE/DROP INDEX 등 식별자가
-    # 정의/참조되는 DDL 구문 범위. 세미콜론까지(또는 세미콜론이 없으면
-    # 문자열 끝까지)를 하나의 구문으로 간주하는 보수적인 스캐너.
-    _DDL_CONTEXT_PATTERN = re.compile(
-        r'\b(?:CREATE(?:\s+(?:UNIQUE|FULLTEXT|SPATIAL))?|ALTER|DROP|RENAME)'
-        r'\s+(?:TABLE|INDEX)\b[^;]*;?',
-        re.IGNORECASE | re.DOTALL,
-    )
-    # 완전한 백틱 토큰 하나(개행을 넘어가지 않음)
-    _TOKEN_PATTERN = re.compile(r'`([^`\r\n]*)`')
-    # 작은/큰따옴표 문자열 리터럴 (이스케이프 문자 포함)
-    _STRING_LITERAL_PATTERN = re.compile(r"'(?:[^'\\]|\\.)*'|\"(?:[^\"\\]|\\.)*\"", re.DOTALL)
-
-    def __init__(self, predicate):
-        self._predicate = predicate
-
-    @classmethod
-    def _mask_string_literals(cls, text: str) -> str:
-        """문자열 리터럴 내부를 동일 길이의 'x'로 치환해 오프셋을 보존한다."""
-        def _mask(m):
-            s = m.group(0)
-            if len(s) < 2:
-                return s
-            return s[0] + 'x' * (len(s) - 2) + s[-1]
-        return cls._STRING_LITERAL_PATTERN.sub(_mask, text)
-
-    def _iter_scan_spans(self, text: str):
-        """DDL 컨텍스트 구간만 산출. 컨텍스트 키워드가 전혀 없으면
-        (상수 단위 테스트처럼 식별자만 단독으로 주어진 입력) 전체 텍스트를
-        그대로 하나의 구간으로 취급한다."""
-        found = False
-        for m in self._DDL_CONTEXT_PATTERN.finditer(text):
-            found = True
-            yield m.start(), m.group(0)
-        if not found:
-            yield 0, text
-
-    def finditer(self, text: str):
-        for offset, span_text in self._iter_scan_spans(text):
-            masked = self._mask_string_literals(span_text)
-            for m in self._TOKEN_PATTERN.finditer(masked):
-                if self._predicate(m.group(1)):
-                    real_match = self._TOKEN_PATTERN.match(text, offset + m.start())
-                    if real_match:
-                        yield real_match
-
-    def search(self, text: str):
-        for m in self.finditer(text):
-            return m
-        return None
-
-
-class _ContextualDotPattern:
-    """FROM/JOIN/INTO/UPDATE/TABLE/REFERENCES 키워드 바로 뒤에 오는
-    식별자 참조에서만 연속 점(..) 오타를 검사하는 패턴 매처.
-
-    키워드 제한 없이 원시 텍스트 전체를 스캔하면 INSERT 데이터나 문자열
-    리터럴 안의 '..'까지 식별자 문제로 오인한다. 매치 시작 위치를 키워드
-    바로 다음으로 고정하므로 `match.group(0)`에는 키워드가 포함되지 않는다.
-    """
-
-    _KEYWORD_PATTERN = re.compile(
-        r'\b(?:FROM|JOIN|INTO|UPDATE|TABLE|REFERENCES)\s+',
-        re.IGNORECASE,
-    )
-    _IDENTIFIER_PATTERN = re.compile(r'`?[\w$]+`?\s*\.\.\s*`?[\w$]+`?')
-
-    def finditer(self, text: str):
-        for kw_match in self._KEYWORD_PATTERN.finditer(text):
-            id_match = self._IDENTIFIER_PATTERN.match(text, kw_match.end())
-            if id_match:
-                yield id_match
-
-    def search(self, text: str):
-        for m in self.finditer(text):
-            return m
-        return None
+# _IdentifierIssuePattern / _ContextualDotPattern과 이에 의존하는 인스턴스
+# (DOLLAR_SIGN_PATTERN, TRAILING_SPACE_PATTERN, CONTROL_CHAR_PATTERN,
+# INVALID_57_NAME_MULTIPLE_DOTS_PATTERN)는 src/core/migration_identifier_matchers.py로
+# 이동했다. 하위 호환을 위해 모듈 상단에서 재노출(re-export)한다.
 
 
 # ============================================================
@@ -581,24 +504,6 @@ SET_EMPTY_PATTERN = re.compile(
     re.IGNORECASE
 )
 
-# 제어 문자 판별용 내부 문자 클래스
-# \x09(tab)은 트레일링 스페이스 검사가 담당하고 \x0a/\x0d(개행)는 백틱
-# 토큰이 개행을 넘어가지 않도록 이미 제외되므로 여기서는 제외한다.
-_CONTROL_CHAR_INNER_PATTERN = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]')
-
-# 달러 기호 식별자 패턴 (DDL 식별자 컨텍스트로 제한, 문자열 리터럴 제외)
-DOLLAR_SIGN_PATTERN = _IdentifierIssuePattern(lambda name: '$' in name)
-
-# 트레일링 스페이스 식별자 패턴 (DDL 식별자 컨텍스트로 제한, 문자열 리터럴 제외)
-TRAILING_SPACE_PATTERN = _IdentifierIssuePattern(
-    lambda name: bool(name) and name[-1] in (' ', '\t')
-)
-
-# 제어 문자 식별자 패턴 (DDL 식별자 컨텍스트로 제한, 문자열 리터럴 제외)
-CONTROL_CHAR_PATTERN = _IdentifierIssuePattern(
-    lambda name: bool(_CONTROL_CHAR_INNER_PATTERN.search(name))
-)
-
 # TIMESTAMP 패턴 (범위 확인용)
 TIMESTAMP_PATTERN = re.compile(
     r"'(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2}):(\d{2})'"
@@ -662,10 +567,8 @@ ROUTINE_SYNTAX_KEYWORD_PATTERN = re.compile(
     re.IGNORECASE
 )
 
-# 식별자에 연속 점(..) 사용 패턴 (schema..table 또는 ..table 형태)
-# FROM/JOIN/INTO/UPDATE/TABLE/REFERENCES 등 식별자 참조 컨텍스트로 제한하여
-# INSERT 데이터나 문자열 리터럴 내부의 '..'를 오탐하지 않도록 한다.
-INVALID_57_NAME_MULTIPLE_DOTS_PATTERN = _ContextualDotPattern()
+# INVALID_57_NAME_MULTIPLE_DOTS_PATTERN은 migration_identifier_matchers.py로
+# 이동했고 모듈 상단에서 재노출된다.
 
 # ============================================================
 # Upgrade check ID 매핑
@@ -715,4 +618,46 @@ DOC_LINKS: Dict[IssueType, str] = {
     IssueType.INDEX_TOO_LARGE: "https://dev.mysql.com/doc/refman/8.4/en/innodb-limits.html",
     IssueType.GROUPBY_ASC_DESC: "https://dev.mysql.com/doc/refman/8.4/en/select.html",
     IssueType.SQL_CALC_FOUND_ROWS_USAGE: "https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_found-rows",
+}
+
+# ============================================================
+# 자동 수정 가능 이슈 타입 (UI 공용 단일 소스)
+# ============================================================
+# 마이그레이션 UI(migration_dialogs.py, fix_wizard_issue_selection_page.py 등)에서
+# "자동 수정 위저드" 대상 여부를 판단하는 canonical 목록.
+AUTO_FIXABLE_ISSUE_TYPES: frozenset = frozenset({
+    IssueType.INVALID_DATE,
+    IssueType.CHARSET_ISSUE,
+    IssueType.ZEROFILL_USAGE,
+    IssueType.FLOAT_PRECISION,
+    IssueType.INT_DISPLAY_WIDTH,
+    IssueType.DEPRECATED_ENGINE,
+    IssueType.ENUM_EMPTY_VALUE,
+})
+
+# ============================================================
+# 이슈 유형별 표시 이름 (UI 공용 단일 소스)
+# ============================================================
+# migration_dialogs.py, migration_manual_guide_dialog.py, fix_wizard_issue_selection_page.py,
+# fix_wizard_option_page.py에 흩어져 있던 5개 type_names dict를 통합한 canonical 매핑.
+ISSUE_TYPE_DISPLAY_NAMES: Dict[IssueType, str] = {
+    IssueType.ORPHAN_ROW: "고아 레코드",
+    IssueType.DEPRECATED_FUNCTION: "deprecated 함수",
+    IssueType.CHARSET_ISSUE: "문자셋 이슈",
+    IssueType.RESERVED_KEYWORD: "예약어",
+    IssueType.SQL_MODE_ISSUE: "SQL 모드",
+    IssueType.REMOVED_SYS_VAR: "제거된 시스템 변수",
+    IssueType.AUTH_PLUGIN_ISSUE: "인증 플러그인",
+    IssueType.INVALID_DATE: "잘못된 날짜",
+    IssueType.ZEROFILL_USAGE: "ZEROFILL 속성",
+    IssueType.FLOAT_PRECISION: "FLOAT 정밀도",
+    IssueType.INT_DISPLAY_WIDTH: "INT 표시 너비",
+    IssueType.FK_NAME_LENGTH: "FK 이름 길이",
+    IssueType.FTS_TABLE_PREFIX: "FTS_ 테이블명",
+    IssueType.SUPER_PRIVILEGE: "SUPER 권한",
+    IssueType.DEFAULT_VALUE_CHANGE: "기본값 변경",
+    IssueType.DEPRECATED_ENGINE: "deprecated 엔진",
+    IssueType.ENUM_EMPTY_VALUE: "ENUM 빈 값",
+    IssueType.PARTITION_ISSUE: "파티션 이슈",
+    IssueType.INDEX_ISSUE: "인덱스 이슈",
 }

--- a/src/core/migration_dump_analyzer.py
+++ b/src/core/migration_dump_analyzer.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from src.core.migration_constants import (
+    ALL_RESERVED_KEYWORDS,
     IssueType,
     CompatibilityIssue,
     INVALID_DATE_PATTERN,
@@ -137,7 +138,6 @@ class DumpFileAnalyzer:
         Returns:
             발견된 이슈 목록
         """
-        from src.core.migration_analyzer import MigrationAnalyzer
         issues = []
 
         try:
@@ -255,7 +255,7 @@ class DumpFileAnalyzer:
                 re.IGNORECASE
             )
 
-            keywords_upper = set(k.upper() for k in MigrationAnalyzer.NEW_RESERVED_KEYWORDS)
+            keywords_upper = set(k.upper() for k in ALL_RESERVED_KEYWORDS)
 
             for match in table_pattern.finditer(content):
                 table_name = match.group(1)

--- a/src/core/migration_identifier_matchers.py
+++ b/src/core/migration_identifier_matchers.py
@@ -1,0 +1,123 @@
+"""
+식별자 이슈 탐지용 컨텍스트 제한 매처
+
+migration_constants.py에서 분리된 모듈. 아래 매처들은 DDL 식별자 컨텍스트로
+스캔 범위를 제한해 문자열 리터럴/데이터 영역의 오탐을 줄인다.
+"""
+import re
+
+# ============================================================
+# 식별자 이슈 탐지용 컨텍스트 제한 매처
+# ============================================================
+# 배경: 단순 `[^`]*\$[^`]*` 형태의 raw 정규식은 백틱이 짝을 이루는지
+# 확인하지 않아, 인접한 두 식별자 사이의 텍스트(따옴표 문자열 리터럴 포함)를
+# 하나의 식별자로 오인해 대량의 오탐을 만들었다. 아래 헬퍼는 완전한 백틱
+# 토큰(여는/닫는 백틱이 한 쌍인 구간) 단위로만 술어를 검사하고, 문자열
+# 리터럴은 스캔 전에 마스킹하여 데이터 영역의 `$`/제어문자를 식별자 문제로
+# 오인하지 않도록 한다. `.search()`/`.finditer()`는 기존 `re.Pattern`과
+# 동일하게 실제 `re.Match` 객체를 반환하므로 호출부(`schema_rules.py`,
+# 테스트)의 `match.group(0)` 사용은 변경 없이 그대로 동작한다.
+class _IdentifierIssuePattern:
+    """DDL 식별자 컨텍스트 안의 완전한 백틱 토큰만 검사하는 패턴 매처"""
+
+    # CREATE/ALTER/DROP/RENAME TABLE, CREATE/DROP INDEX 등 식별자가
+    # 정의/참조되는 DDL 구문 범위. 세미콜론까지(또는 세미콜론이 없으면
+    # 문자열 끝까지)를 하나의 구문으로 간주하는 보수적인 스캐너.
+    _DDL_CONTEXT_PATTERN = re.compile(
+        r'\b(?:CREATE(?:\s+(?:UNIQUE|FULLTEXT|SPATIAL))?|ALTER|DROP|RENAME)'
+        r'\s+(?:TABLE|INDEX)\b[^;]*;?',
+        re.IGNORECASE | re.DOTALL,
+    )
+    # 완전한 백틱 토큰 하나(개행을 넘어가지 않음)
+    _TOKEN_PATTERN = re.compile(r'`([^`\r\n]*)`')
+    # 작은/큰따옴표 문자열 리터럴 (이스케이프 문자 포함)
+    _STRING_LITERAL_PATTERN = re.compile(r"'(?:[^'\\]|\\.)*'|\"(?:[^\"\\]|\\.)*\"", re.DOTALL)
+
+    def __init__(self, predicate):
+        self._predicate = predicate
+
+    @classmethod
+    def _mask_string_literals(cls, text: str) -> str:
+        """문자열 리터럴 내부를 동일 길이의 'x'로 치환해 오프셋을 보존한다."""
+        def _mask(m):
+            s = m.group(0)
+            if len(s) < 2:
+                return s
+            return s[0] + 'x' * (len(s) - 2) + s[-1]
+        return cls._STRING_LITERAL_PATTERN.sub(_mask, text)
+
+    def _iter_scan_spans(self, text: str):
+        """DDL 컨텍스트 구간만 산출. 컨텍스트 키워드가 전혀 없으면
+        (상수 단위 테스트처럼 식별자만 단독으로 주어진 입력) 전체 텍스트를
+        그대로 하나의 구간으로 취급한다."""
+        found = False
+        for m in self._DDL_CONTEXT_PATTERN.finditer(text):
+            found = True
+            yield m.start(), m.group(0)
+        if not found:
+            yield 0, text
+
+    def finditer(self, text: str):
+        for offset, span_text in self._iter_scan_spans(text):
+            masked = self._mask_string_literals(span_text)
+            for m in self._TOKEN_PATTERN.finditer(masked):
+                if self._predicate(m.group(1)):
+                    real_match = self._TOKEN_PATTERN.match(text, offset + m.start())
+                    if real_match:
+                        yield real_match
+
+    def search(self, text: str):
+        for m in self.finditer(text):
+            return m
+        return None
+
+
+class _ContextualDotPattern:
+    """FROM/JOIN/INTO/UPDATE/TABLE/REFERENCES 키워드 바로 뒤에 오는
+    식별자 참조에서만 연속 점(..) 오타를 검사하는 패턴 매처.
+
+    키워드 제한 없이 원시 텍스트 전체를 스캔하면 INSERT 데이터나 문자열
+    리터럴 안의 '..'까지 식별자 문제로 오인한다. 매치 시작 위치를 키워드
+    바로 다음으로 고정하므로 `match.group(0)`에는 키워드가 포함되지 않는다.
+    """
+
+    _KEYWORD_PATTERN = re.compile(
+        r'\b(?:FROM|JOIN|INTO|UPDATE|TABLE|REFERENCES)\s+',
+        re.IGNORECASE,
+    )
+    _IDENTIFIER_PATTERN = re.compile(r'`?[\w$]+`?\s*\.\.\s*`?[\w$]+`?')
+
+    def finditer(self, text: str):
+        for kw_match in self._KEYWORD_PATTERN.finditer(text):
+            id_match = self._IDENTIFIER_PATTERN.match(text, kw_match.end())
+            if id_match:
+                yield id_match
+
+    def search(self, text: str):
+        for m in self.finditer(text):
+            return m
+        return None
+
+
+# 제어 문자 판별용 내부 문자 클래스
+# \x09(tab)은 트레일링 스페이스 검사가 담당하고 \x0a/\x0d(개행)는 백틱
+# 토큰이 개행을 넘어가지 않도록 이미 제외되므로 여기서는 제외한다.
+_CONTROL_CHAR_INNER_PATTERN = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]')
+
+# 달러 기호 식별자 패턴 (DDL 식별자 컨텍스트로 제한, 문자열 리터럴 제외)
+DOLLAR_SIGN_PATTERN = _IdentifierIssuePattern(lambda name: '$' in name)
+
+# 트레일링 스페이스 식별자 패턴 (DDL 식별자 컨텍스트로 제한, 문자열 리터럴 제외)
+TRAILING_SPACE_PATTERN = _IdentifierIssuePattern(
+    lambda name: bool(name) and name[-1] in (' ', '\t')
+)
+
+# 제어 문자 식별자 패턴 (DDL 식별자 컨텍스트로 제한, 문자열 리터럴 제외)
+CONTROL_CHAR_PATTERN = _IdentifierIssuePattern(
+    lambda name: bool(_CONTROL_CHAR_INNER_PATTERN.search(name))
+)
+
+# 식별자에 연속 점(..) 사용 패턴 (schema..table 또는 ..table 형태)
+# FROM/JOIN/INTO/UPDATE/TABLE/REFERENCES 등 식별자 참조 컨텍스트로 제한하여
+# INSERT 데이터나 문자열 리터럴 내부의 '..'를 오탐하지 않도록 한다.
+INVALID_57_NAME_MULTIPLE_DOTS_PATTERN = _ContextualDotPattern()

--- a/src/ui/dialogs/fix_wizard_issue_selection_page.py
+++ b/src/ui/dialogs/fix_wizard_issue_selection_page.py
@@ -9,7 +9,11 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor
 from typing import List
 
-from src.core.migration_constants import IssueType
+from src.core.migration_constants import (
+    IssueType,
+    ISSUE_TYPE_DISPLAY_NAMES,
+    AUTO_FIXABLE_ISSUE_TYPES,
+)
 from src.core.migration_fix_wizard import CharsetFixPlanBuilder, create_wizard_steps
 
 
@@ -89,29 +93,8 @@ class IssueSelectionPage(QWizardPage):
         self.table.setRowCount(len(issues))
         self.checkboxes.clear()
 
-        # 자동 수정 가능한 이슈 타입
-        auto_fixable_types = {
-            IssueType.INVALID_DATE,
-            IssueType.CHARSET_ISSUE,
-            IssueType.ZEROFILL_USAGE,
-            IssueType.FLOAT_PRECISION,
-            IssueType.INT_DISPLAY_WIDTH,
-            IssueType.DEPRECATED_ENGINE,
-            IssueType.ENUM_EMPTY_VALUE,
-        }
-
-        type_names = {
-            IssueType.INVALID_DATE: "잘못된 날짜",
-            IssueType.CHARSET_ISSUE: "문자셋",
-            IssueType.ZEROFILL_USAGE: "ZEROFILL",
-            IssueType.FLOAT_PRECISION: "FLOAT 정밀도",
-            IssueType.INT_DISPLAY_WIDTH: "INT 표시 너비",
-            IssueType.DEPRECATED_ENGINE: "deprecated 엔진",
-            IssueType.ENUM_EMPTY_VALUE: "ENUM 빈 값",
-            IssueType.AUTH_PLUGIN_ISSUE: "인증 플러그인",
-            IssueType.RESERVED_KEYWORD: "예약어",
-            IssueType.FK_NAME_LENGTH: "FK 이름 길이",
-        }
+        # 자동 수정 가능한 이슈 타입 (공유 단일 소스 참조)
+        auto_fixable_types = AUTO_FIXABLE_ISSUE_TYPES
 
         for i, issue in enumerate(issues):
             # 체크박스
@@ -136,7 +119,7 @@ class IssueSelectionPage(QWizardPage):
             self.table.setItem(i, 1, severity_item)
 
             # 유형
-            type_name = type_names.get(issue.issue_type, str(issue.issue_type.value))
+            type_name = ISSUE_TYPE_DISPLAY_NAMES.get(issue.issue_type, str(issue.issue_type.value))
             type_item = QTableWidgetItem(type_name)
 
             # 자동 수정 가능 표시

--- a/src/ui/dialogs/fix_wizard_option_page.py
+++ b/src/ui/dialogs/fix_wizard_option_page.py
@@ -8,7 +8,7 @@ from PyQt6.QtWidgets import (
 )
 from typing import Dict, List, Optional
 
-from src.core.migration_constants import IssueType
+from src.core.migration_constants import IssueType, ISSUE_TYPE_DISPLAY_NAMES
 from src.core.migration_fix_wizard import FixOption, FixStrategy, FixWizardStep
 
 
@@ -56,19 +56,8 @@ class BatchOptionDialog(QDialog):
             type_counts[step.issue_type] += 1
             type_steps[step.issue_type].append(step)
 
-        type_names = {
-            IssueType.INVALID_DATE: "잘못된 날짜",
-            IssueType.CHARSET_ISSUE: "문자셋 이슈",
-            IssueType.ZEROFILL_USAGE: "ZEROFILL 속성",
-            IssueType.FLOAT_PRECISION: "FLOAT 정밀도",
-            IssueType.INT_DISPLAY_WIDTH: "INT 표시 너비",
-            IssueType.DEPRECATED_ENGINE: "deprecated 엔진",
-            IssueType.ENUM_EMPTY_VALUE: "ENUM 빈 값",
-            IssueType.AUTH_PLUGIN_ISSUE: "인증 플러그인",
-        }
-
         for issue_type, count in type_counts.items():
-            type_name = type_names.get(issue_type, str(issue_type.value))
+            type_name = ISSUE_TYPE_DISPLAY_NAMES.get(issue_type, str(issue_type.value))
             group = QGroupBox(f"{type_name} ({count}개)")
             group_layout = QVBoxLayout(group)
 
@@ -359,17 +348,7 @@ class FixOptionPage(QWizardPage):
         self.update_progress_display()
 
         # 이슈 정보 업데이트
-        type_names = {
-            IssueType.INVALID_DATE: "잘못된 날짜 (0000-00-00)",
-            IssueType.CHARSET_ISSUE: "문자셋 이슈",
-            IssueType.ZEROFILL_USAGE: "ZEROFILL 속성",
-            IssueType.FLOAT_PRECISION: "FLOAT 정밀도 구문",
-            IssueType.INT_DISPLAY_WIDTH: "INT 표시 너비",
-            IssueType.DEPRECATED_ENGINE: "deprecated 스토리지 엔진",
-            IssueType.ENUM_EMPTY_VALUE: "ENUM 빈 문자열",
-        }
-
-        self.lbl_type.setText(type_names.get(step.issue_type, str(step.issue_type.value)))
+        self.lbl_type.setText(ISSUE_TYPE_DISPLAY_NAMES.get(step.issue_type, str(step.issue_type.value)))
         self.lbl_location.setText(step.location)
         self.lbl_description.setText(step.description)
 

--- a/src/ui/dialogs/migration_dialogs.py
+++ b/src/ui/dialogs/migration_dialogs.py
@@ -30,6 +30,7 @@ from src.core.migration_analyzer import (
     MigrationAnalyzer, AnalysisResult, OrphanRecord,
     CompatibilityIssue, CleanupAction, ActionType, IssueType
 )
+from src.core.migration_constants import ISSUE_TYPE_DISPLAY_NAMES, AUTO_FIXABLE_ISSUE_TYPES
 from src.ui.workers.migration_worker import MigrationAnalyzerWorker, CleanupWorker
 from src.core.logger import get_logger
 from src.core.platform_paths import analysis_dir
@@ -868,26 +869,6 @@ class MigrationAnalyzerDialog(QDialog):
             "info": "ℹ️"
         }
 
-        type_names = {
-            # 기존 이슈 타입
-            IssueType.ORPHAN_ROW: "고아 레코드",
-            IssueType.DEPRECATED_FUNCTION: "deprecated 함수",
-            IssueType.CHARSET_ISSUE: "문자셋",
-            IssueType.RESERVED_KEYWORD: "예약어",
-            IssueType.SQL_MODE_ISSUE: "SQL 모드",
-            # MySQL 8.4 Upgrade Checker 이슈 타입 (신규)
-            IssueType.REMOVED_SYS_VAR: "제거된 시스템 변수",
-            IssueType.AUTH_PLUGIN_ISSUE: "인증 플러그인",
-            IssueType.INVALID_DATE: "잘못된 날짜",
-            IssueType.ZEROFILL_USAGE: "ZEROFILL 속성",
-            IssueType.FLOAT_PRECISION: "FLOAT 정밀도",
-            IssueType.INT_DISPLAY_WIDTH: "INT 표시 너비",
-            IssueType.FK_NAME_LENGTH: "FK 이름 길이",
-            IssueType.FTS_TABLE_PREFIX: "FTS_ 테이블명",
-            IssueType.SUPER_PRIVILEGE: "SUPER 권한",
-            IssueType.DEFAULT_VALUE_CHANGE: "기본값 변경",
-        }
-
         for i, issue in enumerate(filtered):
             severity_item = QTableWidgetItem(f"{severity_icons.get(issue.severity, '')} {issue.severity.upper()}")
             if issue.severity == "error":
@@ -896,7 +877,7 @@ class MigrationAnalyzerDialog(QDialog):
                 severity_item.setForeground(QColor("#f39c12"))
 
             self.table_issues.setItem(i, 0, severity_item)
-            self.table_issues.setItem(i, 1, QTableWidgetItem(type_names.get(issue.issue_type, str(issue.issue_type))))
+            self.table_issues.setItem(i, 1, QTableWidgetItem(ISSUE_TYPE_DISPLAY_NAMES.get(issue.issue_type, str(issue.issue_type))))
             self.table_issues.setItem(i, 2, QTableWidgetItem(issue.location))
             self.table_issues.setItem(i, 3, QTableWidgetItem(issue.description))
             self.table_issues.setItem(i, 4, QTableWidgetItem(issue.suggestion))
@@ -1155,16 +1136,8 @@ WHERE c.`{orphan.child_column}` IS NOT NULL
     # 자동 수정 위저드 / 수동 처리 가이드
     # =========================================================================
 
-    # 자동 수정 가능한 이슈 타입
-    AUTO_FIXABLE_TYPES = {
-        IssueType.INVALID_DATE,
-        IssueType.CHARSET_ISSUE,
-        IssueType.ZEROFILL_USAGE,
-        IssueType.FLOAT_PRECISION,
-        IssueType.INT_DISPLAY_WIDTH,
-        IssueType.DEPRECATED_ENGINE,
-        IssueType.ENUM_EMPTY_VALUE,
-    }
+    # 자동 수정 가능한 이슈 타입 (공유 단일 소스 참조)
+    AUTO_FIXABLE_TYPES = AUTO_FIXABLE_ISSUE_TYPES
 
     def _update_fix_buttons(self, issues: list):
         """자동 수정 / 수동 가이드 버튼 활성화 상태 업데이트"""

--- a/src/ui/dialogs/migration_manual_guide_dialog.py
+++ b/src/ui/dialogs/migration_manual_guide_dialog.py
@@ -10,6 +10,7 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore import Qt
 
 from src.core.migration_analyzer import IssueType
+from src.core.migration_constants import ISSUE_TYPE_DISPLAY_NAMES
 
 
 class ManualGuideDialog(QDialog):
@@ -196,18 +197,10 @@ class ManualGuideDialog(QDialog):
 
     def populate_issues(self):
         """이슈 목록 채우기"""
-        type_names = {
-            IssueType.AUTH_PLUGIN_ISSUE: "인증 플러그인",
-            IssueType.RESERVED_KEYWORD: "예약어 충돌",
-            IssueType.FK_NAME_LENGTH: "FK 이름 길이",
-            IssueType.PARTITION_ISSUE: "파티션 이슈",
-            IssueType.INDEX_ISSUE: "인덱스 이슈",
-        }
-
         self.issue_list.setRowCount(len(self.issues))
 
         for i, issue in enumerate(self.issues):
-            type_name = type_names.get(issue.issue_type, str(issue.issue_type.value))
+            type_name = ISSUE_TYPE_DISPLAY_NAMES.get(issue.issue_type, str(issue.issue_type.value))
             self.issue_list.setItem(i, 0, QTableWidgetItem(type_name))
             self.issue_list.setItem(i, 1, QTableWidgetItem(issue.location))
 


### PR DESCRIPTION
## 요약
Clean Code 리팩토링 Round 1 - WP-1.5. 마이그레이션 관련 3종의 교차 파일 중복 상수를 `migration_constants.py` 단일 소스로 통합하는 순수 behavior-preserving 리팩터입니다.

## Findings covered
- CC-051 (`migration_analyzer.py:179`): `MigrationAnalyzer.NEW_RESERVED_KEYWORDS` 클래스 속성(list) 삭제 → 모듈 상수 `ALL_RESERVED_KEYWORDS`(tuple) 참조로 대체. `migration_dump_analyzer.py`의 함수 스코프 import(순환참조 회피용, 더 이상 불필요)도 함께 제거.
- CC-062 (`migration_constants.py:433`): 식별자 이슈 탐지용 컨텍스트 제한 매처(`_IdentifierIssuePattern`, `_ContextualDotPattern`)와 이에 의존하는 인스턴스(`DOLLAR_SIGN_PATTERN`, `TRAILING_SPACE_PATTERN`, `CONTROL_CHAR_PATTERN`, `INVALID_57_NAME_MULTIPLE_DOTS_PATTERN`)를 신규 모듈 `migration_identifier_matchers.py`로 분리. `migration_constants.py`에서 re-export하여 `schema_rules.py`/테스트의 기존 import 경로를 그대로 유지.
- CC-063 (`migration_constants.py:302`): `STORAGE_ENGINE_STATUS: Dict[str, any]` 타입 어노테이션 오타를 `Dict[str, Any]`로 수정 (런타임 값 불변).
- CC-146 (`migration_dialogs.py:1159`): `AUTO_FIXABLE_TYPES` 2중복(`migration_dialogs.py`, `fix_wizard_issue_selection_page.py`)을 `migration_constants.AUTO_FIXABLE_ISSUE_TYPES` 단일 소스로 통합.
- CC-147 (`migration_dialogs.py:871`): `IssueType` → 표시 라벨 dict 5중복(`migration_dialogs.py`, `migration_manual_guide_dialog.py`, `fix_wizard_issue_selection_page.py`, `fix_wizard_option_page.py` 2곳)을 `migration_constants.ISSUE_TYPE_DISPLAY_NAMES`로 통합. 드리프트된 라벨은 가장 서술적인 값으로 통일.

## 변경 파일
- `src/core/migration_analyzer.py`, `migration_constants.py`, `migration_dump_analyzer.py` (수정)
- `src/core/migration_identifier_matchers.py` (신규)
- `src/ui/dialogs/migration_dialogs.py`, `fix_wizard_issue_selection_page.py`, `fix_wizard_option_page.py`, `migration_manual_guide_dialog.py` (수정)

## 검증 결과
- `py_compile` 대상 8개 파일 전체 통과
- 타겟 pytest (`test_migration_constants.py`, `test_migration_analyzer.py`, `test_migration_rules.py`, `test_fix_wizard_dialog.py`, `test_migration_fix_wizard.py`): **374 passed**
- 전체 pytest: **1809 passed, 1 failed** — 실패한 `test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`는 GitHub CI 환경(gh CLI/원격 조회)에 의존하는 로컬 환경 무관 기존 실패이며 본 변경과 무관.

## 리스크 / 후속 작업
- CC-147 라벨 통합으로 일부 UI 다이얼로그의 한국어 표시 텍스트가 미세하게 변경됨 (예: `RESERVED_KEYWORD` "예약어 충돌" → "예약어", `ZEROFILL_USAGE` "ZEROFILL" → "ZEROFILL 속성"). enum 값/로직 변경은 없음. 순수 표시 텍스트 정규화이며 CC-147의 명시적 목표.
- 본 WP는 `ISSUE_TYPE_DISPLAY_NAMES`/`AUTO_FIXABLE_ISSUE_TYPES`를 신설하는 foundational WP로, Round 2(`migration_analyzer.py`/`migration_constants.py` 정리)와 Round 3(UI WP) 작업이 이 PR에 의존합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)