### PR TITLE
refactor(styles): settings.py 인라인 버튼 스타일을 ButtonStyles로 통합

### DIFF
--- a/src/ui/dialogs/settings.py
+++ b/src/ui/dialogs/settings.py
@@ -25,6 +25,7 @@ from src.core.platform_integration import (
 )
 from src.ui.themes import ThemeType
 from src.ui.theme_manager import ThemeManager
+from src.ui.styles import ButtonStyles
 from src.ui.dialogs.settings_close_confirm_dialog import CloseConfirmDialog
 from src.ui.dialogs.settings_update_helpers import (
     UpdatePackageActionText,
@@ -64,23 +65,11 @@ class SettingsDialog(QDialog):
         # 버튼
         button_layout = QHBoxLayout()
         self.btn_save = QPushButton(tr("common.save"))
-        self.btn_save.setStyleSheet("""
-            QPushButton {
-                background-color: #3498db; color: white; font-weight: bold;
-                padding: 6px 16px; border-radius: 4px; border: none;
-            }
-            QPushButton:hover { background-color: #2980b9; }
-        """)
+        self.btn_save.setStyleSheet(ButtonStyles.PRIMARY)
         self.btn_save.clicked.connect(self.save_settings)
 
         self.btn_cancel = QPushButton(tr("common.cancel"))
-        self.btn_cancel.setStyleSheet("""
-            QPushButton {
-                background-color: #ecf0f1; color: #2c3e50;
-                padding: 6px 16px; border-radius: 4px; border: 1px solid #bdc3c7;
-            }
-            QPushButton:hover { background-color: #d5dbdb; }
-        """)
+        self.btn_cancel.setStyleSheet(ButtonStyles.SECONDARY)
         self.btn_cancel.clicked.connect(self.reject)
 
         button_layout.addStretch()
@@ -197,15 +186,7 @@ class SettingsDialog(QDialog):
             test_layout = QHBoxLayout()
             test_layout.setContentsMargins(20, 5, 0, 0)
             btn_test = QPushButton("연결 테스트")
-            btn_test.setStyleSheet("""
-                QPushButton {
-                    background-color: #95a5a6; color: white;
-                    padding: 6px 12px; border-radius: 4px; border: none;
-                    font-size: 11px;
-                    min-height: 26px;
-                }
-                QPushButton:hover { background-color: #7f8c8d; }
-            """)
+            btn_test.setStyleSheet(ButtonStyles.MUTED_SMALL_TALL)
             btn_test.clicked.connect(self._test_github_connection)
             test_layout.addWidget(btn_test)
             test_layout.addStretch()
@@ -256,38 +237,17 @@ class SettingsDialog(QDialog):
         backup_btn_layout = QHBoxLayout()
 
         btn_restore = QPushButton("복원")
-        btn_restore.setStyleSheet("""
-            QPushButton {
-                background-color: #27ae60; color: white;
-                padding: 6px 12px; border-radius: 4px; border: none;
-                font-size: 11px;
-            }
-            QPushButton:hover { background-color: #219a52; }
-        """)
+        btn_restore.setStyleSheet(ButtonStyles.SUCCESS_SMALL)
         btn_restore.clicked.connect(self._restore_selected_backup)
         backup_btn_layout.addWidget(btn_restore)
 
         btn_export = QPushButton("내보내기")
-        btn_export.setStyleSheet("""
-            QPushButton {
-                background-color: #3498db; color: white;
-                padding: 6px 12px; border-radius: 4px; border: none;
-                font-size: 11px;
-            }
-            QPushButton:hover { background-color: #2980b9; }
-        """)
+        btn_export.setStyleSheet(ButtonStyles.INFO_SMALL)
         btn_export.clicked.connect(self._export_config)
         backup_btn_layout.addWidget(btn_export)
 
         btn_import = QPushButton("가져오기")
-        btn_import.setStyleSheet("""
-            QPushButton {
-                background-color: #95a5a6; color: white;
-                padding: 6px 12px; border-radius: 4px; border: none;
-                font-size: 11px;
-            }
-            QPushButton:hover { background-color: #7f8c8d; }
-        """)
+        btn_import.setStyleSheet(ButtonStyles.MUTED_SMALL)
         btn_import.clicked.connect(self._import_config)
         backup_btn_layout.addWidget(btn_import)
 
@@ -463,40 +423,19 @@ class SettingsDialog(QDialog):
 
         # 새로고침 버튼
         btn_refresh_log = QPushButton("새로고침")
-        btn_refresh_log.setStyleSheet("""
-            QPushButton {
-                background-color: #3498db; color: white;
-                padding: 6px 12px; border-radius: 4px; border: none;
-                font-size: 11px;
-            }
-            QPushButton:hover { background-color: #2980b9; }
-        """)
+        btn_refresh_log.setStyleSheet(ButtonStyles.INFO_SMALL)
         btn_refresh_log.clicked.connect(self._refresh_log_viewer)
         control_layout.addWidget(btn_refresh_log)
 
         # 로그 폴더 열기 버튼
         btn_open_log_folder = QPushButton("로그 폴더 열기")
-        btn_open_log_folder.setStyleSheet("""
-            QPushButton {
-                background-color: #95a5a6; color: white;
-                padding: 6px 12px; border-radius: 4px; border: none;
-                font-size: 11px;
-            }
-            QPushButton:hover { background-color: #7f8c8d; }
-        """)
+        btn_open_log_folder.setStyleSheet(ButtonStyles.MUTED_SMALL)
         btn_open_log_folder.clicked.connect(self._open_log_folder)
         control_layout.addWidget(btn_open_log_folder)
 
         # 로그 초기화 버튼
         btn_clear_log = QPushButton("로그 초기화")
-        btn_clear_log.setStyleSheet("""
-            QPushButton {
-                background-color: #e74c3c; color: white;
-                padding: 6px 12px; border-radius: 4px; border: none;
-                font-size: 11px;
-            }
-            QPushButton:hover { background-color: #c0392b; }
-        """)
+        btn_clear_log.setStyleSheet(ButtonStyles.DANGER_SMALL)
         btn_clear_log.clicked.connect(self._clear_log_file)
         control_layout.addWidget(btn_clear_log)
 
@@ -598,15 +537,7 @@ class SettingsDialog(QDialog):
         # 업데이트 확인 버튼
         btn_layout = QHBoxLayout()
         self.btn_check_update = QPushButton("업데이트 확인")
-        self.btn_check_update.setStyleSheet("""
-            QPushButton {
-                background-color: #3498db; color: white;
-                padding: 8px 16px; border-radius: 4px; border: none;
-                font-size: 12px;
-            }
-            QPushButton:hover { background-color: #2980b9; }
-            QPushButton:disabled { background-color: #bdc3c7; }
-        """)
+        self.btn_check_update.setStyleSheet(ButtonStyles.PRIMARY_MD)
         self.btn_check_update.clicked.connect(self._check_for_updates)
         btn_layout.addWidget(self.btn_check_update)
         btn_layout.addStretch()
@@ -641,27 +572,12 @@ class SettingsDialog(QDialog):
         # 다운로드/설치 버튼 및 취소 버튼
         download_btn_layout = QHBoxLayout()
         self.btn_download = QPushButton("🔽 새 버전 다운로드")
-        self.btn_download.setStyleSheet("""
-            QPushButton {
-                background-color: #27ae60; color: white;
-                padding: 8px 16px; border-radius: 4px; border: none;
-                font-size: 12px;
-            }
-            QPushButton:hover { background-color: #229954; }
-            QPushButton:disabled { background-color: #bdc3c7; }
-        """)
+        self.btn_download.setStyleSheet(ButtonStyles.SUCCESS_MD)
         self.btn_download.clicked.connect(self._start_download)
         download_btn_layout.addWidget(self.btn_download)
 
         self.btn_cancel_download = QPushButton("취소")
-        self.btn_cancel_download.setStyleSheet("""
-            QPushButton {
-                background-color: #e74c3c; color: white;
-                padding: 8px 12px; border-radius: 4px; border: none;
-                font-size: 12px;
-            }
-            QPushButton:hover { background-color: #c0392b; }
-        """)
+        self.btn_cancel_download.setStyleSheet(ButtonStyles.DANGER_MD)
         self.btn_cancel_download.clicked.connect(self._cancel_download)
         self.btn_cancel_download.hide()
         download_btn_layout.addWidget(self.btn_cancel_download)
@@ -899,14 +815,7 @@ class SettingsDialog(QDialog):
             self.download_progress.setValue(100)
             self.btn_download.setText(action_text.button)
             self.btn_download.setEnabled(True)
-            self.btn_download.setStyleSheet("""
-                QPushButton {
-                    background-color: #9b59b6; color: white;
-                    padding: 8px 16px; border-radius: 4px; border: none;
-                    font-size: 12px; font-weight: bold;
-                }
-                QPushButton:hover { background-color: #8e44ad; }
-            """)
+            self.btn_download.setStyleSheet(ButtonStyles.INSTALL)
             # 버튼 클릭 이벤트 변경
             self.btn_download.clicked.disconnect()
             self.btn_download.clicked.connect(self._launch_installer)

--- a/src/ui/styles.py
+++ b/src/ui/styles.py
@@ -121,6 +121,99 @@ class ButtonStyles:
         QPushButton:hover { color: #2980b9; text-decoration: underline; }
     """
 
+    # 정보 버튼 (작은 크기) - settings.py btn_export, btn_refresh_log
+    INFO_SMALL = """
+            QPushButton {
+                background-color: #3498db; color: white;
+                padding: 6px 12px; border-radius: 4px; border: none;
+                font-size: 11px;
+            }
+            QPushButton:hover { background-color: #2980b9; }
+        """
+
+    # 회색 버튼 (작은 크기) - settings.py btn_import, btn_open_log_folder
+    MUTED_SMALL = """
+            QPushButton {
+                background-color: #95a5a6; color: white;
+                padding: 6px 12px; border-radius: 4px; border: none;
+                font-size: 11px;
+            }
+            QPushButton:hover { background-color: #7f8c8d; }
+        """
+
+    # 회색 버튼 (작은 크기 + 최소 높이) - settings.py btn_test
+    MUTED_SMALL_TALL = """
+                QPushButton {
+                    background-color: #95a5a6; color: white;
+                    padding: 6px 12px; border-radius: 4px; border: none;
+                    font-size: 11px;
+                    min-height: 26px;
+                }
+                QPushButton:hover { background-color: #7f8c8d; }
+            """
+
+    # 성공 버튼 (작은 크기) - settings.py btn_restore
+    SUCCESS_SMALL = """
+            QPushButton {
+                background-color: #27ae60; color: white;
+                padding: 6px 12px; border-radius: 4px; border: none;
+                font-size: 11px;
+            }
+            QPushButton:hover { background-color: #219a52; }
+        """
+
+    # 위험 버튼 (작은 크기) - settings.py btn_clear_log
+    DANGER_SMALL = """
+            QPushButton {
+                background-color: #e74c3c; color: white;
+                padding: 6px 12px; border-radius: 4px; border: none;
+                font-size: 11px;
+            }
+            QPushButton:hover { background-color: #c0392b; }
+        """
+
+    # 기본 버튼 (중간 크기, disabled 포함) - settings.py btn_check_update
+    PRIMARY_MD = """
+            QPushButton {
+                background-color: #3498db; color: white;
+                padding: 8px 16px; border-radius: 4px; border: none;
+                font-size: 12px;
+            }
+            QPushButton:hover { background-color: #2980b9; }
+            QPushButton:disabled { background-color: #bdc3c7; }
+        """
+
+    # 성공 버튼 (중간 크기, disabled 포함) - settings.py btn_download
+    SUCCESS_MD = """
+            QPushButton {
+                background-color: #27ae60; color: white;
+                padding: 8px 16px; border-radius: 4px; border: none;
+                font-size: 12px;
+            }
+            QPushButton:hover { background-color: #229954; }
+            QPushButton:disabled { background-color: #bdc3c7; }
+        """
+
+    # 위험 버튼 (중간 크기) - settings.py btn_cancel_download
+    DANGER_MD = """
+            QPushButton {
+                background-color: #e74c3c; color: white;
+                padding: 8px 12px; border-radius: 4px; border: none;
+                font-size: 12px;
+            }
+            QPushButton:hover { background-color: #c0392b; }
+        """
+
+    # 설치 전환 버튼 - settings.py _on_download_finished 에서 btn_download 재스타일
+    INSTALL = """
+                QPushButton {
+                    background-color: #9b59b6; color: white;
+                    padding: 8px 16px; border-radius: 4px; border: none;
+                    font-size: 12px; font-weight: bold;
+                }
+                QPushButton:hover { background-color: #8e44ad; }
+            """
+
 
 class LabelStyles:
     """라벨 스타일 정의"""
@@ -153,229 +246,12 @@ class LabelStyles:
     HIGHLIGHT = "color: #2c3e50; font-weight: bold;"
 
 
-class InputStyles:
-    """입력 필드 스타일 정의"""
-
-    # 기본 입력 필드
-    DEFAULT = """
-        QLineEdit, QSpinBox, QComboBox {
-            padding: 6px 10px;
-            border: 1px solid #bdc3c7;
-            border-radius: 4px;
-            background-color: white;
-        }
-        QLineEdit:focus, QSpinBox:focus, QComboBox:focus {
-            border-color: #3498db;
-        }
-        QLineEdit:disabled, QSpinBox:disabled, QComboBox:disabled {
-            background-color: #ecf0f1;
-            color: #95a5a6;
-        }
-    """
-
-    # 오류 상태
-    ERROR = """
-        QLineEdit, QSpinBox {
-            border: 1px solid #e74c3c;
-            background-color: #fdf2f0;
-        }
-    """
-
-    # 성공 상태
-    SUCCESS = """
-        QLineEdit, QSpinBox {
-            border: 1px solid #27ae60;
-            background-color: #f0fdf4;
-        }
-    """
-
-
-class GroupBoxStyles:
-    """그룹박스 스타일 정의"""
-
-    DEFAULT = """
-        QGroupBox {
-            font-weight: bold;
-            border: 1px solid #bdc3c7;
-            border-radius: 6px;
-            margin-top: 12px;
-            padding-top: 10px;
-        }
-        QGroupBox::title {
-            subcontrol-origin: margin;
-            left: 10px;
-            padding: 0 5px;
-            color: #2c3e50;
-        }
-    """
-
-
-class TableStyles:
-    """테이블 스타일 정의"""
-
-    DEFAULT = """
-        QTableWidget {
-            border: 1px solid #bdc3c7;
-            gridline-color: #ecf0f1;
-            selection-background-color: #d5f5e3;
-        }
-        QTableWidget::item {
-            padding: 5px;
-        }
-        QHeaderView::section {
-            background-color: #ecf0f1;
-            padding: 8px;
-            border: none;
-            border-bottom: 1px solid #bdc3c7;
-            font-weight: bold;
-        }
-    """
-
-
-class ProgressStyles:
-    """프로그레스바 스타일 정의"""
-
-    DEFAULT = """
-        QProgressBar {
-            border: 1px solid #bdc3c7;
-            border-radius: 4px;
-            text-align: center;
-            height: 20px;
-        }
-        QProgressBar::chunk {
-            background-color: #3498db;
-            border-radius: 3px;
-        }
-    """
-
-    SUCCESS = """
-        QProgressBar::chunk {
-            background-color: #27ae60;
-        }
-    """
-
-    WARNING = """
-        QProgressBar::chunk {
-            background-color: #f1c40f;
-        }
-    """
-
-
-class TextEditStyles:
-    """텍스트 에디터 스타일 정의"""
-
-    # 로그 출력용 (모노스페이스)
-    LOG = """
-        QTextEdit {
-            font-family: Consolas, 'Courier New', monospace;
-            font-size: 12px;
-            background-color: #1e1e1e;
-            color: #d4d4d4;
-            border: 1px solid #3c3c3c;
-            border-radius: 4px;
-            padding: 8px;
-        }
-    """
-
-    # 일반 텍스트 에디터
-    DEFAULT = """
-        QTextEdit {
-            border: 1px solid #bdc3c7;
-            border-radius: 4px;
-            padding: 8px;
-        }
-        QTextEdit:focus {
-            border-color: #3498db;
-        }
-    """
-
-
-class TabStyles:
-    """탭 위젯 스타일 정의"""
-
-    DEFAULT = """
-        QTabWidget::pane {
-            border: 1px solid #bdc3c7;
-            border-radius: 4px;
-        }
-        QTabBar::tab {
-            background-color: #ecf0f1;
-            padding: 8px 16px;
-            margin-right: 2px;
-            border-top-left-radius: 4px;
-            border-top-right-radius: 4px;
-        }
-        QTabBar::tab:selected {
-            background-color: white;
-            border: 1px solid #bdc3c7;
-            border-bottom: none;
-        }
-        QTabBar::tab:hover:!selected {
-            background-color: #d5dbdb;
-        }
-    """
-
-
-class DialogStyles:
-    """다이얼로그 스타일 정의"""
-
-    # 다이얼로그 기본 배경
-    DEFAULT = "background-color: #f8f9f9;"
-
-
-# 자주 사용하는 색상 상수
-class Colors:
-    """색상 상수"""
-
-    PRIMARY = "#3498db"
-    PRIMARY_DARK = "#2980b9"
-
-    SUCCESS = "#27ae60"
-    SUCCESS_LIGHT = "#2ecc71"
-
-    DANGER = "#e74c3c"
-    DANGER_DARK = "#c0392b"
-
-    WARNING = "#f1c40f"
-    WARNING_DARK = "#d4ac0d"
-
-    INFO = "#3498db"
-
-    GRAY_LIGHT = "#ecf0f1"
-    GRAY = "#bdc3c7"
-    GRAY_DARK = "#95a5a6"
-
-    TEXT_PRIMARY = "#2c3e50"
-    TEXT_SECONDARY = "#7f8c8d"
-
-    WHITE = "#ffffff"
-    BLACK = "#333333"
-
-
-def apply_button_style(button, style: str):
-    """버튼에 스타일 적용 헬퍼 함수
-
-    Args:
-        button: QPushButton 인스턴스
-        style: ButtonStyles 클래스의 스타일 상수
-    """
-    button.setStyleSheet(style)
-
-
-def apply_label_style(label, style: str):
-    """라벨에 스타일 적용 헬퍼 함수
-
-    Args:
-        label: QLabel 인스턴스
-        style: LabelStyles 클래스의 스타일 상수
-    """
-    label.setStyleSheet(style)
-
-
 # =============================================================================
 # 동적 테마 스타일 생성 함수
 # =============================================================================
 
+# NOTE(Round 3 call-site 마이그레이션 대상): get_dynamic_button_style/get_dynamic_label_style는
+# 현재 호출부가 없으나 ButtonStyles/LabelStyles(정적 상수)를 대체할 목표 API라 유지한다.
 def get_dynamic_button_style(variant: str, colors: ThemeColors = None) -> str:
     """테마 기반 동적 버튼 스타일 생성
 
@@ -681,6 +557,7 @@ def get_dynamic_progress_style(colors: ThemeColors = None) -> str:
     """
 
 
+# NOTE(Round 3 call-site 마이그레이션 대상): 위 get_dynamic_button_style와 동일한 사유로 유지.
 def get_dynamic_label_style(variant: str, colors: ThemeColors = None) -> str:
     """테마 기반 동적 라벨 스타일
 


### PR DESCRIPTION
## 개요 (WP-1.6, Clean Code Round 1)

**Findings**: CC-181 (`src/ui/dialogs/settings.py:67`), CC-204 (`src/ui/styles.py:23`)

### CC-181: settings.py 인라인 QPushButton 스타일 → ButtonStyles 상수 치환

`src/ui/dialogs/settings.py`의 QPushButton `setStyleSheet("""...""")` 인라인 블록 13곳을 전량 `ButtonStyles` 상수 참조로 치환했습니다.

- **재사용**: `btn_save` → `ButtonStyles.PRIMARY`, `btn_cancel` → `ButtonStyles.SECONDARY`
  - 두 상수는 인라인 원본에 없던 `QPushButton:disabled` 규칙을 추가로 포함하지만, 이 두 버튼은 코드 어디서도 `setEnabled(False)`를 호출하지 않아 관찰 가능한 시각 변화가 없습니다 (의도된 무해한 델타).
- **신규 상수 9개** (원본 인라인 CSS를 공백/개행까지 verbatim 복사, AST로 byte-identical 검증 완료):
  - `INFO_SMALL` — `btn_export`, `btn_refresh_log`
  - `MUTED_SMALL` — `btn_import`, `btn_open_log_folder`
  - `MUTED_SMALL_TALL` — `btn_test` (min-height 26px 포함)
  - `SUCCESS_SMALL` — `btn_restore`
  - `DANGER_SMALL` — `btn_clear_log`
  - `PRIMARY_MD` — `btn_check_update`
  - `SUCCESS_MD` — `btn_download`
  - `DANGER_MD` — `btn_cancel_download` (padding/font-size가 `DANGER_SMALL`과 달라 별도 상수로 분리)
  - `INSTALL` — `_on_download_finished`에서 다운로드 완료 후 `btn_download`를 보라색 설치 버튼으로 전환할 때 사용

`settings.py`는 스타일 치환만 수행했고, 레이아웃/시그널/로직은 손대지 않았습니다 (갓클래스 분해는 Round 3 WP-3.7 몫). non-button 인라인 스타일(QListWidget, QTextBrowser, QLabel 등)은 이 WP 범위 밖이라 그대로 두었습니다.

### CC-204: styles.py 경쟁 시스템 정리 (dead code만)

외부 참조가 전혀 없음을 `grep -rn` 으로 재확인한 뒤 삭제했습니다:
- 클래스: `TableStyles`, `TabStyles`, `DialogStyles`, `ProgressStyles`, `TextEditStyles`, `GroupBoxStyles`, `InputStyles`, `Colors`
- 헬퍼 함수: `apply_button_style`, `apply_label_style`

`ButtonStyles`/`LabelStyles`는 `main_window.py`, `dialogs/tunnel_config.py`, `dialogs/group_dialog.py` (모두 Round 3 파일)에서 여전히 사용 중이라 **삭제하지 않았습니다** — call-site 마이그레이션 및 최종 삭제는 Round 3로 이연.

`get_dynamic_button_style`/`get_dynamic_label_style`은 현재 호출부가 없지만 Round 3 테마 마이그레이션의 목표 API이므로 유지하고 주석(`Round 3 call-site 마이그레이션 대상`)을 추가했습니다. `get_full_app_style`과 그 의존 함수들은 활성 코드라 그대로 유지했습니다.

## 검증

- `python -m py_compile src/ui/styles.py src/ui/dialogs/settings.py` ✅
- `python -c "from src.ui.styles import ButtonStyles, LabelStyles, get_full_app_style, get_dynamic_button_style, get_dynamic_label_style"` ✅
- 타겟 pytest (`test_settings_update_launch`, `test_settings_update_actions`, `test_tunnel_config_dialog`, `test_main_window_export_import_labels`, `test_tunnel_tree`): **37 passed**
- 전체 pytest: **1809 passed, 1 failed** — 실패 1건은 `test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`로 GitHub Actions 워크플로 상태에 의존하는 로컬 환경 항상-실패 테스트이며 이번 변경과 무관 (기존에도 로컬에서 항상 실패).
- 원본 인라인 CSS와 신규 상수의 byte-identical 여부를 AST 파싱으로 직접 비교 검증 (11개 전량 일치, PRIMARY/SECONDARY 2개는 의도된 `:disabled` 델타만 존재).

## 위험 영역

- `styles.py`는 자체 테스트 커버리지가 없어(어떤 테스트도 직접 import하지 않음) 버튼 외형 회귀는 정적 검증(py_compile + import + AST byte-diff)으로만 간접 검증됨.
- `settings.py`는 Round 3 갓클래스 분해(WP-3.7) 대상이라 later-round에서 재수정될 예정 — WP-3.7은 본 PR이 중앙화한 상수를 기반으로 rebase 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)