### PR TITLE
refactor(cross-engine-migration): render_result_report 렌더링 로직 분해 및 상수화

### DIFF
--- a/src/core/cross_engine_migration.py
+++ b/src/core/cross_engine_migration.py
@@ -1,7 +1,14 @@
-"""Cross-engine migration protocol models.
+"""Cross-engine migration protocol support for the tunnelforge-core helper.
 
-The PyQt UI talks to the Rust helper through newline-delimited JSON.  This
-module keeps that wire format isolated from widgets and worker orchestration.
+The PyQt UI talks to the Rust helper through newline-delimited JSON, and this
+module keeps four responsibilities isolated from widgets and worker
+orchestration:
+
+1. JSONL wire-format models, parsing, and request building for the
+   tunnelforge-core helper protocol.
+2. Locating the tunnelforge-core executable across dev/frozen/PATH layouts.
+3. Persisting and loading resume-state to/from disk between migration runs.
+4. Rendering human-readable text reports from migration result payloads.
 """
 import json
 import os
@@ -73,6 +80,8 @@ class HelperProtocolError(ValueError):
 
 
 FULL_MIGRATION_WORKFLOW = ("inspect", "preflight", "plan", "migrate", "verify")
+
+MAX_MISMATCHES_DISPLAYED = 50
 
 
 def next_workflow_command(completed_command: str, success: bool) -> Optional[str]:
@@ -266,6 +275,130 @@ def schema_from_inspect_result(payload: Dict[str, Any]) -> Optional[Dict[str, An
     return None
 
 
+def _render_issues(issues: Any) -> List[str]:
+    """Render the top-level payload issue list section."""
+    if not isinstance(issues, list):
+        return []
+    lines = ["", f"Issues: {len(issues)}"]
+    for issue in issues:
+        if isinstance(issue, dict):
+            lines.append(
+                f"- [{issue.get('severity', 'info')}] "
+                f"{issue.get('location', '')}: {issue.get('message', '')}"
+            )
+    return lines
+
+
+def _render_mismatches(mismatches: Any) -> List[str]:
+    """Render the verify-result mismatch list section."""
+    if not isinstance(mismatches, list):
+        return []
+    lines = ["", f"Mismatches: {len(mismatches)}"]
+    for mismatch in mismatches[:MAX_MISMATCHES_DISPLAYED]:
+        if isinstance(mismatch, dict):
+            table = mismatch.get("table", "")
+            kind = mismatch.get("kind", "")
+            detail = mismatch.get("column") or mismatch.get("digest") or mismatch.get("message") or ""
+            lines.append(f"- {table} {kind} {detail}".strip())
+    if len(mismatches) > MAX_MISMATCHES_DISPLAYED:
+        lines.append(f"... {len(mismatches) - MAX_MISMATCHES_DISPLAYED} more")
+    return lines
+
+
+def _render_plan(plan: Any) -> List[str]:
+    """Render the plan DDL section."""
+    if not isinstance(plan, dict):
+        return []
+    ddl = plan.get("ddl")
+    if not isinstance(ddl, list):
+        return []
+    lines = ["", "DDL:"]
+    lines.extend(str(item) for item in ddl)
+    return lines
+
+
+def _render_table_guide(table: Any) -> List[str]:
+    """Render one table's columns, row samples, and insert example."""
+    if not isinstance(table, dict):
+        return []
+    lines = [f"  Table {table.get('table', '')}: rows={table.get('row_count', 0)}"]
+
+    columns = table.get("columns")
+    if isinstance(columns, list):
+        for column in columns:
+            if not isinstance(column, dict):
+                continue
+            lines.append(
+                "    Column "
+                f"{column.get('name', '')}: "
+                f"{column.get('source_type', '')} -> "
+                f"{column.get('target_type', '')}"
+            )
+
+    rows = table.get("row_samples")
+    if isinstance(rows, list):
+        for index, row in enumerate(rows, start=1):
+            lines.append(
+                f"    Row sample {index}: "
+                f"{json.dumps(row, ensure_ascii=False, sort_keys=True)}"
+            )
+
+    insert_sql = table.get("insert_example_sql")
+    if insert_sql:
+        lines.append(f"    Insert example: {insert_sql}")
+
+    return lines
+
+
+def _render_direction_guide(guide: Dict[str, Any]) -> List[str]:
+    """Render a direction's create-table SQL, follow-up SQL, and table guides."""
+    lines: List[str] = []
+
+    create_sql = guide.get("create_table_sql")
+    if isinstance(create_sql, list) and create_sql:
+        lines.append("  Create table SQL:")
+        lines.extend(f"  {item}" for item in create_sql)
+
+    sequence_sql = guide.get("sequence_reset_sql")
+    post_data_sql = guide.get("post_data_sql")
+    followup_sql = []
+    if isinstance(sequence_sql, list):
+        followup_sql.extend(sequence_sql)
+    if isinstance(post_data_sql, list):
+        followup_sql.extend(post_data_sql)
+    if followup_sql:
+        lines.append("  Follow-up SQL:")
+        lines.extend(f"  {item}" for item in followup_sql)
+
+    tables = guide.get("tables")
+    if isinstance(tables, list):
+        for table in tables:
+            lines.extend(_render_table_guide(table))
+
+    return lines
+
+
+def _render_directions(directions: Any) -> List[str]:
+    """Render the direction readiness section."""
+    if not isinstance(directions, list):
+        return []
+    lines = ["", "Direction Readiness:"]
+    for direction in directions:
+        if not isinstance(direction, dict):
+            continue
+        status = "ready" if direction.get("success") else "blocked"
+        direction_issues = direction.get("issues")
+        issue_count = len(direction_issues) if isinstance(direction_issues, list) else 0
+        lines.append(
+            f"- {direction.get('direction', '')}: {status} "
+            f"tables={direction.get('table_count', 0)} issues={issue_count}"
+        )
+        guide = direction.get("guide")
+        if isinstance(guide, dict):
+            lines.extend(_render_direction_guide(guide))
+    return lines
+
+
 def render_result_report(payload: Dict[str, Any]) -> str:
     """Render a concise human-readable migration helper result."""
     command = payload.get("command", "unknown")
