### PR TITLE
refactor(i18n): i18n.py를 keys/legacy_translate/qt_hooks 패키지로 분할 [WP-1.4]

### DIFF
--- a/src/core/i18n/__init__.py
+++ b/src/core/i18n/__init__.py
@@ -1,0 +1,52 @@
+"""TunnelForge runtime internationalization package.
+
+Three layers behind one stable import surface:
+
+* :mod:`src.core.i18n.keys` -- structured ``tr()`` catalog, active-language
+  state, and language selection (CLI args, installer hint, saved setting, OS
+  locale).
+* :mod:`src.core.i18n.legacy_translate` -- best-effort auto-translation of
+  hardcoded Korean UI strings that predate the structured catalog.
+* :mod:`src.core.i18n.qt_hooks` -- one-time PyQt widget-text patching that
+  routes legacy strings through the auto-translation layer at render time.
+
+Existing call sites import from ``src.core.i18n``; the names below are
+re-exported so the package split stays invisible to consumers.
+"""
+from src.core.i18n.keys import (
+    DEFAULT_LANGUAGE,
+    INSTALLER_LANGUAGE_HINT_FILE,
+    SUPPORTED_LANGUAGES,
+    configure_language,
+    consume_installer_language_hint,
+    current_language,
+    detect_system_language,
+    installer_language_hint_path,
+    language_from_args,
+    language_label,
+    normalize_language,
+    read_installer_language_hint,
+    set_language,
+    tr,
+)
+from src.core.i18n.legacy_translate import _translate_sequence, translate_text
+from src.core.i18n.qt_hooks import install_qt_i18n
+
+__all__ = [
+    "DEFAULT_LANGUAGE",
+    "INSTALLER_LANGUAGE_HINT_FILE",
+    "SUPPORTED_LANGUAGES",
+    "configure_language",
+    "consume_installer_language_hint",
+    "current_language",
+    "detect_system_language",
+    "install_qt_i18n",
+    "installer_language_hint_path",
+    "language_from_args",
+    "language_label",
+    "normalize_language",
+    "read_installer_language_hint",
+    "set_language",
+    "tr",
+    "translate_text",
+]

