### PR TITLE
refactor(rust-dump-exporter): god-file 3분할 - ForeignKeyResolver/dump_progress 분리 (CC-099~104)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ main.py (Entry Point)
 
 - **DbCoreFacade** (`src/core/db_core_service.py`): Long-lived JSONL client for `tunnelforge-core`. DB credentials, schema calls, SQL execution, dump/import, and migration commands go through this facade.
 
-- **RustDumpExporter** (`src/exporters/rust_dump_exporter.py`): Export/import wrapper over Rust `dump.run` and `dump.import`. Partial exports auto-include FK parent tables via `RustDumpExporter._resolve_required_tables_from_rust_schema` (Rust-schema driven). `ForeignKeyResolver` in the same module is used for orphan-record dependency analysis, not for export table selection.
+- **RustDumpExporter** (`src/exporters/rust_dump_exporter.py`): Export/import wrapper over Rust `dump.run` and `dump.import`. Partial exports auto-include FK parent tables via `RustDumpExporter._resolve_required_tables_from_rust_schema` (Rust-schema driven). `ForeignKeyResolver` now lives in `src/core/foreign_key_resolver.py` and is used for orphan-record dependency analysis, not for export table selection; `rust_dump_exporter` re-exports it (along with `OrphanRecordInfo`) for backward compatibility.
 
 - **UI Threading**: Long operations run in `QThread` workers such as `src/ui/workers/rust_dump_worker.py` and `src/ui/workers/cross_engine_migration_worker.py` to keep UI responsive.
 

--- a/src/core/foreign_key_resolver.py
+++ b/src/core/foreign_key_resolver.py
@@ -1,0 +1,201 @@
+"""Foreign-key dependency analysis and orphan-record detection for MySQL schemas."""
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Dict, List, Optional, Set, Tuple
+
+from src.core.db_connector import MySQLConnector
+
+
+@dataclass
+class OrphanRecordInfo:
+    """Foreign-key orphan record summary."""
+
+    table: str
+    column: str
+    referenced_table: str
+    referenced_column: str
+    orphan_count: int
+    sample_values: List[str]
+    query: str
+
+
+class ForeignKeyResolver:
+    """Foreign-key dependency analysis used before partial table dumps."""
+
+    def __init__(self, connector: MySQLConnector):
+        self.connector = connector
+
+    def get_all_dependencies(self, schema: str) -> Dict[str, Set[str]]:
+        query = """
+        SELECT TABLE_NAME, REFERENCED_TABLE_NAME
+        FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+        WHERE TABLE_SCHEMA = %s
+          AND REFERENCED_TABLE_NAME IS NOT NULL
+        """
+        deps: Dict[str, Set[str]] = {}
+        for row in self.connector.execute(query, (schema,)):
+            table = row["TABLE_NAME"]
+            ref_table = row["REFERENCED_TABLE_NAME"]
+            if table != ref_table:
+                deps.setdefault(table, set()).add(ref_table)
+        return deps
+
+    def get_fk_details(self, schema: str) -> List[Dict]:
+        query = """
+        SELECT
+            TABLE_NAME,
+            COLUMN_NAME,
+            REFERENCED_TABLE_NAME,
+            REFERENCED_COLUMN_NAME,
+            CONSTRAINT_NAME
+        FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+        WHERE TABLE_SCHEMA = %s
+          AND REFERENCED_TABLE_NAME IS NOT NULL
+        ORDER BY TABLE_NAME, COLUMN_NAME
+        """
+        rows = self.connector.execute(query, (schema,))
+        return [
+            {
+                "table": row["TABLE_NAME"],
+                "column": row["COLUMN_NAME"],
+                "referenced_table": row["REFERENCED_TABLE_NAME"],
+                "referenced_column": row["REFERENCED_COLUMN_NAME"],
+                "constraint_name": row["CONSTRAINT_NAME"],
+            }
+            for row in rows
+        ]
+
+    def _orphan_join_where(
+        self,
+        schema: str,
+        table: str,
+        column: str,
+        ref_table: str,
+        ref_column: str,
+    ) -> str:
+        """Shared FROM/LEFT JOIN/WHERE fragment for orphan-record queries."""
+        return (
+            f"FROM `{schema}`.`{table}` c "
+            f"LEFT JOIN `{schema}`.`{ref_table}` p ON c.`{column}` = p.`{ref_column}` "
+            f"WHERE c.`{column}` IS NOT NULL AND p.`{ref_column}` IS NULL"
+        )
+
+    def generate_orphan_query(
+        self,
+        schema: str,
+        table: str,
+        column: str,
+        ref_table: str,
+        ref_column: str,
+    ) -> str:
+        join_where = self._orphan_join_where(schema, table, column, ref_table, ref_column)
+        return f"SELECT c.*\n{join_where}"
+
+    def find_orphan_records(
+        self,
+        schema: str,
+        tables: Optional[List[str]] = None,
+        sample_limit: int = 5,
+        progress_callback: Optional[Callable[[str], None]] = None,
+    ) -> List[OrphanRecordInfo]:
+        fk_details = self.get_fk_details(schema)
+        if tables:
+            table_set = set(tables)
+            fk_details = [fk for fk in fk_details if fk["table"] in table_set]
+
+        results = []
+        for index, fk in enumerate(fk_details, 1):
+            table = fk["table"]
+            column = fk["column"]
+            ref_table = fk["referenced_table"]
+            ref_column = fk["referenced_column"]
+
+            if progress_callback:
+                progress_callback(f"검사 중... ({index}/{len(fk_details)}) {table}.{column}")
+
+            join_where = self._orphan_join_where(schema, table, column, ref_table, ref_column)
+
+            count_query = f"SELECT COUNT(*) as cnt {join_where}"
+            count_result = self.connector.execute(count_query)
+            orphan_count = count_result[0]["cnt"] if count_result else 0
+            if orphan_count <= 0:
+                continue
+
+            sample_query = f"SELECT DISTINCT c.`{column}` as orphan_value {join_where} LIMIT {sample_limit}"
+            sample_values = [
+                str(row["orphan_value"])
+                for row in self.connector.execute(sample_query)
+            ]
+            results.append(
+                OrphanRecordInfo(
+                    table=table,
+                    column=column,
+                    referenced_table=ref_table,
+                    referenced_column=ref_column,
+                    orphan_count=orphan_count,
+                    sample_values=sample_values,
+                    query=self.generate_orphan_query(schema, table, column, ref_table, ref_column),
+                )
+            )
+        return results
+
+    def export_orphan_report(
+        self,
+        schema: str,
+        output_path: str,
+        tables: Optional[List[str]] = None,
+        progress_callback: Optional[Callable[[str], None]] = None,
+    ) -> Tuple[bool, str, int]:
+        try:
+            orphans = self.find_orphan_records(schema, tables, progress_callback=progress_callback)
+            with open(output_path, "w", encoding="utf-8") as file:
+                file.write("# 고아 레코드 분석 보고서\n")
+                file.write(f"# 스키마: {schema}\n")
+                file.write(f"# 생성일시: {datetime.now().isoformat()}\n")
+                file.write(f"# 발견된 고아 관계: {len(orphans)}건\n")
+                file.write("=" * 80 + "\n\n")
+                if not orphans:
+                    file.write("고아 레코드가 발견되지 않았습니다.\n")
+                else:
+                    total_orphans = sum(item.orphan_count for item in orphans)
+                    file.write(f"총 {total_orphans:,}개의 고아 레코드 발견\n\n")
+                    for index, item in enumerate(orphans, 1):
+                        file.write(
+                            f"## [{index}] {item.table}.{item.column} -> "
+                            f"{item.referenced_table}.{item.referenced_column}\n"
+                        )
+                        file.write(f"   고아 레코드 수: {item.orphan_count:,}건\n")
+                        file.write(f"   샘플 값: {', '.join(item.sample_values)}\n")
+                        file.write("\n   조회 쿼리:\n")
+                        file.write("   ```sql\n")
+                        for line in item.query.split("\n"):
+                            file.write(f"   {line}\n")
+                        file.write("   ```\n\n")
+                        file.write("-" * 80 + "\n\n")
+            return True, f"보고서 저장 완료: {output_path}", len(orphans)
+        except Exception as exc:
+            return False, f"보고서 저장 실패: {exc}", 0
+
+    def get_all_orphan_queries(self, schema: str, tables: Optional[List[str]] = None) -> str:
+        fk_details = self.get_fk_details(schema)
+        if tables:
+            table_set = set(tables)
+            fk_details = [fk for fk in fk_details if fk["table"] in table_set]
+
+        queries = [
+            f"-- 고아 레코드 조회 쿼리 (스키마: {schema})",
+            f"-- 생성일시: {datetime.now().isoformat()}",
+            f"-- FK 관계 수: {len(fk_details)}개",
+            "",
+        ]
+        for index, fk in enumerate(fk_details, 1):
+            table = fk["table"]
+            column = fk["column"]
+            ref_table = fk["referenced_table"]
+            ref_column = fk["referenced_column"]
+            queries.append(f"-- [{index}] {table}.{column} -> {ref_table}.{ref_column}")
+            join_where = self._orphan_join_where(schema, table, column, ref_table, ref_column)
+            queries.append(
+                f"SELECT '{table}.{column}' AS fk_relation, COUNT(*) AS orphan_count {join_where};\n"
+            )
+        return "\n".join(queries)