@@ -282,94 +415,9 @@ def render_result_report(payload: Dict[str, Any]) -> str:
     if "chunks_copied" in payload:
         lines.append(f"Chunks copied: {payload.get('chunks_copied')}")
 
-    issues = payload.get("issues")
-    if isinstance(issues, list):
-        lines.append("")
-        lines.append(f"Issues: {len(issues)}")
-        for issue in issues:
-            if isinstance(issue, dict):
-                lines.append(
-                    f"- [{issue.get('severity', 'info')}] "
-                    f"{issue.get('location', '')}: {issue.get('message', '')}"
-                )
-
-    mismatches = payload.get("mismatches")
-    if isinstance(mismatches, list):
-        lines.append("")
-        lines.append(f"Mismatches: {len(mismatches)}")
-        for mismatch in mismatches[:50]:
-            if isinstance(mismatch, dict):
-                table = mismatch.get("table", "")
-                kind = mismatch.get("kind", "")
-                detail = mismatch.get("column") or mismatch.get("digest") or mismatch.get("message") or ""
-                lines.append(f"- {table} {kind} {detail}".strip())
-        if len(mismatches) > 50:
-            lines.append(f"... {len(mismatches) - 50} more")
-
-    plan = payload.get("plan")
-    if isinstance(plan, dict):
-        ddl = plan.get("ddl")
-        if isinstance(ddl, list):
-            lines.append("")
-            lines.append("DDL:")
-            lines.extend(str(item) for item in ddl)
-
-    directions = payload.get("directions")
-    if isinstance(directions, list):
-        lines.append("")
-        lines.append("Direction Readiness:")
-        for direction in directions:
-            if isinstance(direction, dict):
-                status = "ready" if direction.get("success") else "blocked"
-                issues = direction.get("issues")
-                issue_count = len(issues) if isinstance(issues, list) else 0
-                lines.append(
-                    f"- {direction.get('direction', '')}: {status} "
-                    f"tables={direction.get('table_count', 0)} issues={issue_count}"
-                )
-                guide = direction.get("guide")
-                if isinstance(guide, dict):
-                    create_sql = guide.get("create_table_sql")
-                    if isinstance(create_sql, list) and create_sql:
-                        lines.append("  Create table SQL:")
-                        lines.extend(f"  {item}" for item in create_sql)
-                    sequence_sql = guide.get("sequence_reset_sql")
-                    post_data_sql = guide.get("post_data_sql")
-                    followup_sql = []
-                    if isinstance(sequence_sql, list):
-                        followup_sql.extend(sequence_sql)
-                    if isinstance(post_data_sql, list):
-                        followup_sql.extend(post_data_sql)
-                    if followup_sql:
-                        lines.append("  Follow-up SQL:")
-                        lines.extend(f"  {item}" for item in followup_sql)
-                    tables = guide.get("tables")
-                    if isinstance(tables, list):
-                        for table in tables:
-                            if not isinstance(table, dict):
-                                continue
-                            lines.append(
-                                f"  Table {table.get('table', '')}: rows={table.get('row_count', 0)}"
-                            )
-                            columns = table.get("columns")
-                            if isinstance(columns, list):
-                                for column in columns:
-                                    if isinstance(column, dict):
-                                        lines.append(
-                                            "    Column "
-                                            f"{column.get('name', '')}: "
-                                            f"{column.get('source_type', '')} -> "
-                                            f"{column.get('target_type', '')}"
-                                        )
-                            rows = table.get("row_samples")
-                            if isinstance(rows, list):
-                                for index, row in enumerate(rows, start=1):
-                                    lines.append(
-                                        f"    Row sample {index}: "
-                                        f"{json.dumps(row, ensure_ascii=False, sort_keys=True)}"
-                                    )
-                            insert_sql = table.get("insert_example_sql")
-                            if insert_sql:
-                                lines.append(f"    Insert example: {insert_sql}")
+    lines.extend(_render_issues(payload.get("issues")))
+    lines.extend(_render_mismatches(payload.get("mismatches")))
+    lines.extend(_render_plan(payload.get("plan")))
+    lines.extend(_render_directions(payload.get("directions")))
 
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## 요약 (WP-2.7)