--- a/src/core/i18n/keys.py
+++ b/src/core/i18n/keys.py
@@ -1,0 +1,256 @@
+"""Structured translation catalog and active-language state.
+
+Owns the ``tr()`` key/value catalog, the process-wide current-language flag,
+and language selection (CLI args, installer hint, saved setting, OS locale).
+Other i18n submodules must read the active language only through
+``current_language()`` / ``set_language()`` so a language switch is reflected
+immediately; importing the ``_current_language`` global directly would copy a
+stale snapshot at import time.
+"""
+import locale
+import os
+from pathlib import Path
+from typing import Iterable, Optional
+
+from src.core.platform_paths import app_support_dir
+
+
+DEFAULT_LANGUAGE = "ko"
+SUPPORTED_LANGUAGES = {
+    "ko": "한국어",
+    "en": "English",
+}
+INSTALLER_LANGUAGE_HINT_FILE = "installer-language.txt"
+
+_current_language = DEFAULT_LANGUAGE
+
+_TRANSLATIONS = {
+    "ko": {
+        "app.ready": "준비됨",
+        "common.cancel": "취소",
+        "common.close": "닫기",
+        "common.delete": "삭제",
+        "common.edit": "수정",
+        "common.ok": "확인",
+        "common.save": "저장",
+        "common.start": "시작",
+        "common.stop": "중지",
+        "common.unknown": "알 수 없음",
+        "main.add_group": "그룹 추가",
+        "main.add_tunnel": "연결 추가",
+        "main.db_transition": "DB 전환",
+        "main.manage": "관리",
+        "main.migration": "마이그레이션",
+        "main.name": "이름",
+        "main.open": "열기",
+        "main.power": "전원",
+        "main.quit": "종료",
+        "main.schedule": "스케줄",
+        "main.schedule_backup": "스케줄 백업",
+        "main.schedule_manage": "스케줄 관리...",
+        "main.run_now": "즉시 실행",
+        "main.schema_diff": "스키마 비교",
+        "main.settings": "설정",
+        "main.status": "상태",
+        "main.target_host": "타겟 호스트",
+        "main.default_schema": "기본 스키마",
+        "main.title": "터널링 연결 목록",
+        "main.local_port": "로컬 포트",
+        "tree.connect_all": "모두 연결",
+        "tree.db_connect": "DB 연결",
+        "tree.delete_group": "그룹 삭제",
+        "tree.disconnect_all": "모두 해제",
+        "tree.duplicate": "복사하여 새로 만들기",
+        "tree.edit_group": "그룹 수정",
+        "tree.sql_editor": "SQL 에디터",
+        "tree.test_connection": "연결 테스트",
+        "tree.ungrouped": "그룹 없음",
+        "settings.about": "정보",
+        "settings.always_exit": "항상 프로그램 종료",
+        "settings.always_minimize": "항상 시스템 트레이로 최소화",
+        "settings.ask_every_time": "매번 묻기",
+        "settings.auto_reconnect": "연결 끊김 시 자동 재연결",
+        "settings.backup_restore": "설정 백업/복원",
+        "settings.close_behavior": "창 닫기(X) 버튼 동작",
+        "settings.dark_mode": "다크 모드",
+        "settings.general": "일반",
+        "settings.github_auto_report": "GitHub 이슈 자동 보고",
+        "settings.language": "언어",
+        "settings.light_mode": "라이트 모드",
+        "settings.logs": "로그",
+        "settings.max_reconnect_attempts": "최대 재연결 시도 횟수:",
+        "settings.reconnect": "터널 자동 재연결",
+        "settings.reconnect_description": "연결이 끊어지면 점진적 백오프(1초→60초)를 적용하여 자동으로 재연결을 시도합니다.",
+        "settings.restart_note": "일부 화면의 언어는 새 창을 열거나 앱을 재시작하면 완전히 반영됩니다.",
+        "settings.startup": "시작 프로그램",
+        "settings.startup_auto": "시스템 시작 시 자동 실행",
+        "settings.startup_description": "로그인 시 시스템 트레이에 최소화된 상태로 자동 시작됩니다.",
+        "settings.system_theme": "시스템 설정 따르기",
+        "settings.theme": "테마",
+        "settings.theme_label": "화면 테마:",
+        "settings.title": "설정",
+    },
+    "en": {
+        "app.ready": "Ready",
+        "common.cancel": "Cancel",
+        "common.close": "Close",
+        "common.delete": "Delete",
+        "common.edit": "Edit",
+        "common.ok": "OK",
+        "common.save": "Save",
+        "common.start": "Start",
+        "common.stop": "Stop",
+        "common.unknown": "Unknown",
+        "main.add_group": "Add Group",
+        "main.add_tunnel": "Add Connection",
+        "main.db_transition": "DB Transition",
+        "main.manage": "Manage",
+        "main.migration": "Migration",
+        "main.name": "Name",
+        "main.open": "Open",
+        "main.power": "Power",
+        "main.quit": "Quit",
+        "main.schedule": "Schedule",
+        "main.schedule_backup": "Scheduled Backups",
+        "main.schedule_manage": "Manage Schedules...",
+        "main.run_now": "Run Now",
+        "main.schema_diff": "Schema Diff",
+        "main.settings": "Settings",
+        "main.status": "Status",
+        "main.target_host": "Target Host",
+        "main.default_schema": "Default Schema",
+        "main.title": "Tunnel Connections",
+        "main.local_port": "Local Port",
+        "tree.connect_all": "Connect All",
+        "tree.db_connect": "DB Connect",
+        "tree.delete_group": "Delete Group",
+        "tree.disconnect_all": "Disconnect All",
+        "tree.duplicate": "Duplicate as New",
+        "tree.edit_group": "Edit Group",
+        "tree.sql_editor": "SQL Editor",
+        "tree.test_connection": "Test Connection",
+        "tree.ungrouped": "Ungrouped",
+        "settings.about": "About",
+        "settings.always_exit": "Always exit the app",
+        "settings.always_minimize": "Always minimize to system tray",
+        "settings.ask_every_time": "Ask every time",
+        "settings.auto_reconnect": "Automatically reconnect when disconnected",
+        "settings.backup_restore": "Settings Backup/Restore",
+        "settings.close_behavior": "Close (X) Button Behavior",
+        "settings.dark_mode": "Dark Mode",
+        "settings.general": "General",
+        "settings.github_auto_report": "Automatic GitHub Issue Reporting",
+        "settings.language": "Language",
+        "settings.light_mode": "Light Mode",
+        "settings.logs": "Logs",
+        "settings.max_reconnect_attempts": "Max reconnect attempts:",
+        "settings.reconnect": "Tunnel Auto-Reconnect",
+        "settings.reconnect_description": "When a connection drops, TunnelForge retries with incremental backoff from 1 to 60 seconds.",
+        "settings.restart_note": "Some screens fully apply the language after opening a new window or restarting the app.",
+        "settings.startup": "Startup",
+        "settings.startup_auto": "Launch automatically at system startup",
+        "settings.startup_description": "Start minimized to the system tray when you log in.",
+        "settings.system_theme": "Follow system setting",
+        "settings.theme": "Theme",
+        "settings.theme_label": "Display theme:",
+        "settings.title": "Settings",
+    },
+}
+
+
+def normalize_language(value: Optional[str]) -> str:
+    """Return a supported language code, falling back to Korean."""
+    text = (value or "").strip().lower().replace("_", "-")
+    if text.startswith("ko"):
+        return "ko"
+    if text.startswith("en"):
+        return "en"
+    return DEFAULT_LANGUAGE
+
+
+def detect_system_language() -> str:
+    language, _ = locale.getlocale()
+    return normalize_language(language)
+
+
+def installer_language_hint_path() -> Path:
+    return app_support_dir() / INSTALLER_LANGUAGE_HINT_FILE
+
+
+def read_installer_language_hint() -> Optional[str]:
+    path = installer_language_hint_path()
+    try:
+        if not path.exists():
+            return None
+        return normalize_language(path.read_text(encoding="utf-8").strip())
+    except OSError:
+        return None
+
+
+def consume_installer_language_hint() -> Optional[str]:
+    language = read_installer_language_hint()
+    if language:
+        try:
+            installer_language_hint_path().unlink()
+        except OSError:
+            pass
+    return language
+
+
+def language_from_args(args: Optional[Iterable[str]]) -> Optional[str]:
+    if not args:
+        return None
+    prefixes = ("--language=", "--lang=")
+    for arg in args:
+        for prefix in prefixes:
+            if arg.startswith(prefix):
+                return normalize_language(arg[len(prefix):])
+    env_value = os.environ.get("TUNNELFORGE_LANGUAGE")
+    return normalize_language(env_value) if env_value else None
+
+
+def current_language() -> str:
+    return _current_language
+
+
+def set_language(language: Optional[str]) -> str:
+    global _current_language
+    _current_language = normalize_language(language)
+    return _current_language
+
+
+def configure_language(config_manager=None, args: Optional[Iterable[str]] = None) -> str:
+    """Load the active language from args, installer hint, settings, then OS locale."""
+    explicit = language_from_args(args)
+    if explicit:
+        language = explicit
+    else:
+        language = None
+        if config_manager is not None:
+            get_setting = getattr(config_manager, "get_app_setting", None)
+            saved = get_setting("language", None) if get_setting else None
+            if saved:
+                language = normalize_language(saved)
+            else:
+                language = consume_installer_language_hint()
+        if not language:
+            language = detect_system_language()
+
+    language = set_language(language)
+    if config_manager is not None:
+        get_setting = getattr(config_manager, "get_app_setting", None)
+        set_setting = getattr(config_manager, "set_app_setting", None)
+        if get_setting and set_setting and normalize_language(get_setting("language", None)) != language:
+            set_setting("language", language)
+    return language
+
+
+def tr(key: str) -> str:
+    return _TRANSLATIONS.get(_current_language, {}).get(
+        key,
+        _TRANSLATIONS[DEFAULT_LANGUAGE].get(key, key),
+    )
+
+
+def language_label(language: str) -> str:
+    return SUPPORTED_LANGUAGES[normalize_language(language)]

--- a/src/core/i18n/legacy_translate.py
+++ b/src/core/i18n/legacy_translate.py
@@ -1,253 +1,19 @@
-"""Small runtime i18n layer for user-facing app chrome."""
-import locale
-import os
+"""Legacy auto-translation of hardcoded Korean UI strings to English.
+
+Best-effort substitution layer (exact dictionary, regex, phrase, and word
+tables plus Korean particle stripping) for Korean literals that predate the
+structured ``tr()`` catalog in :mod:`src.core.i18n.keys`. ``translate_text``
+passes values through unchanged when the active language is the default
+(Korean) or the value contains no Hangul.
+"""
 import re
-from pathlib import Path
-from typing import Iterable, Optional
 
-from src.core.platform_paths import app_support_dir
+from src.core.i18n.keys import DEFAULT_LANGUAGE, current_language
 