--- a/src/exporters/dump_progress.py
+++ b/src/exporters/dump_progress.py
@@ -1,0 +1,202 @@
+"""Rust DB Core dump/import progress tracking and event forwarding."""
+import json
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Set, Tuple
+
+
+def _format_import_phase_message(event: dict) -> Optional[str]:
+    strategy = str(event.get("strategy") or "")
+    performance = str(event.get("performance") or "")
+    message = str(event.get("message") or "")
+    if (
+        strategy in {"temporary_local_infile", "temporary_local_infile_restore", "insert_fallback"}
+        or performance == "fast_path"
+        or "local_infile" in message
+        or "LOAD DATA LOCAL" in message
+    ):
+        return None
+    return str(event.get("message") or event.get("phase") or "Rust DB Core 작업 중...")
+
+
+class TableProgressTracker:
+    """Table progress metadata helper for the import UI."""
+
+    def __init__(self, metadata: Optional[Dict]):
+        self.chunk_counts = metadata.get("chunk_counts", {}) if metadata else {}
+        self.table_sizes = metadata.get("table_sizes", {}) if metadata else {}
+        self.total_bytes = metadata.get("total_bytes", 0) if metadata else 0
+        self.completed_tables: Set[str] = set()
+
+    def estimate_loading_tables(
+        self,
+        loaded_bytes: int,
+        completed_tables: List[str],
+    ) -> List[Tuple[str, int, int]]:
+        self.completed_tables = set(completed_tables)
+        candidates = [
+            (table, self.table_sizes.get(table, 0), self.chunk_counts.get(table, 1))
+            for table in self.table_sizes
+            if table not in self.completed_tables and self.table_sizes.get(table, 0) > 10_000_000
+        ]
+        candidates.sort(key=lambda item: -item[1])
+        return candidates[:4]
+
+    def get_table_info(self, table_name: str) -> Tuple[int, int]:
+        return self.table_sizes.get(table_name, 0), self.chunk_counts.get(table_name, 1)
+
+    def format_size(self, size_bytes: int) -> str:
+        if size_bytes < 1024:
+            return f"{size_bytes} B"
+        if size_bytes < 1024 * 1024:
+            return f"{size_bytes / 1024:.1f} KB"
+        if size_bytes < 1024 * 1024 * 1024:
+            return f"{size_bytes / (1024 * 1024):.1f} MB"
+        return f"{size_bytes / (1024 * 1024 * 1024):.2f} GB"
+
+
+@dataclass
+class DumpEventCallbacks:
+    """Bundle of optional callbacks forwarded while a Rust dump/import runs."""
+
+    progress: Optional[Callable[[str], None]] = None
+    table_progress: Optional[Callable[[int, int, str], None]] = None
+    detail: Optional[Callable[[dict], None]] = None
+    table_status: Optional[Callable[[str, str, str], None]] = None
+    raw_output: Optional[Callable[[str], None]] = None
+    metadata: Optional[Callable[[dict], None]] = None
+    table_chunk_progress: Optional[Callable[[str, int, int], None]] = None
+
+
+def _handle_dump_plan_event(
+    event: Dict,
+    detail_callback: Optional[Callable[[dict], None]],
+) -> None:
+    if detail_callback:
+        detail_callback({
+            "event": "dump_plan",
+            "tables_total": int(event.get("tables_total") or 0),
+            "rows_total": int(event.get("rows_total") or 0),
+            "tables": event.get("tables") if isinstance(event.get("tables"), list) else [],
+        })
+
+
+def _handle_dump_schedule_event(
+    event: Dict,
+    detail_callback: Optional[Callable[[dict], None]],
+) -> None:
+    if detail_callback:
+        detail_callback({
+            "event": "dump_schedule",
+            "threads": int(event.get("threads") or 0),
+            "table_workers": int(event.get("table_workers") or 0),
+            "range_workers_per_table": int(event.get("range_workers_per_table") or 0),
+            "chunk_size": int(event.get("chunk_size") or 0),
+            "data_format": str(event.get("data_format") or ""),
+            "compression": str(event.get("compression") or ""),
+            "scheduled_tables": event.get("scheduled_tables") if isinstance(event.get("scheduled_tables"), list) else [],
+        })
+
+
+def _handle_phase_event(
+    event: Dict,
+    progress_callback: Optional[Callable[[str], None]],
+) -> None:
+    if not progress_callback:
+        return
+    message = _format_import_phase_message(event)
+    if message:
+        progress_callback(message)
+
+
+def _handle_table_progress_event(
+    event: Dict,
+    table: str,
+    table_progress_callback: Optional[Callable[[int, int, str], None]],
+    table_status_callback: Optional[Callable[[str, str, str], None]],
+    import_results: Optional[dict],
+) -> None:
+    current = int(event.get("current") or 0)
+    total = int(event.get("total") or 0)
+    status = str(event.get("status") or "")
+    ui_status = "loading" if status in ("dumping", "importing") else "done" if status == "completed" else status
+    if table_progress_callback and status == "completed":
+        table_progress_callback(current, total, table)
+    if table_status_callback and table:
+        table_status_callback(table, ui_status, "")
+    if import_results is not None and table:
+        import_results[table] = {"status": ui_status or "loading", "message": ""}
+
+
+def _handle_row_progress_event(
+    event: Dict,
+    table: str,
+    detail_callback: Optional[Callable[[dict], None]],
+    table_chunk_progress_callback: Optional[Callable[[str, int, int], None]],
+) -> None:
+    rows = int(event.get("table_rows_done") or event.get("rows") or 0)
+    total = int(event.get("table_rows_total") or event.get("total") or 0)
+    overall_rows = int(event.get("overall_rows_done") or 0)
+    overall_total = int(event.get("overall_rows_total") or 0)
+    chunk_rows = int(event.get("chunk_rows") or 0)
+    elapsed_ms = int(event.get("stream_ms") or event.get("read_ms") or event.get("load_ms") or 0)
+    rows_sec = int((chunk_rows * 1000) / elapsed_ms) if chunk_rows and elapsed_ms else 0
+    if overall_total:
+        percent = int((overall_rows / overall_total) * 100)
+    else:
+        percent = int((rows / total) * 100) if total else 0
+    if detail_callback:
+        detail_callback({
+            "event": "row_progress",
+            "table": table,
+            "percent": min(percent, 100),
+            "rows_done": rows,
+            "rows_total": total,
+            "overall_rows_done": overall_rows,
+            "overall_rows_total": overall_total,
+            "chunk_rows": chunk_rows,
+            "rows_sec": rows_sec,
+            "speed": f"{rows_sec:,} rows/s" if rows_sec else "Rust DB Core",
+            "chunk_index": event.get("chunk_index"),
+            "chunks_done": event.get("chunks_done"),
+            "chunks_total": event.get("chunks_total"),
+            "strategy": event.get("strategy"),
+            "stream_ms": event.get("stream_ms"),
+            "read_ms": event.get("read_ms"),
+            "write_ms": event.get("write_ms"),
+            "load_ms": event.get("load_ms"),
+        })
+    chunks_done = int(event.get("chunks_done") or 0)
+    chunks_total = int(event.get("chunks_total") or 0)
+    if table_chunk_progress_callback and table and chunks_done and chunks_total:
+        table_chunk_progress_callback(table, chunks_done, chunks_total)
+
+
+def emit_core_event(
+    event: Dict,
+    progress_callback: Optional[Callable[[str], None]] = None,
+    table_progress_callback: Optional[Callable[[int, int, str], None]] = None,
+    detail_callback: Optional[Callable[[dict], None]] = None,
+    table_status_callback: Optional[Callable[[str, str, str], None]] = None,
+    raw_output_callback: Optional[Callable[[str], None]] = None,
+    import_results: Optional[dict] = None,
+    table_chunk_progress_callback: Optional[Callable[[str, int, int], None]] = None,
+) -> None:
+    event_type = event.get("event")
+    table = str(event.get("table") or "")
+    if raw_output_callback:
+        raw_output_callback(json.dumps(event, ensure_ascii=False))
+
+    handlers = {
+        "dump_plan": lambda: _handle_dump_plan_event(event, detail_callback),
+        "dump_schedule": lambda: _handle_dump_schedule_event(event, detail_callback),
+        "phase": lambda: _handle_phase_event(event, progress_callback),
+        "table_progress": lambda: _handle_table_progress_event(
+            event, table, table_progress_callback, table_status_callback, import_results
+        ),
+        "row_progress": lambda: _handle_row_progress_event(
+            event, table, detail_callback, table_chunk_progress_callback
+        ),
+    }
+    handler = handlers.get(event_type)
+    if handler:
+        handler()