- **CC-076**: `render_result_report(payload)`의 issues/mismatches/plan/directions 5개 인라인 섹션을 파일 내부 private 헬퍼(`_render_issues`, `_render_mismatches`, `_render_plan`, `_render_directions`)로 분해. 각 헬퍼는 `List[str]`을 반환하고 `render_result_report`는 `lines.extend(...)`로 이어붙인다. **public 시그니처 `render_result_report(payload: Dict[str, Any]) -> str`는 변경 없음** (dialog `cross_engine_migration_dialog.py:1189`, worker, 테스트 import 경로 보존).
- **CC-076**: 가장 깊었던 directions/guide/table 9단 중첩을 3계층으로 분리: `_render_directions`(readiness 루프) → `_render_direction_guide`(create_table_sql/follow-up SQL/tables 루프) → `_render_table_guide`(columns/row_samples/insert_example_sql). 각 헬퍼는 guard clause(`if not isinstance(x, dict): return []` / 루프 내 `continue`)로 중첩을 2-3단으로 낮춤. 기존 isinstance 분기 결과와 동일하게 유지.
- **CC-078**: `_render_directions` 내부에서 `direction.get("issues")`를 `direction_issues`로 리네임하여 상위 payload의 `issues`와의 변수 shadowing을 헬퍼 스코프 분리로 구조적으로 제거.
- **CC-079**: 리터럴 `50`을 모듈 상단 상수 `MAX_MISMATCHES_DISPLAYED = 50`으로 단일화하고 `_render_mismatches`의 슬라이싱(`mismatches[:MAX_MISMATCHES_DISPLAYED]`)과 `"... N more"` 조건 두 곳 모두 상수 참조로 교체.
- **CC-077**: 모듈 docstring을 이 파일이 실제로 소유하는 4개 책임(1. JSONL wire-format 모델/파싱/빌드, 2. tunnelforge-core 실행파일 탐색, 3. resume-state 디스크 영속화, 4. 텍스트 결과 리포트 렌더링)에 맞게 재작성. **물리적 파일 분리는 하지 않음** (internal-only docstring 변경) — 스펙의 HARD CONSTRAINT 및 risks에 따라 `cross_engine_executable.py`/`cross_engine_state.py` 신규 생성이나 `render_result_report`를 `migration_report_renderer.py`로 이동하는 물리적 split은 이번 WP 범위에서 제외했다. 이유: 최소 5개 소비처(`db_core_client.py`, `cross_engine_migration_dialog.py`, `cross_engine_migration_worker.py`, `main.py`, 테스트)가 직접 import하며, 물리 분리는 re-export를 강제하고 round-3 UI WP와 파일 충돌 위험을 키운다.

## 스펙 노후화 참고
- `_WP_SPEC.md`는 Round 1 머지 이전 기준이라 라인번호가 대부분 무효했음. 심볼명(`render_result_report`, `FULL_MIGRATION_WORKFLOW` 등) 기준으로 현재 코드 위치를 재확인 후 작업. Round 1에서 이미 해결된 finding은 없었음(이 파일은 Round 1에서 손대지 않음).
- 소비처 확인 결과 스펙 기재와 일치: `db_core_service.py` → Round 1에서 `db_core_client.py`로 분리되었지만 여전히 `db_core_executable`/`parse_helper_event`를 동일 경로에서 import(이번 WP 대상 아님).

## 변경 파일
- `src/core/cross_engine_migration.py` (스코프 잠금 준수, 다른 파일 미수정)

## 검증
- [x] `python -m py_compile src/core/cross_engine_migration.py` — 통과
- [x] `python -m pytest tests/test_cross_engine_migration_protocol.py -q` — 18 passed
- [x] `python -m pytest -q` (전체) — 1836 passed, 1 failed
  - 실패 1건은 `test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`로, GitHub Actions API에 의존하는 로컬 환경 flaky 테스트(기존에도 로컬에서 항상 실패, 이번 변경과 무관)

## 리스크
- `render_result_report`는 substring 기반 테스트 3개로만 검증됨. 헬퍼 추출 시 append 순서/blank line/들여쓰기/`json.dumps(row, ensure_ascii=False, sort_keys=True)` 포맷을 원본과 정확히 동일하게 재현했음 — 라인 단위로 원본과 대조 완료.
- 소비처(`cross_engine_migration_dialog.py`, `cross_engine_migration_worker.py`)는 round-3 UI WP 대상이지만 이번 WP는 public 이름/시그니처/import 경로를 모두 보존하여 파일 충돌 없음.
- `migration_report_renderer.py`(별개 `MigrationReport` dataclass용 HTML/JSON 익스포터)와 통합하지 않음 — 도메인이 다름.

🤖 Generated with [Claude Code](https://claude.com/claude-code)