-
-DEFAULT_LANGUAGE = "ko"
-SUPPORTED_LANGUAGES = {
-    "ko": "한국어",
-    "en": "English",
-}
-INSTALLER_LANGUAGE_HINT_FILE = "installer-language.txt"
-
-_current_language = DEFAULT_LANGUAGE
-_qt_i18n_installed = False
-
-_TRANSLATIONS = {
-    "ko": {
-        "app.ready": "준비됨",
-        "common.cancel": "취소",
-        "common.close": "닫기",
-        "common.delete": "삭제",
-        "common.edit": "수정",
-        "common.ok": "확인",
-        "common.save": "저장",
-        "common.start": "시작",
-        "common.stop": "중지",
-        "common.unknown": "알 수 없음",
-        "main.add_group": "그룹 추가",
-        "main.add_tunnel": "연결 추가",
-        "main.db_transition": "DB 전환",
-        "main.manage": "관리",
-        "main.migration": "마이그레이션",
-        "main.name": "이름",
-        "main.open": "열기",
-        "main.power": "전원",
-        "main.quit": "종료",
-        "main.schedule": "스케줄",
-        "main.schedule_backup": "스케줄 백업",
-        "main.schedule_manage": "스케줄 관리...",
-        "main.run_now": "즉시 실행",
-        "main.schema_diff": "스키마 비교",
-        "main.settings": "설정",
-        "main.status": "상태",
-        "main.target_host": "타겟 호스트",
-        "main.default_schema": "기본 스키마",
-        "main.title": "터널링 연결 목록",
-        "main.local_port": "로컬 포트",
-        "tree.connect_all": "모두 연결",
-        "tree.db_connect": "DB 연결",
-        "tree.delete_group": "그룹 삭제",
-        "tree.disconnect_all": "모두 해제",
-        "tree.duplicate": "복사하여 새로 만들기",
-        "tree.edit_group": "그룹 수정",
-        "tree.sql_editor": "SQL 에디터",
-        "tree.test_connection": "연결 테스트",
-        "tree.ungrouped": "그룹 없음",
-        "settings.about": "정보",
-        "settings.always_exit": "항상 프로그램 종료",
-        "settings.always_minimize": "항상 시스템 트레이로 최소화",
-        "settings.ask_every_time": "매번 묻기",
-        "settings.auto_reconnect": "연결 끊김 시 자동 재연결",
-        "settings.backup_restore": "설정 백업/복원",
-        "settings.close_behavior": "창 닫기(X) 버튼 동작",
-        "settings.dark_mode": "다크 모드",
-        "settings.general": "일반",
-        "settings.github_auto_report": "GitHub 이슈 자동 보고",
-        "settings.language": "언어",
-        "settings.light_mode": "라이트 모드",
-        "settings.logs": "로그",
-        "settings.max_reconnect_attempts": "최대 재연결 시도 횟수:",
-        "settings.reconnect": "터널 자동 재연결",
-        "settings.reconnect_description": "연결이 끊어지면 점진적 백오프(1초→60초)를 적용하여 자동으로 재연결을 시도합니다.",
-        "settings.restart_note": "일부 화면의 언어는 새 창을 열거나 앱을 재시작하면 완전히 반영됩니다.",
-        "settings.startup": "시작 프로그램",
-        "settings.startup_auto": "시스템 시작 시 자동 실행",
-        "settings.startup_description": "로그인 시 시스템 트레이에 최소화된 상태로 자동 시작됩니다.",
-        "settings.system_theme": "시스템 설정 따르기",
-        "settings.theme": "테마",
-        "settings.theme_label": "화면 테마:",
-        "settings.title": "설정",
-    },
-    "en": {
-        "app.ready": "Ready",
-        "common.cancel": "Cancel",
-        "common.close": "Close",
-        "common.delete": "Delete",
-        "common.edit": "Edit",
-        "common.ok": "OK",
-        "common.save": "Save",
-        "common.start": "Start",
-        "common.stop": "Stop",
-        "common.unknown": "Unknown",
-        "main.add_group": "Add Group",
-        "main.add_tunnel": "Add Connection",
-        "main.db_transition": "DB Transition",
-        "main.manage": "Manage",
-        "main.migration": "Migration",
-        "main.name": "Name",
-        "main.open": "Open",
-        "main.power": "Power",
-        "main.quit": "Quit",
-        "main.schedule": "Schedule",
-        "main.schedule_backup": "Scheduled Backups",
-        "main.schedule_manage": "Manage Schedules...",
-        "main.run_now": "Run Now",
-        "main.schema_diff": "Schema Diff",
-        "main.settings": "Settings",
-        "main.status": "Status",
-        "main.target_host": "Target Host",
-        "main.default_schema": "Default Schema",
-        "main.title": "Tunnel Connections",
-        "main.local_port": "Local Port",
-        "tree.connect_all": "Connect All",
-        "tree.db_connect": "DB Connect",
-        "tree.delete_group": "Delete Group",
-        "tree.disconnect_all": "Disconnect All",
-        "tree.duplicate": "Duplicate as New",
-        "tree.edit_group": "Edit Group",
-        "tree.sql_editor": "SQL Editor",
-        "tree.test_connection": "Test Connection",
-        "tree.ungrouped": "Ungrouped",
-        "settings.about": "About",
-        "settings.always_exit": "Always exit the app",
-        "settings.always_minimize": "Always minimize to system tray",
-        "settings.ask_every_time": "Ask every time",
-        "settings.auto_reconnect": "Automatically reconnect when disconnected",
-        "settings.backup_restore": "Settings Backup/Restore",
-        "settings.close_behavior": "Close (X) Button Behavior",
-        "settings.dark_mode": "Dark Mode",
-        "settings.general": "General",
-        "settings.github_auto_report": "Automatic GitHub Issue Reporting",
-        "settings.language": "Language",
-        "settings.light_mode": "Light Mode",
-        "settings.logs": "Logs",
-        "settings.max_reconnect_attempts": "Max reconnect attempts:",
-        "settings.reconnect": "Tunnel Auto-Reconnect",
-        "settings.reconnect_description": "When a connection drops, TunnelForge retries with incremental backoff from 1 to 60 seconds.",
-        "settings.restart_note": "Some screens fully apply the language after opening a new window or restarting the app.",
-        "settings.startup": "Startup",
-        "settings.startup_auto": "Launch automatically at system startup",
-        "settings.startup_description": "Start minimized to the system tray when you log in.",
-        "settings.system_theme": "Follow system setting",
-        "settings.theme": "Theme",
-        "settings.theme_label": "Display theme:",
-        "settings.title": "Settings",
-    },
-}
-
-
-def normalize_language(value: Optional[str]) -> str:
-    """Return a supported language code, falling back to Korean."""
-    text = (value or "").strip().lower().replace("_", "-")
-    if text.startswith("ko"):
-        return "ko"
-    if text.startswith("en"):
-        return "en"
-    return DEFAULT_LANGUAGE
-
-
-def detect_system_language() -> str:
-    language, _ = locale.getlocale()
-    return normalize_language(language)
-
-
-def installer_language_hint_path() -> Path:
-    return app_support_dir() / INSTALLER_LANGUAGE_HINT_FILE
-
-
-def read_installer_language_hint() -> Optional[str]:
-    path = installer_language_hint_path()
-    try:
-        if not path.exists():
-            return None
-        return normalize_language(path.read_text(encoding="utf-8").strip())
-    except OSError:
-        return None
-
-
-def consume_installer_language_hint() -> Optional[str]:
-    language = read_installer_language_hint()
-    if language:
-        try:
-            installer_language_hint_path().unlink()
-        except OSError:
-            pass
-    return language
-
-
-def language_from_args(args: Optional[Iterable[str]]) -> Optional[str]:
-    if not args:
-        return None
-    prefixes = ("--language=", "--lang=")
-    for arg in args:
-        for prefix in prefixes:
-            if arg.startswith(prefix):
-                return normalize_language(arg[len(prefix):])
-    env_value = os.environ.get("TUNNELFORGE_LANGUAGE")
-    return normalize_language(env_value) if env_value else None
-
-
-def current_language() -> str:
-    return _current_language
-
-
-def set_language(language: Optional[str]) -> str:
-    global _current_language
-    _current_language = normalize_language(language)
-    return _current_language
-
-
-def configure_language(config_manager=None, args: Optional[Iterable[str]] = None) -> str:
-    """Load the active language from args, installer hint, settings, then OS locale."""
-    explicit = language_from_args(args)
-    if explicit:
-        language = explicit
-    else:
-        language = None
-        if config_manager is not None:
-            get_setting = getattr(config_manager, "get_app_setting", None)
-            saved = get_setting("language", None) if get_setting else None
-            if saved:
-                language = normalize_language(saved)
-            else:
-                language = consume_installer_language_hint()
-        if not language:
-            language = detect_system_language()
-
-    language = set_language(language)
-    if config_manager is not None:
-        get_setting = getattr(config_manager, "get_app_setting", None)
-        set_setting = getattr(config_manager, "set_app_setting", None)
-        if get_setting and set_setting and normalize_language(get_setting("language", None)) != language:
-            set_setting("language", language)
-    return language
-
-
-def tr(key: str) -> str:
-    return _TRANSLATIONS.get(_current_language, {}).get(
-        key,
-        _TRANSLATIONS[DEFAULT_LANGUAGE].get(key, key),
-    )
-
-
-def language_label(language: str) -> str:
-    return SUPPORTED_LANGUAGES[normalize_language(language)]
+# Hangul Syllables Unicode block boundaries (가~힣).
+_HANGUL_SYLLABLES_START = "가"
+_HANGUL_SYLLABLES_END = "힣"
+_HANGUL_CHAR_CLASS = f"[{_HANGUL_SYLLABLES_START}-{_HANGUL_SYLLABLES_END}]"
 
 
 _EN_TEXT_TRANSLATIONS = {
@@ -1345,7 +1111,44 @@ _EN_WORD_TRANSLATIONS = {
 
 
 def _has_hangul(value: str) -> bool:
-    return any("\uac00" <= char <= "\ud7a3" for char in value)
+    return any(_HANGUL_SYLLABLES_START <= char <= _HANGUL_SYLLABLES_END for char in value)
+
+
+_SORTED_PHRASE_TRANSLATIONS = tuple(
+    sorted(_EN_PHRASE_TRANSLATIONS.items(), key=lambda item: len(item[0]), reverse=True)
+)
+_SORTED_WORD_TRANSLATIONS = tuple(
+    sorted(_EN_WORD_TRANSLATIONS.items(), key=lambda item: len(item[0]), reverse=True)
+)
+
+
+def _apply_regex_pairs(value):
+    for pattern, replacement in _EN_REGEX_TRANSLATIONS:
+        value = re.sub(pattern, replacement, value, flags=re.DOTALL)
+    return value
+
+
+def _apply_phrase_substitutions(value):
+    for korean, english in _SORTED_PHRASE_TRANSLATIONS:
+        value = value.replace(korean, english)
+    return value
+
+
+def _apply_word_substitutions(value):
+    for korean, english in _SORTED_WORD_TRANSLATIONS:
+        value = re.sub(
+            rf"(?<!{_HANGUL_CHAR_CLASS}){re.escape(korean)}(?!{_HANGUL_CHAR_CLASS})",
+            english,
+            value,
+        )
+    return value
+
+
+def _strip_korean_particles(translated):
+    translated = re.sub(r"(?<=[A-Za-z0-9)}'\"`])(?:은|는|이|가|을|를|와|과|의|에|에서|부터|까지|도|로|으로)(?=[\s,.:;!?)]|$)", "", translated)
+    translated = re.sub(r"(?<=[A-Za-z0-9)}'\"`])하시겠습니까", "?", translated)
+    translated = re.sub(r"(?<=[A-Za-z0-9)}'\"`])하세요", ".", translated)
+    return translated
 
 
 def translate_text(value):
@@ -1364,264 +1167,12 @@ def translate_text(value):
     if stripped in _EN_TEXT_TRANSLATIONS:
         return value.replace(stripped, _EN_TEXT_TRANSLATIONS[stripped], 1)
 
-    translated = value
-    for pattern, replacement in _EN_REGEX_TRANSLATIONS:
-        translated = re.sub(pattern, replacement, translated, flags=re.DOTALL)
-
-    for korean, english in sorted(_EN_PHRASE_TRANSLATIONS.items(), key=lambda item: len(item[0]), reverse=True):
-        translated = translated.replace(korean, english)
-
-    for korean, english in sorted(_EN_WORD_TRANSLATIONS.items(), key=lambda item: len(item[0]), reverse=True):
-        translated = re.sub(
-            rf"(?<![\uac00-\ud7a3]){re.escape(korean)}(?![\uac00-\ud7a3])",
-            english,
-            translated,
-        )
-
-    translated = re.sub(r"(?<=[A-Za-z0-9)}'\"`])(?:은|는|이|가|을|를|와|과|의|에|에서|부터|까지|도|로|으로)(?=[\s,.:;!?)]|$)", "", translated)
-    translated = re.sub(r"(?<=[A-Za-z0-9)}'\"`])하시겠습니까", "?", translated)
-    translated = re.sub(r"(?<=[A-Za-z0-9)}'\"`])하세요", ".", translated)
-
+    translated = _apply_regex_pairs(value)
+    translated = _apply_phrase_substitutions(translated)
+    translated = _apply_word_substitutions(translated)
+    translated = _strip_korean_particles(translated)
     return translated
 
 
 def _translate_sequence(values):
     return [translate_text(value) for value in values]
-
-
-def install_qt_i18n() -> bool:
-    """Install broad PyQt text translation hooks for legacy hardcoded UI strings."""
-    global _qt_i18n_installed
-    if _qt_i18n_installed:
-        return False
-
-    try:
-        from PyQt6.QtGui import QAction
-        from PyQt6.QtWidgets import (
-            QAbstractButton,
-            QCheckBox,
-            QComboBox,
-            QDialog,
-            QFileDialog,
-            QFormLayout,
-            QGroupBox,
-            QLabel,
-            QLineEdit,
-            QMenu,
-            QMessageBox,
-            QPlainTextEdit,
-            QProgressBar,
-            QPushButton,
-            QRadioButton,
-            QStatusBar,
-            QSystemTrayIcon,
-            QTabWidget,
-            QTableWidget,
-            QTextEdit,
-            QToolTip,
-            QTreeWidget,
-            QWidget,
-            QWizard,
-            QWizardPage,
-        )
-    except Exception:
-        return False
-
-    def translate_qt_arg(value):
-        if isinstance(value, str):
-            return translate_text(value)
-        if isinstance(value, list):
-            return [translate_qt_arg(item) for item in value]
-        if isinstance(value, tuple):
-            return tuple(translate_qt_arg(item) for item in value)
-        return value
-
-    def patch_init(cls, text_index=0):
-        original = cls.__init__
-        if getattr(original, "_tf_i18n_wrapped", False):
-            return
-
-        def wrapped(self, *args, **kwargs):
-            args = list(args)
-            if text_index is None:
-                args = [translate_qt_arg(arg) for arg in args]
-            elif len(args) > text_index:
-                args[text_index] = translate_qt_arg(args[text_index])
-            original(self, *args, **kwargs)
-
-        wrapped._tf_i18n_wrapped = True
-        cls.__init__ = wrapped
-
-    def patch_method(cls, name, text_indexes):
-        original = getattr(cls, name, None)
-        if original is None or getattr(original, "_tf_i18n_wrapped", False):
-            return
-
-        def wrapped(self, *args, **kwargs):
-            args = list(args)
-            for index in text_indexes:
-                if len(args) > index:
-                    args[index] = translate_qt_arg(args[index])
-            return original(self, *args, **kwargs)
-
-        wrapped._tf_i18n_wrapped = True
-        setattr(cls, name, wrapped)
-
-    def patch_all_string_args_method(cls, name):
-        original = getattr(cls, name, None)
-        if original is None or getattr(original, "_tf_i18n_wrapped", False):
-            return
-
-        def wrapped(self, *args, **kwargs):
-            args = [translate_qt_arg(arg) for arg in args]
-            return original(self, *args, **kwargs)
-
-        wrapped._tf_i18n_wrapped = True
-        setattr(cls, name, wrapped)
-
-    for cls in (QLabel, QAbstractButton, QPushButton, QCheckBox, QRadioButton, QGroupBox, QAction, QMenu):
-        patch_init(cls, None)
-        patch_method(cls, "setText", [0])
-
-    patch_init(QMessageBox, None)
-    patch_method(QWidget, "setWindowTitle", [0])
-    patch_method(QWidget, "setToolTip", [0])
-    patch_method(QWidget, "setStatusTip", [0])
-    patch_method(QWidget, "setWhatsThis", [0])
-    patch_method(QDialog, "setWindowTitle", [0])
-    patch_method(QGroupBox, "setTitle", [0])
-    patch_method(QMenu, "setTitle", [0])
-    patch_method(QAction, "setToolTip", [0])
-    patch_method(QAction, "setStatusTip", [0])
-    patch_method(QStatusBar, "showMessage", [0])
-    patch_method(QSystemTrayIcon, "showMessage", [0, 1])
-    patch_method(QProgressBar, "setFormat", [0])
-    patch_method(QWizard, "setButtonText", [1])
-    patch_method(QWizardPage, "setTitle", [0])
-    patch_method(QWizardPage, "setSubTitle", [0])
-
-    for cls in (QLineEdit, QTextEdit, QPlainTextEdit):
-        patch_method(cls, "setPlaceholderText", [0])
-    patch_method(QTextEdit, "append", [0])
-    patch_method(QTextEdit, "setHtml", [0])
-    patch_method(QPlainTextEdit, "appendPlainText", [0])
-
-    patch_method(QComboBox, "setPlaceholderText", [0])
-    # Combo inserted items can be schema/database identifiers; preserve them exactly.
-    patch_method(QComboBox, "setItemText", [1])
-
-    patch_all_string_args_method(QTabWidget, "addTab")
-    patch_method(QTabWidget, "setTabText", [1])
-    patch_all_string_args_method(QFormLayout, "addRow")
-
-    original_tree_headers = QTreeWidget.setHeaderLabels
-    if not getattr(original_tree_headers, "_tf_i18n_wrapped", False):
-        def tree_headers(self, labels):
-            return original_tree_headers(self, _translate_sequence(list(labels)))
-
-        tree_headers._tf_i18n_wrapped = True
-        QTreeWidget.setHeaderLabels = tree_headers
-
-    original_table_headers = QTableWidget.setHorizontalHeaderLabels
-    if not getattr(original_table_headers, "_tf_i18n_wrapped", False):
-        def table_headers(self, labels):
-            return original_table_headers(self, _translate_sequence(list(labels)))
-
-        table_headers._tf_i18n_wrapped = True
-        QTableWidget.setHorizontalHeaderLabels = table_headers
-
-    original_vertical_table_headers = QTableWidget.setVerticalHeaderLabels
-    if not getattr(original_vertical_table_headers, "_tf_i18n_wrapped", False):
-        def vertical_table_headers(self, labels):
-            return original_vertical_table_headers(self, _translate_sequence(list(labels)))
-
-        vertical_table_headers._tf_i18n_wrapped = True
-        QTableWidget.setVerticalHeaderLabels = vertical_table_headers
-
-    original_tooltip_show_text = QToolTip.showText
-    if not getattr(original_tooltip_show_text, "_tf_i18n_wrapped", False):
-        def tooltip_show_text(*args, **kwargs):
-            args = list(args)
-            if len(args) > 1 and isinstance(args[1], str):
-                args[1] = translate_text(args[1])
-            return original_tooltip_show_text(*args, **kwargs)
-
-        tooltip_show_text._tf_i18n_wrapped = True
-        QToolTip.showText = tooltip_show_text
-
-    original_menu_add_action = QMenu.addAction
-    if not getattr(original_menu_add_action, "_tf_i18n_wrapped", False):
-        def menu_add_action(self, *args, **kwargs):
-            args = list(args)
-            if args and isinstance(args[0], str):
-                args[0] = translate_text(args[0])
-            elif len(args) > 1 and isinstance(args[1], str):
-                args[1] = translate_text(args[1])
-            return original_menu_add_action(self, *args, **kwargs)
-
-        menu_add_action._tf_i18n_wrapped = True
-        QMenu.addAction = menu_add_action
-
-    original_menu_add_menu = QMenu.addMenu
-    if not getattr(original_menu_add_menu, "_tf_i18n_wrapped", False):
-        def menu_add_menu(self, *args, **kwargs):
-            args = list(args)
-            if args and isinstance(args[0], str):
-                args[0] = translate_text(args[0])
-            elif len(args) > 1 and isinstance(args[1], str):
-                args[1] = translate_text(args[1])
-            return original_menu_add_menu(self, *args, **kwargs)
-
-        menu_add_menu._tf_i18n_wrapped = True
-        QMenu.addMenu = menu_add_menu
-
-    for name in ("information", "warning", "critical", "question"):
-        original = getattr(QMessageBox, name)
-        if getattr(original, "_tf_i18n_wrapped", False):
-            continue
-
-        def make_message_wrapper(fn):
-            def wrapped(*args, **kwargs):
-                args = list(args)
-                for index in (1, 2):
-                    if len(args) > index and isinstance(args[index], str):
-                        args[index] = translate_text(args[index])
-                if isinstance(kwargs.get("title"), str):
-                    kwargs["title"] = translate_text(kwargs["title"])
-                if isinstance(kwargs.get("text"), str):
-                    kwargs["text"] = translate_text(kwargs["text"])
-                return fn(*args, **kwargs)
-
-            wrapped._tf_i18n_wrapped = True
-            return wrapped
-
-        setattr(QMessageBox, name, make_message_wrapper(original))
-
-    patch_method(QMessageBox, "setText", [0])
-    patch_method(QMessageBox, "setInformativeText", [0])
-    patch_method(QMessageBox, "setDetailedText", [0])
-
-    for name in ("getOpenFileName", "getSaveFileName", "getExistingDirectory"):
-        original = getattr(QFileDialog, name)
-        if getattr(original, "_tf_i18n_wrapped", False):
-            continue
-
-        def make_file_dialog_wrapper(fn):
-            def wrapped(*args, **kwargs):
-                args = list(args)
-                for index in (1, 3):
-                    if len(args) > index and isinstance(args[index], str):
-                        args[index] = translate_text(args[index])
-                if isinstance(kwargs.get("caption"), str):
-                    kwargs["caption"] = translate_text(kwargs["caption"])
-                if isinstance(kwargs.get("filter"), str):
-                    kwargs["filter"] = translate_text(kwargs["filter"])
-                return fn(*args, **kwargs)
-
-            wrapped._tf_i18n_wrapped = True
-            return wrapped
-
-        setattr(QFileDialog, name, make_file_dialog_wrapper(original))
-
-    _qt_i18n_installed = True
-    return True

--- a/src/core/i18n/qt_hooks.py
+++ b/src/core/i18n/qt_hooks.py
@@ -1,0 +1,227 @@
+"""PyQt widget-text patching for legacy hardcoded UI strings.
+
+Installs one-time monkey-patches over common PyQt6 widget constructors and
+text setters so Korean literals still embedded in the UI are auto-translated
+through :func:`src.core.i18n.legacy_translate.translate_text` at render time.
+Identity-like values (for example combo-box schema/database entries) are
+deliberately left untranslated.
+"""
+from src.core.i18n.legacy_translate import _translate_sequence, translate_text
+
+_qt_i18n_installed = False
+
+
+def _wrap_callable(container, name, transform):
+    """Wrap ``container.name`` so string arguments are translated first.
+
+    ``transform`` receives ``(args, kwargs)`` -- ``args`` is a mutable list and
+    ``kwargs`` the original dict -- and returns the ``(args, kwargs)`` forwarded
+    to the original callable. The wrapper is idempotent via the
+    ``_tf_i18n_wrapped`` guard, so repeated installs are safe.
+    """
+    original = getattr(container, name, None)
+    if original is None or getattr(original, "_tf_i18n_wrapped", False):
+        return
+
+    def wrapped(*args, **kwargs):
+        new_args, new_kwargs = transform(list(args), kwargs)
+        return original(*new_args, **new_kwargs)
+
+    wrapped._tf_i18n_wrapped = True
+    setattr(container, name, wrapped)
+
+
+def _translate_header_labels(args, kwargs):
+    # Instance method (setHeaderLabels / setHorizontal/VerticalHeaderLabels):
+    # args[0] is self, args[1] the label sequence.
+    args[1] = _translate_sequence(list(args[1]))
+    return args, kwargs
+
+
+def _translate_tooltip_text(args, kwargs):
+    # Static QToolTip.showText(pos, text, ...): translate the text arg only.
+    if len(args) > 1 and isinstance(args[1], str):
+        args[1] = translate_text(args[1])
+    return args, kwargs
+
+
+def _translate_menu_label(args, kwargs):
+    # Instance QMenu.addAction / addMenu: args[0] is self; the label is the
+    # first str after self, or the second when the first arg is an icon.
+    if len(args) > 1 and isinstance(args[1], str):
+        args[1] = translate_text(args[1])
+    elif len(args) > 2 and isinstance(args[2], str):
+        args[2] = translate_text(args[2])
+    return args, kwargs
+
+
+def _translate_messagebox_static(args, kwargs):
+    # Static QMessageBox.information/warning/critical/question: title/text.
+    for index in (1, 2):
+        if len(args) > index and isinstance(args[index], str):
+            args[index] = translate_text(args[index])
+    if isinstance(kwargs.get("title"), str):
+        kwargs["title"] = translate_text(kwargs["title"])
+    if isinstance(kwargs.get("text"), str):
+        kwargs["text"] = translate_text(kwargs["text"])
+    return args, kwargs
+
+
+def _translate_filedialog_static(args, kwargs):
+    # Static QFileDialog.get*: caption (index 1) and filter (index 3).
+    for index in (1, 3):
+        if len(args) > index and isinstance(args[index], str):
+            args[index] = translate_text(args[index])
+    if isinstance(kwargs.get("caption"), str):
+        kwargs["caption"] = translate_text(kwargs["caption"])
+    if isinstance(kwargs.get("filter"), str):
+        kwargs["filter"] = translate_text(kwargs["filter"])
+    return args, kwargs
+
+
+def install_qt_i18n() -> bool:
+    """Install broad PyQt text translation hooks for legacy hardcoded UI strings."""
+    global _qt_i18n_installed
+    if _qt_i18n_installed:
+        return False
+
+    try:
+        from PyQt6.QtGui import QAction
+        from PyQt6.QtWidgets import (
+            QAbstractButton,
+            QCheckBox,
+            QComboBox,
+            QDialog,
+            QFileDialog,
+            QFormLayout,
+            QGroupBox,
+            QLabel,
+            QLineEdit,
+            QMenu,
+            QMessageBox,
+            QPlainTextEdit,
+            QProgressBar,
+            QPushButton,
+            QRadioButton,
+            QStatusBar,
+            QSystemTrayIcon,
+            QTabWidget,
+            QTableWidget,
+            QTextEdit,
+            QToolTip,
+            QTreeWidget,
+            QWidget,
+            QWizard,
+            QWizardPage,
+        )
+    except Exception:
+        return False
+
+    def translate_qt_arg(value):
+        if isinstance(value, str):
+            return translate_text(value)
+        if isinstance(value, list):
+            return [translate_qt_arg(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(translate_qt_arg(item) for item in value)
+        return value
+
+    def patch_init(cls, text_index=0):
+        original = cls.__init__
+        if getattr(original, "_tf_i18n_wrapped", False):
+            return
+
+        def wrapped(self, *args, **kwargs):
+            args = list(args)
+            if text_index is None:
+                args = [translate_qt_arg(arg) for arg in args]
+            elif len(args) > text_index:
+                args[text_index] = translate_qt_arg(args[text_index])
+            original(self, *args, **kwargs)
+
+        wrapped._tf_i18n_wrapped = True
+        cls.__init__ = wrapped
+
+    def patch_method(cls, name, text_indexes):
+        original = getattr(cls, name, None)
+        if original is None or getattr(original, "_tf_i18n_wrapped", False):
+            return
+
+        def wrapped(self, *args, **kwargs):
+            args = list(args)
+            for index in text_indexes:
+                if len(args) > index:
+                    args[index] = translate_qt_arg(args[index])
+            return original(self, *args, **kwargs)
+
+        wrapped._tf_i18n_wrapped = True
+        setattr(cls, name, wrapped)
+
+    def patch_all_string_args_method(cls, name):
+        original = getattr(cls, name, None)
+        if original is None or getattr(original, "_tf_i18n_wrapped", False):
+            return
+
+        def wrapped(self, *args, **kwargs):
+            args = [translate_qt_arg(arg) for arg in args]
+            return original(self, *args, **kwargs)
+
+        wrapped._tf_i18n_wrapped = True
+        setattr(cls, name, wrapped)
+
+    for cls in (QLabel, QAbstractButton, QPushButton, QCheckBox, QRadioButton, QGroupBox, QAction, QMenu):
+        patch_init(cls, None)
+        patch_method(cls, "setText", [0])
+
+    patch_init(QMessageBox, None)
+    patch_method(QWidget, "setWindowTitle", [0])
+    patch_method(QWidget, "setToolTip", [0])
+    patch_method(QWidget, "setStatusTip", [0])
+    patch_method(QWidget, "setWhatsThis", [0])
+    patch_method(QDialog, "setWindowTitle", [0])
+    patch_method(QGroupBox, "setTitle", [0])
+    patch_method(QMenu, "setTitle", [0])
+    patch_method(QAction, "setToolTip", [0])
+    patch_method(QAction, "setStatusTip", [0])
+    patch_method(QStatusBar, "showMessage", [0])
+    patch_method(QSystemTrayIcon, "showMessage", [0, 1])
+    patch_method(QProgressBar, "setFormat", [0])
+    patch_method(QWizard, "setButtonText", [1])
+    patch_method(QWizardPage, "setTitle", [0])
+    patch_method(QWizardPage, "setSubTitle", [0])
+
+    for cls in (QLineEdit, QTextEdit, QPlainTextEdit):
+        patch_method(cls, "setPlaceholderText", [0])
+    patch_method(QTextEdit, "append", [0])
+    patch_method(QTextEdit, "setHtml", [0])
+    patch_method(QPlainTextEdit, "appendPlainText", [0])
+
+    patch_method(QComboBox, "setPlaceholderText", [0])
+    # Combo inserted items can be schema/database identifiers; preserve them exactly.
+    patch_method(QComboBox, "setItemText", [1])
+
+    patch_all_string_args_method(QTabWidget, "addTab")
+    patch_method(QTabWidget, "setTabText", [1])
+    patch_all_string_args_method(QFormLayout, "addRow")
+
+    _wrap_callable(QTreeWidget, "setHeaderLabels", _translate_header_labels)
+    _wrap_callable(QTableWidget, "setHorizontalHeaderLabels", _translate_header_labels)
+    _wrap_callable(QTableWidget, "setVerticalHeaderLabels", _translate_header_labels)
+
+    _wrap_callable(QToolTip, "showText", _translate_tooltip_text)
+
+    _wrap_callable(QMenu, "addAction", _translate_menu_label)
+    _wrap_callable(QMenu, "addMenu", _translate_menu_label)
+
+    for name in ("information", "warning", "critical", "question"):
+        _wrap_callable(QMessageBox, name, _translate_messagebox_static)
+
+    patch_method(QMessageBox, "setText", [0])
+    patch_method(QMessageBox, "setInformativeText", [0])
+    patch_method(QMessageBox, "setDetailedText", [0])
+
+    for name in ("getOpenFileName", "getSaveFileName", "getExistingDirectory"):
+        _wrap_callable(QFileDialog, name, _translate_filedialog_static)
+
+    _qt_i18n_installed = True
+    return True

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from src.core import i18n
+from src.core.i18n import keys as i18n_keys
 
 
 @pytest.fixture(autouse=True)
@@ -47,8 +48,10 @@ def test_configure_language_prefers_cli_arg_and_persists():
 def test_configure_language_uses_installer_hint_before_system_locale(monkeypatch, tmp_path):
     hint_path = tmp_path / i18n.INSTALLER_LANGUAGE_HINT_FILE
     hint_path.write_text("en", encoding="utf-8")
-    monkeypatch.setattr(i18n, "installer_language_hint_path", lambda: hint_path)
-    monkeypatch.setattr(i18n, "detect_system_language", lambda: "ko")
+    # configure_language resolves these helpers inside the keys module namespace,
+    # so the package-level attribute must be patched on src.core.i18n.keys.
+    monkeypatch.setattr(i18n_keys, "installer_language_hint_path", lambda: hint_path)
+    monkeypatch.setattr(i18n_keys, "detect_system_language", lambda: "ko")
     config = FakeConfig()
 
     result = i18n.configure_language(config, ["TunnelForge"])
@@ -177,9 +180,10 @@ def test_qcombobox_inserted_identity_text_is_not_translated(monkeypatch):
 
 def test_en_phrase_translations_have_no_duplicate_source_keys():
     project_root = Path(__file__).resolve().parents[1]
-    source_path = project_root / "src" / "core" / "i18n.py"
+    source_path = project_root / "src" / "core" / "i18n" / "legacy_translate.py"
     tree = ast.parse(source_path.read_text(encoding="utf-8"))
 
+    found = False
     duplicates = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Assign):
@@ -187,6 +191,7 @@ def test_en_phrase_translations_have_no_duplicate_source_keys():
         if not any(isinstance(target, ast.Name) and target.id == "_EN_PHRASE_TRANSLATIONS" for target in node.targets):
             continue
 
+        found = True
         seen = {}
         for key_node in node.value.keys:
             if not isinstance(key_node, ast.Constant) or not isinstance(key_node.value, str):
@@ -197,6 +202,7 @@ def test_en_phrase_translations_have_no_duplicate_source_keys():
             else:
                 seen[key] = key_node.lineno
 
+    assert found, "_EN_PHRASE_TRANSLATIONS assignment not found in legacy_translate.py"
     assert duplicates == []
 
 


### PR DESCRIPTION
## 개요

Clean Code 리팩토링 Round 1 [WP-1.4]. `src/core/i18n.py`(1627줄) 단일 모듈을
3계층 패키지 `src/core/i18n/`로 분할한다. `__init__.py` 재수출 shim으로 기존
소비자 12개 import 사이트를 100% 호환 유지하며, **소비자 파일(main.py, src/ui/*)은
한 줄도 수정하지 않는다**.

## Findings covered

`CC-041`, `CC-042`, `CC-043`, `CC-044`, `CC-045`, `CC-046`

## 패키지 구조

| 모듈 | 역할 |
|------|------|
| `keys.py` | 구조화된 `tr()` 카탈로그 + 활성 언어 상태(`_current_language` 단독 소유) + 언어 선택(CLI/installer hint/설정/OS locale) |
| `legacy_translate.py` | 하드코딩 한글 자동 번역(exact/regex/phrase/word 4개 테이블 + 조사 제거 파이프라인) |
| `qt_hooks.py` | PyQt 위젯 텍스트 monkey-patch(`_qt_i18n_installed` 플래그 이동) |
| `__init__.py` | 소비자가 쓰는 이름 16개 순수 재수출 shim |

## 동작 보존 리팩토링

- **CC-041**: 모듈 → 패키지 전환. 원본 파일 삭제(패키지가 모듈을 가리는 문제 방지).
  상태 소유권: `_current_language`는 `keys.py` 단독 소유, 타 모듈은 `current_language()`/
  `set_language()` 함수 경유(전역 from-import 금지 → 언어 전환 즉시 반영).
- **CC-044**: `translate_text()`를 `_apply_regex_pairs` / `_apply_phrase_substitutions` /
  `_apply_word_substitutions` / `_strip_korean_particles` 명명 파이프라인으로 분해.
  공개 시그니처·출력 완전 동일.
- **CC-045**: 매 호출 재정렬 제거. 구/단어 테이블 정렬을 모듈 로드 시 1회
  `_SORTED_PHRASE_TRANSLATIONS` / `_SORTED_WORD_TRANSLATIONS`로 프리컴퓨트.
  안정 정렬로 동일 길이 키의 tie-order(삽입순) 유지 → 결과 문자열 byte 동일.
- **CC-043**: 8개 인라인 monkey-patch 블록의 공통 스캐폴딩(원본 저장 → 가드 →
  플래그 → setattr)을 `_wrap_callable(container, name, transform)` 제네릭 헬퍼로 통합.
  사이트별 인자 semantics(QToolTip=args[1], QMenu=args[0|1], QMessageBox=args[1,2]+kwargs,
  QFileDialog=args[1,3]+kwargs, 헤더라벨=`_translate_sequence`)는 정확히 보존.
- **CC-046/CC-042**: Hangul Syllables 블록 경계(가~힣)를 `_HANGUL_SYLLABLES_START`/
  `_HANGUL_SYLLABLES_END` 상수로 통합, `_has_hangul` 비교식·워드 경계 정규식 모두
  이 상수로부터 구성. docstring도 서브모듈별로 정확히 재작성.

## 테스트 동기화 (tests/test_i18n.py)

- `test_en_phrase_translations_have_no_duplicate_source_keys`: AST 파싱 경로를
  `src/core/i18n/legacy_translate.py`로 변경 + `found` 플래그로 무음 통과 방지.
- `test_configure_language_uses_installer_hint_before_system_locale`: monkeypatch 대상을
  `src.core.i18n.keys` 모듈로 정정(패키지 attr 패치는 keys 내부 참조에 미적용되는 함정).

## 검증 결과

- `py_compile`: 패키지 4파일 + 테스트 통과.
- `pytest tests/test_i18n.py`: **9/9 통과** (particle stripping, qt_hooks 리팩토링,
  QComboBox 정체성 보존, monkeypatch 정정 포함).
- 전체 `pytest -q`: **1809 passed, 1 failed** — 실패 1건은 기존 GitHub CI 의존 flaky
  macOS validation 테스트로 회귀 판정에서 제외.
- 스모크: 소비자 이름 16개 재수출 + 상태 소유권 + 실시간 언어 전환 검증 통과.
- verbatim 영역(4개 테이블, keys 본문, 조사 정규식)은 원본에서 byte 단위로 추출해
  `diff` byte-identical 확인.

## 위험 영역

- import fan-out 10파일/12사이트가 재수출 shim으로 흡수됨 — 재수출 이름 누락 시 앱 기동
  실패 위험이 있어 grep + 런타임 스모크로 교차검증 완료.
- `_wrap_callable` 통합 시 self 포함 여부(instance vs static)에 따른 인자 인덱스 비대칭이
  핵심 — 원본 인덱스 기대치를 그대로 보존해 QComboBox 식별자 보존 등 의도된 동작 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