--- a/src/exporters/rust_dump_exporter.py
+++ b/src/exporters/rust_dump_exporter.py
@@ -13,11 +13,14 @@ from src.core.db_core_service import (
     DbEndpoint,
     normalize_db_engine,
 )
+from src.core.foreign_key_resolver import ForeignKeyResolver, OrphanRecordInfo
 from src.core.logger import get_logger
+from src.exporters.dump_progress import DumpEventCallbacks, TableProgressTracker, emit_core_event
 
 logger = get_logger("rust_dump_exporter")
 
 DEFAULT_DUMP_COMPRESSION = "zstd"
+DEFAULT_DUMP_THREADS = 8
 
 
 def _safe_dump_child_dir(dump_dir: str, table_path: str) -> Optional[Path]:
@@ -47,20 +50,6 @@ def _safe_dump_child_file(dump_dir: str, path: Path) -> Optional[Path]:
     except ValueError:
         return None
     return file_path if file_path.is_file() else None
-
-
-def _format_import_phase_message(event: dict) -> Optional[str]:
-    strategy = str(event.get("strategy") or "")
-    performance = str(event.get("performance") or "")
-    message = str(event.get("message") or "")
-    if (
-        strategy in {"temporary_local_infile", "temporary_local_infile_restore", "insert_fallback"}
-        or performance == "fast_path"
-        or "local_infile" in message
-        or "LOAD DATA LOCAL" in message
-    ):
-        return None
-    return str(event.get("message") or event.get("phase") or "Rust DB Core 작업 중...")
 
 
 def _shutdown_owned_facade(facade: DbCoreFacade, owns_facade: bool) -> None:
@@ -127,205 +116,8 @@ cargo build --manifest-path migration_core/Cargo.toml --release
 """
 
 
-@dataclass
-class OrphanRecordInfo:
-    """Foreign-key orphan record summary."""
-
-    table: str
-    column: str
-    referenced_table: str
-    referenced_column: str
-    orphan_count: int
-    sample_values: List[str]
-    query: str
-
-
-class ForeignKeyResolver:
-    """Foreign-key dependency analysis used before partial table dumps."""
-
-    def __init__(self, connector: MySQLConnector):
-        self.connector = connector
-
-    def get_all_dependencies(self, schema: str) -> Dict[str, Set[str]]:
-        query = """
-        SELECT TABLE_NAME, REFERENCED_TABLE_NAME
-        FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
-        WHERE TABLE_SCHEMA = %s
-          AND REFERENCED_TABLE_NAME IS NOT NULL
-        """
-        deps: Dict[str, Set[str]] = {}
-        for row in self.connector.execute(query, (schema,)):
-            table = row["TABLE_NAME"]
-            ref_table = row["REFERENCED_TABLE_NAME"]
-            if table != ref_table:
-                deps.setdefault(table, set()).add(ref_table)
-        return deps
-
-    def get_fk_details(self, schema: str) -> List[Dict]:
-        query = """
-        SELECT
-            TABLE_NAME,
-            COLUMN_NAME,
-            REFERENCED_TABLE_NAME,
-            REFERENCED_COLUMN_NAME,
-            CONSTRAINT_NAME
-        FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
-        WHERE TABLE_SCHEMA = %s
-          AND REFERENCED_TABLE_NAME IS NOT NULL
-        ORDER BY TABLE_NAME, COLUMN_NAME
-        """
-        rows = self.connector.execute(query, (schema,))
-        return [
-            {
-                "table": row["TABLE_NAME"],
-                "column": row["COLUMN_NAME"],
-                "referenced_table": row["REFERENCED_TABLE_NAME"],
-                "referenced_column": row["REFERENCED_COLUMN_NAME"],
-                "constraint_name": row["CONSTRAINT_NAME"],
-            }
-            for row in rows
-        ]
-
-    def generate_orphan_query(
-        self,
-        schema: str,
-        table: str,
-        column: str,
-        ref_table: str,
-        ref_column: str,
-    ) -> str:
-        return f"""SELECT c.*
-FROM `{schema}`.`{table}` c
-LEFT JOIN `{schema}`.`{ref_table}` p ON c.`{column}` = p.`{ref_column}`
-WHERE c.`{column}` IS NOT NULL
-  AND p.`{ref_column}` IS NULL"""
-
-    def find_orphan_records(
-        self,
-        schema: str,
-        tables: Optional[List[str]] = None,
-        sample_limit: int = 5,
-        progress_callback: Optional[Callable[[str], None]] = None,
-    ) -> List[OrphanRecordInfo]:
-        fk_details = self.get_fk_details(schema)
-        if tables:
-            table_set = set(tables)
-            fk_details = [fk for fk in fk_details if fk["table"] in table_set]
-
-        results = []
-        for index, fk in enumerate(fk_details, 1):
-            table = fk["table"]
-            column = fk["column"]
-            ref_table = fk["referenced_table"]
-            ref_column = fk["referenced_column"]
-
-            if progress_callback:
-                progress_callback(f"검사 중... ({index}/{len(fk_details)}) {table}.{column}")
-
-            count_query = f"""
-            SELECT COUNT(*) as cnt
-            FROM `{schema}`.`{table}` c
-            LEFT JOIN `{schema}`.`{ref_table}` p ON c.`{column}` = p.`{ref_column}`
-            WHERE c.`{column}` IS NOT NULL
-              AND p.`{ref_column}` IS NULL
-            """
-            count_result = self.connector.execute(count_query)
-            orphan_count = count_result[0]["cnt"] if count_result else 0
-            if orphan_count <= 0:
-                continue
-
-            sample_query = f"""
-            SELECT DISTINCT c.`{column}` as orphan_value
-            FROM `{schema}`.`{table}` c
-            LEFT JOIN `{schema}`.`{ref_table}` p ON c.`{column}` = p.`{ref_column}`
-            WHERE c.`{column}` IS NOT NULL
-              AND p.`{ref_column}` IS NULL
-            LIMIT {sample_limit}
-            """
-            sample_values = [
-                str(row["orphan_value"])
-                for row in self.connector.execute(sample_query)
-            ]
-            results.append(
-                OrphanRecordInfo(
-                    table=table,
-                    column=column,
-                    referenced_table=ref_table,
-                    referenced_column=ref_column,
-                    orphan_count=orphan_count,
-                    sample_values=sample_values,
-                    query=self.generate_orphan_query(schema, table, column, ref_table, ref_column),
-                )
-            )
-        return results
-
-    def export_orphan_report(
-        self,
-        schema: str,
-        output_path: str,
-        tables: Optional[List[str]] = None,
-        progress_callback: Optional[Callable[[str], None]] = None,
-    ) -> Tuple[bool, str, int]:
-        try:
-            orphans = self.find_orphan_records(schema, tables, progress_callback=progress_callback)
-            with open(output_path, "w", encoding="utf-8") as file:
-                file.write("# 고아 레코드 분석 보고서\n")
-                file.write(f"# 스키마: {schema}\n")
-                file.write(f"# 생성일시: {datetime.now().isoformat()}\n")
-                file.write(f"# 발견된 고아 관계: {len(orphans)}건\n")
-                file.write("=" * 80 + "\n\n")
-                if not orphans:
-                    file.write("고아 레코드가 발견되지 않았습니다.\n")
-                else:
-                    total_orphans = sum(item.orphan_count for item in orphans)
-                    file.write(f"총 {total_orphans:,}개의 고아 레코드 발견\n\n")
-                    for index, item in enumerate(orphans, 1):
-                        file.write(
-                            f"## [{index}] {item.table}.{item.column} -> "
-                            f"{item.referenced_table}.{item.referenced_column}\n"
-                        )
-                        file.write(f"   고아 레코드 수: {item.orphan_count:,}건\n")
-                        file.write(f"   샘플 값: {', '.join(item.sample_values)}\n")
-                        file.write("\n   조회 쿼리:\n")
-                        file.write("   ```sql\n")
-                        for line in item.query.split("\n"):
-                            file.write(f"   {line}\n")
-                        file.write("   ```\n\n")
-                        file.write("-" * 80 + "\n\n")
-            return True, f"보고서 저장 완료: {output_path}", len(orphans)
-        except Exception as exc:
-            return False, f"보고서 저장 실패: {exc}", 0
-
-    def get_all_orphan_queries(self, schema: str, tables: Optional[List[str]] = None) -> str:
-        fk_details = self.get_fk_details(schema)
-        if tables:
-            table_set = set(tables)
-            fk_details = [fk for fk in fk_details if fk["table"] in table_set]
-
-        queries = [
-            f"-- 고아 레코드 조회 쿼리 (스키마: {schema})",
-            f"-- 생성일시: {datetime.now().isoformat()}",
-            f"-- FK 관계 수: {len(fk_details)}개",
-            "",
-        ]
-        for index, fk in enumerate(fk_details, 1):
-            table = fk["table"]
-            column = fk["column"]
-            ref_table = fk["referenced_table"]
-            ref_column = fk["referenced_column"]
-            queries.append(f"-- [{index}] {table}.{column} -> {ref_table}.{ref_column}")
-            queries.append(
-                f"""SELECT '{table}.{column}' AS fk_relation, COUNT(*) AS orphan_count
-FROM `{schema}`.`{table}` c
-LEFT JOIN `{schema}`.`{ref_table}` p ON c.`{column}` = p.`{ref_column}`
-WHERE c.`{column}` IS NOT NULL AND p.`{ref_column}` IS NULL;
-"""
-            )
-        return "\n".join(queries)
-
-
-class RustDumpExporter:
-    """Rust DB Core backed dump exporter."""
+class _RustDumpClientBase:
+    """Shared facade/endpoint plumbing for Rust dump exporter/importer."""
 
     def __init__(self, config: RustDumpConfig, facade: Optional[DbCoreFacade] = None):
         self.config = config
@@ -341,6 +133,10 @@ class RustDumpExporter:
             password=self.config.password,
             database=schema,
         )
+
+
+class RustDumpExporter(_RustDumpClientBase):
+    """Rust DB Core backed dump exporter."""
 
     def _resolve_required_tables_from_rust_schema(
         self,
@@ -403,15 +199,12 @@ class RustDumpExporter:
         schema: str,
         output_dir: str,
         tables: Optional[List[str]],
-        threads: int = 8,
+        threads: int = DEFAULT_DUMP_THREADS,
         chunk_size: int = 50000,
         compression: str = DEFAULT_DUMP_COMPRESSION,
-        progress_callback: Optional[Callable[[str], None]] = None,
-        table_progress_callback: Optional[Callable[[int, int, str], None]] = None,
-        detail_callback: Optional[Callable[[dict], None]] = None,
-        table_status_callback: Optional[Callable[[str, str, str], None]] = None,
-        raw_output_callback: Optional[Callable[[str], None]] = None,
+        callbacks: Optional[DumpEventCallbacks] = None,
     ) -> Tuple[bool, str]:
+        callbacks = callbacks or DumpEventCallbacks()
         payload = {
             "source": self._endpoint(schema).to_payload(),
             "output_dir": output_dir,
@@ -424,18 +217,18 @@ class RustDumpExporter:
         if tables:
             payload["tables"] = tables
 
-        if progress_callback:
-            progress_callback(f"Rust DB Core export 시작: {self.config.get_masked_uri()}/{schema}")
+        if callbacks.progress:
+            callbacks.progress(f"Rust DB Core export 시작: {self.config.get_masked_uri()}/{schema}")
 
         result = self.facade.run_dump(
             payload,
             on_event=lambda event: self._emit_core_event(
                 event,
-                progress_callback,
-                table_progress_callback,
-                detail_callback,
-                table_status_callback,
-                raw_output_callback,
+                callbacks.progress,
+                callbacks.table_progress,
+                callbacks.detail,
+                callbacks.table_status,
+                callbacks.raw_output,
             ),
         )
         rows = int(result.get("rows_dumped") or 0)
@@ -450,7 +243,7 @@ class RustDumpExporter:
         self,
         schema: str,
         output_dir: str,
-        threads: int = 8,
+        threads: int = DEFAULT_DUMP_THREADS,
         compression: str = DEFAULT_DUMP_COMPRESSION,
         progress_callback: Optional[Callable[[str], None]] = None,
         table_progress_callback: Optional[Callable[[int, int, str], None]] = None,
@@ -465,11 +258,13 @@ class RustDumpExporter:
                 tables=None,
                 threads=threads,
                 compression=compression,
-                progress_callback=progress_callback,
-                table_progress_callback=table_progress_callback,
-                detail_callback=detail_callback,
-                table_status_callback=table_status_callback,
-                raw_output_callback=raw_output_callback,
+                callbacks=DumpEventCallbacks(
+                    progress=progress_callback,
+                    table_progress=table_progress_callback,
+                    detail=detail_callback,
+                    table_status=table_status_callback,
+                    raw_output=raw_output_callback,
+                ),
             )
             if success:
                 self._write_metadata(output_dir, schema, "full", None)
@@ -486,7 +281,7 @@ class RustDumpExporter:
         schema: str,
         tables: List[str],
         output_dir: str,
-        threads: int = 8,
+        threads: int = DEFAULT_DUMP_THREADS,
         compression: str = DEFAULT_DUMP_COMPRESSION,
         include_fk_parents: bool = True,
         progress_callback: Optional[Callable[[str], None]] = None,
@@ -512,11 +307,13 @@ class RustDumpExporter:
                 tables=final_tables,
                 threads=threads,
                 compression=compression,
-                progress_callback=progress_callback,
-                table_progress_callback=table_progress_callback,
-                detail_callback=detail_callback,
-                table_status_callback=table_status_callback,
-                raw_output_callback=raw_output_callback,
+                callbacks=DumpEventCallbacks(
+                    progress=progress_callback,
+                    table_progress=table_progress_callback,
+                    detail=detail_callback,
+                    table_status=table_status_callback,
+                    raw_output=raw_output_callback,
+                ),
             )
             if success:
                 self._write_metadata(output_dir, schema, "partial", final_tables, added_tables)
@@ -565,23 +362,8 @@ def _mark_non_done_import_results_error(
             table_status_callback(table, "error", message)
 
 
-class RustDumpImporter:
+class RustDumpImporter(_RustDumpClientBase):
     """Rust DB Core backed dump importer."""
-
-    def __init__(self, config: RustDumpConfig, facade: Optional[DbCoreFacade] = None):
-        self.config = config
-        self.facade = facade if facade is not None else DbCoreFacade()
-        self._owns_facade = facade is None
-
-    def _endpoint(self, schema: str) -> DbEndpoint:
-        return DbEndpoint(
-            engine=self.config.engine,
-            host=self.config.host,
-            port=int(self.config.port),
-            user=self.config.user,
-            password=self.config.password,
-            database=schema,
-        )
 
     def _analyze_dump_metadata(self, dump_dir: str) -> Optional[Dict]:
         manifest_path = Path(dump_dir) / "_tunnelforge_dump.json"
@@ -630,7 +412,7 @@ class RustDumpImporter:
         self,
         input_dir: str,
         target_schema: Optional[str] = None,
-        threads: int = 8,
+        threads: int = DEFAULT_DUMP_THREADS,
         import_mode: str = "replace",
         timezone_sql: Optional[str] = None,
         progress_callback: Optional[Callable[[str], None]] = None,
@@ -725,131 +507,6 @@ class RustDumpImporter:
             _shutdown_owned_facade(self.facade, self._owns_facade)
 
 
-class TableProgressTracker:
-    """Table progress metadata helper for the import UI."""
-
-    def __init__(self, metadata: Optional[Dict]):
-        self.chunk_counts = metadata.get("chunk_counts", {}) if metadata else {}
-        self.table_sizes = metadata.get("table_sizes", {}) if metadata else {}
-        self.total_bytes = metadata.get("total_bytes", 0) if metadata else 0
-        self.completed_tables: Set[str] = set()
-
-    def estimate_loading_tables(
-        self,
-        loaded_bytes: int,
-        completed_tables: List[str],
-    ) -> List[Tuple[str, int, int]]:
-        self.completed_tables = set(completed_tables)
-        candidates = [
-            (table, self.table_sizes.get(table, 0), self.chunk_counts.get(table, 1))
-            for table in self.table_sizes
-            if table not in self.completed_tables and self.table_sizes.get(table, 0) > 10_000_000
-        ]
-        candidates.sort(key=lambda item: -item[1])
-        return candidates[:4]
-
-    def get_table_info(self, table_name: str) -> Tuple[int, int]:
-        return self.table_sizes.get(table_name, 0), self.chunk_counts.get(table_name, 1)
-
-    def format_size(self, size_bytes: int) -> str:
-        if size_bytes < 1024:
-            return f"{size_bytes} B"
-        if size_bytes < 1024 * 1024:
-            return f"{size_bytes / 1024:.1f} KB"
-        if size_bytes < 1024 * 1024 * 1024:
-            return f"{size_bytes / (1024 * 1024):.1f} MB"
-        return f"{size_bytes / (1024 * 1024 * 1024):.2f} GB"
-
-
-def emit_core_event(
-    event: Dict,
-    progress_callback: Optional[Callable[[str], None]] = None,
-    table_progress_callback: Optional[Callable[[int, int, str], None]] = None,
-    detail_callback: Optional[Callable[[dict], None]] = None,
-    table_status_callback: Optional[Callable[[str, str, str], None]] = None,
-    raw_output_callback: Optional[Callable[[str], None]] = None,
-    import_results: Optional[dict] = None,
-    table_chunk_progress_callback: Optional[Callable[[str, int, int], None]] = None,
-) -> None:
-    event_type = event.get("event")
-    table = str(event.get("table") or "")
-    if raw_output_callback:
-        raw_output_callback(json.dumps(event, ensure_ascii=False))
-
-    if event_type == "dump_plan":
-        if detail_callback:
-            detail_callback({
-                "event": "dump_plan",
-                "tables_total": int(event.get("tables_total") or 0),
-                "rows_total": int(event.get("rows_total") or 0),
-                "tables": event.get("tables") if isinstance(event.get("tables"), list) else [],
-            })
-    elif event_type == "dump_schedule":
-        if detail_callback:
-            detail_callback({
-                "event": "dump_schedule",
-                "threads": int(event.get("threads") or 0),
-                "table_workers": int(event.get("table_workers") or 0),
-                "range_workers_per_table": int(event.get("range_workers_per_table") or 0),
-                "chunk_size": int(event.get("chunk_size") or 0),
-                "data_format": str(event.get("data_format") or ""),
-                "compression": str(event.get("compression") or ""),
-                "scheduled_tables": event.get("scheduled_tables") if isinstance(event.get("scheduled_tables"), list) else [],
-            })
-    elif event_type == "phase" and progress_callback:
-        message = _format_import_phase_message(event)
-        if message:
-            progress_callback(message)
-    elif event_type == "table_progress":
-        current = int(event.get("current") or 0)
-        total = int(event.get("total") or 0)
-        status = str(event.get("status") or "")
-        ui_status = "loading" if status in ("dumping", "importing") else "done" if status == "completed" else status
-        if table_progress_callback and status == "completed":
-            table_progress_callback(current, total, table)
-        if table_status_callback and table:
-            table_status_callback(table, ui_status, "")
-        if import_results is not None and table:
-            import_results[table] = {"status": ui_status or "loading", "message": ""}
-    elif event_type == "row_progress":
-        rows = int(event.get("table_rows_done") or event.get("rows") or 0)
-        total = int(event.get("table_rows_total") or event.get("total") or 0)
-        overall_rows = int(event.get("overall_rows_done") or 0)
-        overall_total = int(event.get("overall_rows_total") or 0)
-        chunk_rows = int(event.get("chunk_rows") or 0)
-        elapsed_ms = int(event.get("stream_ms") or event.get("read_ms") or event.get("load_ms") or 0)
-        rows_sec = int((chunk_rows * 1000) / elapsed_ms) if chunk_rows and elapsed_ms else 0
-        if overall_total:
-            percent = int((overall_rows / overall_total) * 100)
-        else:
-            percent = int((rows / total) * 100) if total else 0
-        if detail_callback:
-            detail_callback({
-                "event": "row_progress",
-                "table": table,
-                "percent": min(percent, 100),
-                "rows_done": rows,
-                "rows_total": total,
-                "overall_rows_done": overall_rows,
-                "overall_rows_total": overall_total,
-                "chunk_rows": chunk_rows,
-                "rows_sec": rows_sec,
-                "speed": f"{rows_sec:,} rows/s" if rows_sec else "Rust DB Core",
-                "chunk_index": event.get("chunk_index"),
-                "chunks_done": event.get("chunks_done"),
-                "chunks_total": event.get("chunks_total"),
-                "strategy": event.get("strategy"),
-                "stream_ms": event.get("stream_ms"),
-                "read_ms": event.get("read_ms"),
-                "write_ms": event.get("write_ms"),
-                "load_ms": event.get("load_ms"),
-            })
-        chunks_done = int(event.get("chunks_done") or 0)
-        chunks_total = int(event.get("chunks_total") or 0)
-        if table_chunk_progress_callback and table and chunks_done and chunks_total:
-            table_chunk_progress_callback(table, chunks_done, chunks_total)
-
-
 def check_rust_dump() -> Tuple[bool, str]:
     installed, message, _ = RustDumpChecker.check_installation()
     return installed, message
@@ -862,7 +519,7 @@ def export_schema(
     password: str,
     schema: str,
     output_dir: str,
-    threads: int = 8,
+    threads: int = DEFAULT_DUMP_THREADS,
     progress_callback: Optional[Callable[[str], None]] = None,
     engine: str = "mysql",
 ) -> Tuple[bool, str]:
@@ -879,7 +536,7 @@ def export_tables(
     schema: str,
     tables: List[str],
     output_dir: str,
-    threads: int = 8,
+    threads: int = DEFAULT_DUMP_THREADS,
     include_fk_parents: bool = True,
     progress_callback: Optional[Callable[[str], None]] = None,
     engine: str = "mysql",
@@ -903,7 +560,7 @@ def import_dump(
     password: str,
     input_dir: str,
     target_schema: Optional[str] = None,
-    threads: int = 8,
+    threads: int = DEFAULT_DUMP_THREADS,
     import_mode: str = "replace",
     progress_callback: Optional[Callable[[str], None]] = None,
     table_chunk_progress_callback: Optional[Callable[[str, int, int], None]] = None,

--- a/tests/test_dump_progress.py
+++ b/tests/test_dump_progress.py
@@ -1,0 +1,84 @@
+"""
+dump_progress 모듈(src.exporters.dump_progress) 신규 경로 테스트
+"""
+
+
+def test_import_path_from_dump_progress_module():
+    """새 경로에서 emit_core_event/TableProgressTracker/DumpEventCallbacks를 직접 import할 수 있다."""
+    from src.exporters.dump_progress import DumpEventCallbacks, TableProgressTracker, emit_core_event
+
+    assert emit_core_event is not None
+    assert TableProgressTracker is not None
+    assert DumpEventCallbacks is not None
+
+
+def test_rust_dump_exporter_reexports_same_symbols():
+    """rust_dump_exporter의 re-export가 dump_progress 모듈의 심볼과 동일 객체를 가리킨다."""
+    from src.exporters.dump_progress import TableProgressTracker as CoreTracker
+    from src.exporters.dump_progress import emit_core_event as core_emit_core_event
+    from src.exporters.rust_dump_exporter import TableProgressTracker as ReexportedTracker
+    from src.exporters.rust_dump_exporter import emit_core_event as reexported_emit_core_event
+
+    assert CoreTracker is ReexportedTracker
+    assert core_emit_core_event is reexported_emit_core_event
+
+
+def test_dump_event_callbacks_defaults_to_none():
+    """DumpEventCallbacks의 모든 필드는 기본값 None을 가진다."""
+    from src.exporters.dump_progress import DumpEventCallbacks
+
+    callbacks = DumpEventCallbacks()
+
+    assert callbacks.progress is None
+    assert callbacks.table_progress is None
+    assert callbacks.detail is None
+    assert callbacks.table_status is None
+    assert callbacks.raw_output is None
+    assert callbacks.metadata is None
+    assert callbacks.table_chunk_progress is None
+
+
+def test_emit_core_event_dispatches_dump_plan():
+    """dump_plan 이벤트가 detail_callback으로 전달된다 (dispatch table 경유)."""
+    from src.exporters.dump_progress import emit_core_event
+
+    details = []
+    emit_core_event(
+        {"event": "dump_plan", "tables_total": 1, "rows_total": 10, "tables": []},
+        detail_callback=details.append,
+    )
+
+    assert details == [{
+        "event": "dump_plan",
+        "tables_total": 1,
+        "rows_total": 10,
+        "tables": [],
+    }]
+
+
+def test_emit_core_event_ignores_unknown_event_type():
+    """알 수 없는 event type은 어떤 콜백도 호출하지 않는다."""
+    from src.exporters.dump_progress import emit_core_event
+
+    calls = []
+    emit_core_event(
+        {"event": "unknown_event"},
+        progress_callback=calls.append,
+        detail_callback=calls.append,
+    )
+
+    assert calls == []
+
+
+def test_emit_core_event_raw_output_forwarded_regardless_of_event_type():
+    """raw_output_callback은 event type과 무관하게 항상 호출된다."""
+    from src.exporters.dump_progress import emit_core_event
+
+    raw_events = []
+    emit_core_event(
+        {"event": "unknown_event", "foo": "bar"},
+        raw_output_callback=raw_events.append,
+    )
+
+    assert len(raw_events) == 1
+    assert "unknown_event" in raw_events[0]

--- a/tests/test_foreign_key_resolver.py
+++ b/tests/test_foreign_key_resolver.py
@@ -1,0 +1,102 @@
+"""
+ForeignKeyResolver / OrphanRecordInfo 신규 경로(src.core.foreign_key_resolver) 테스트
+"""
+from unittest.mock import MagicMock
+
+
+def test_import_path_from_core_module():
+    """새 경로에서 ForeignKeyResolver/OrphanRecordInfo를 직접 import할 수 있다."""
+    from src.core.foreign_key_resolver import ForeignKeyResolver, OrphanRecordInfo
+
+    assert ForeignKeyResolver is not None
+    assert OrphanRecordInfo is not None
+
+
+def test_rust_dump_exporter_reexports_same_symbols():
+    """rust_dump_exporter의 re-export가 core 모듈의 심볼과 동일 객체를 가리킨다."""
+    from src.core.foreign_key_resolver import ForeignKeyResolver as CoreResolver
+    from src.core.foreign_key_resolver import OrphanRecordInfo as CoreOrphanInfo
+    from src.exporters.rust_dump_exporter import ForeignKeyResolver as ReexportedResolver
+    from src.exporters.rust_dump_exporter import OrphanRecordInfo as ReexportedOrphanInfo
+
+    assert CoreResolver is ReexportedResolver
+    assert CoreOrphanInfo is ReexportedOrphanInfo
+
+
+def test_get_all_dependencies():
+    """전체 FK 의존성 조회"""
+    from src.core.foreign_key_resolver import ForeignKeyResolver
+
+    mock_connector = MagicMock()
+    mock_connector.execute.return_value = [
+        {'TABLE_NAME': 'posts', 'REFERENCED_TABLE_NAME': 'users'},
+        {'TABLE_NAME': 'comments', 'REFERENCED_TABLE_NAME': 'posts'},
+    ]
+
+    resolver = ForeignKeyResolver(mock_connector)
+    deps = resolver.get_all_dependencies('blog')
+
+    assert deps == {'posts': {'users'}, 'comments': {'posts'}}
+
+
+def test_generate_orphan_query_contains_join_and_where():
+    """generate_orphan_query가 스키마/테이블/컬럼을 포함한 유효한 조회 쿼리를 생성한다."""
+    from src.core.foreign_key_resolver import ForeignKeyResolver
+
+    resolver = ForeignKeyResolver(MagicMock())
+    query = resolver.generate_orphan_query('blog', 'posts', 'user_id', 'users', 'id')
+
+    assert "FROM `blog`.`posts` c" in query
+    assert "LEFT JOIN `blog`.`users` p ON c.`user_id` = p.`id`" in query
+    assert "WHERE c.`user_id` IS NOT NULL AND p.`id` IS NULL" in query
+
+
+def test_find_orphan_records_uses_shared_join_fragment_for_count_and_sample():
+    """find_orphan_records의 count/sample 쿼리가 동일한 JOIN/WHERE 조건을 공유한다."""
+    from src.core.foreign_key_resolver import ForeignKeyResolver
+
+    mock_connector = MagicMock()
+    mock_connector.execute.side_effect = [
+        [{'TABLE_NAME': 'posts', 'COLUMN_NAME': 'user_id',
+          'REFERENCED_TABLE_NAME': 'users', 'REFERENCED_COLUMN_NAME': 'id',
+          'CONSTRAINT_NAME': 'fk_posts_users'}],
+        [{'cnt': 2}],
+        [{'orphan_value': '10'}, {'orphan_value': '11'}],
+    ]
+
+    resolver = ForeignKeyResolver(mock_connector)
+    results = resolver.find_orphan_records('blog')
+
+    assert len(results) == 1
+    info = results[0]
+    assert info.orphan_count == 2
+    assert info.sample_values == ['10', '11']
+
+    count_query = mock_connector.execute.call_args_list[1].args[0]
+    sample_query = mock_connector.execute.call_args_list[2].args[0]
+    assert "FROM `blog`.`posts` c" in count_query
+    assert "FROM `blog`.`posts` c" in sample_query
+    assert "WHERE c.`user_id` IS NOT NULL AND p.`id` IS NULL" in count_query
+    assert "WHERE c.`user_id` IS NOT NULL AND p.`id` IS NULL" in sample_query
+    assert "LIMIT 5" in sample_query
+    assert "LIMIT" not in count_query
+
+
+def test_get_all_orphan_queries_contains_fk_relation_alias():
+    """get_all_orphan_queries가 각 FK별로 집계 쿼리를 생성한다."""
+    from src.core.foreign_key_resolver import ForeignKeyResolver
+
+    mock_connector = MagicMock()
+    mock_connector.execute.return_value = [
+        {'TABLE_NAME': 'posts', 'COLUMN_NAME': 'user_id',
+         'REFERENCED_TABLE_NAME': 'users', 'REFERENCED_COLUMN_NAME': 'id',
+         'CONSTRAINT_NAME': 'fk_posts_users'},
+    ]
+
+    resolver = ForeignKeyResolver(mock_connector)
+    sql = resolver.get_all_orphan_queries('blog')
+
+    assert "posts.user_id" in sql
+    assert "AS fk_relation" in sql
+    assert "AS orphan_count" in sql
+    assert "FROM `blog`.`posts` c" in sql


### PR DESCRIPTION
## 요약

Clean Code 리팩토링 Round 2, WP-2.6. `src/exporters/rust_dump_exporter.py`(921줄) god-file을 책임별로 3분할했다.

- **`src/core/foreign_key_resolver.py`** (신규): `OrphanRecordInfo`, `ForeignKeyResolver` 이동. MySQLConnector를 직접 사용하는 orphan-record 분석 전용 유틸로, 순수 이동만 하고 로직 변경 없음.
- **`src/exporters/dump_progress.py`** (신규): `TableProgressTracker`, `_format_import_phase_message`, `emit_core_event` 이동.
- **`src/exporters/rust_dump_exporter.py`**: `RustDumpConfig`/`RustDumpChecker`/`RustDumpExporter`/`RustDumpImporter`와 경로안전 헬퍼만 남김.

## Findings 처리 (CC-099 ~ CC-104)

- **CC-099** god-file 3분할 + 하위호환 re-export: `rust_dump_exporter`가 `ForeignKeyResolver`/`OrphanRecordInfo`/`TableProgressTracker`/`emit_core_event` 등을 계속 re-export하여 기존 소비자 5개 파일(scheduler.py, db_export_dialog.py, db_import_dialog.py, db_orphan_dialog.py, rust_dump_worker.py) 및 `src/exporters/__init__.py`는 **무변경**으로 유지.
- **CC-100** `_RustDumpClientBase` 도입: `RustDumpExporter`/`RustDumpImporter`의 중복된 `__init__`/`_endpoint`를 공통 베이스 클래스로 통합.
- **CC-101** 콜백 수프 축소: `dump_progress.py`에 `DumpEventCallbacks` dataclass 도입. **private** `_run_rust_dump`의 시그니처만 이 번들로 축소했고, `export_full_schema`/`export_tables`/`import_dump` 공개 시그니처는 파라미터 개수·순서 100% 불변 (Round 3의 `rust_dump_worker.py`가 위치인자로 호출하는 것을 보호).
- **CC-102** `DEFAULT_DUMP_THREADS = 8` 상수화, 기존 7곳의 하드코딩된 `threads: int = 8`을 교체 (값 불변).
- **CC-103** `emit_core_event`를 이벤트타입별 private 핸들러(`_handle_dump_plan_event` 등) + dispatch table로 재구성. 공개 시그니처(이름·순서·기본값)는 100% 불변.
- **CC-104** `ForeignKeyResolver`에 `_orphan_join_where` 헬퍼 추가, 4곳(`generate_orphan_query`/`find_orphan_records`의 count·sample 쿼리/`get_all_orphan_queries`)의 FROM/JOIN/WHERE 조각을 공유. 각 호출부는 SELECT 절/LIMIT만 덧붙이므로 실행되는 SQL의 동작(조인 조건, WHERE 조건)은 기존과 동등. 정확한 텍스트 포맷(줄바꿈)은 공유 조각 도입으로 다소 달라졌으나 기능적으로 동일.

## 순환참조 방지

- `foreign_key_resolver.py`: `db_connector.MySQLConnector` + stdlib만 의존.
- `dump_progress.py`: json/typing/dataclasses만 의존.
- import 방향은 `rust_dump_exporter` → 두 신규 모듈 단방향만 존재.

## 검증

- `python -m py_compile` (3개 대상 파일): 통과
- re-export 심볼 14개 getattr 확인: 통과
- `import src.exporters`: 통과
- 타겟 테스트(`test_rust_dump_exporter`, `test_db_orphan_dialog`, `test_db_export_dialog`, `test_db_import_dialog`, `test_db_dialogs`, 신규 `test_foreign_key_resolver`, `test_dump_progress`): **116 passed**
- 전체 `pytest`: **1848 passed, 1 failed** — 실패한 `test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`는 GitHub Actions 워크플로 조회에 의존하는 사전 존재 flaky 테스트로, 이번 변경(파이썬 dump exporter 분할)과 무관함을 확인.

## 위험 요소 / 참고

- 스펙에 명시된 `_WP_SPEC.md`, `.cc_appdata/`는 커밋에서 제외했다 (git add 시 파일명 명시).
- `docs/current_status.md`를 검증하는 `test_current_status_docs.py`는 run-only로 실행만 하고 수정하지 않았다 (통과 확인됨, 전체 pytest에 포함).
- CLAUDE.md의 `ForeignKeyResolver` 서술을 새 위치(`src/core/foreign_key_resolver.py`) 반영하도록 갱신했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)