### PR TITLE
refactor(schema-diff): schema 도구군 5개 파일 DRY 정리 (CC-096~111)

### DIFF
--- a/src/core/schema_comparator.py
+++ b/src/core/schema_comparator.py
@@ -1,10 +1,12 @@
 """
 두 스키마 구조 비교기
 """
-from typing import List, Dict
+from typing import Any, Callable, Dict, List, Optional
 
 from src.core.schema_diff_models import (
-    ColumnDiff, ColumnInfo, CompareLevel, DiffType, ForeignKeyDiff,
+    ColumnDiff, ColumnInfo, CompareLevel, DIFF_PREFIX_CHARSET,
+    DIFF_PREFIX_COLLATION, DIFF_PREFIX_DEFAULT, DIFF_PREFIX_EXTRA,
+    DIFF_PREFIX_NULLABLE, DIFF_PREFIX_TYPE, DiffType, ForeignKeyDiff,
     ForeignKeyInfo, IndexDiff, IndexInfo, TableDiff, TableSchema,
     _normalize_column_extra,
 )
@@ -140,30 +142,30 @@ class SchemaComparator:
 
                 # 타입 비교 (모든 레벨)
                 if src.data_type.lower() != tgt.data_type.lower():
-                    differences.append(f"타입: {src.data_type} → {tgt.data_type}")
+                    differences.append(f"{DIFF_PREFIX_TYPE} {src.data_type} → {tgt.data_type}")
 
                 # Quick 모드: 타입만 비교
                 if compare_level != CompareLevel.QUICK:
                     if src.nullable != tgt.nullable:
                         src_null = "NULL" if src.nullable else "NOT NULL"
                         tgt_null = "NULL" if tgt.nullable else "NOT NULL"
-                        differences.append(f"Nullable: {src_null} → {tgt_null}")
+                        differences.append(f"{DIFF_PREFIX_NULLABLE} {src_null} → {tgt_null}")
 
                     if src.default != tgt.default:
-                        differences.append(f"Default: {src.default} → {tgt.default}")
+                        differences.append(f"{DIFF_PREFIX_DEFAULT} {src.default} → {tgt.default}")
 
                     src_extra = _normalize_column_extra(src.extra)
                     tgt_extra = _normalize_column_extra(tgt.extra)
                     if src_extra.lower() != tgt_extra.lower():
-                        differences.append(f"Extra: {src_extra} → {tgt_extra}")
+                        differences.append(f"{DIFF_PREFIX_EXTRA} {src_extra} → {tgt_extra}")
 
                 # Strict 모드: charset + collation 추가 비교
                 if compare_level == CompareLevel.STRICT:
                     if src.charset and tgt.charset and src.charset.lower() != tgt.charset.lower():
-                        differences.append(f"Charset: {src.charset} → {tgt.charset}")
+                        differences.append(f"{DIFF_PREFIX_CHARSET} {src.charset} → {tgt.charset}")
 
                     if src.collation and tgt.collation and src.collation.lower() != tgt.collation.lower():
-                        differences.append(f"Collation: {src.collation} → {tgt.collation}")
+                        differences.append(f"{DIFF_PREFIX_COLLATION} {src.collation} → {tgt.collation}")
 
                 if differences:
                     diffs.append(ColumnDiff(
@@ -199,58 +201,43 @@ class SchemaComparator:
             fk.on_update,
         )
 
-    def _compare_indexes(
+    def _compare_named_entities(
         self,
-        source_idx: List[IndexInfo],
-        target_idx: List[IndexInfo]
-    ) -> List[IndexDiff]:
-        """인덱스 비교 (rename 감지 포함)"""
-        diffs = []
+        source_map: Dict[str, Any],
+        target_map: Dict[str, Any],
+        content_key_fn: Callable[[Any], tuple],
+        diff_builder: Callable[..., Any],
+    ) -> List[Any]:
+        """이름 매칭 → content-key 기반 RENAMED 감지 → 잔여 ADDED/REMOVED
+        3단계 제네릭 비교 알고리즘 (인덱스/FK 비교가 공유).
 
-        source_map = {i.name.lower(): i for i in source_idx}
-        target_map = {i.name.lower(): i for i in target_idx}
+        diff_builder(src=None, tgt=None, diff_type=None, old_name=None)는
+        diff_type이 None이면 이름이 매칭된 src/tgt를 비교해 MODIFIED/UNCHANGED를
+        직접 판단하고, 그 외에는 지정된 diff_type(RENAMED/ADDED/REMOVED)으로
+        엔티티별 Diff 인스턴스를 만들어 반환해야 한다.
+        """
+        diffs = []
 
         # 1단계: 이름으로 매칭
         matched_source = set()
         matched_target = set()
 
         common_names = set(source_map.keys()) & set(target_map.keys())
-        for idx_name in sorted(common_names):
-            src = source_map[idx_name]
-            tgt = target_map[idx_name]
-            matched_source.add(idx_name)
-            matched_target.add(idx_name)
-
-            differences = []
-            if src.columns != tgt.columns:
-                differences.append(f"컬럼: {src.columns} → {tgt.columns}")
-            if src.unique != tgt.unique:
-                differences.append(f"Unique: {src.unique} → {tgt.unique}")
-
-            if differences:
-                diffs.append(IndexDiff(
-                    index_name=src.name,
-                    diff_type=DiffType.MODIFIED,
-                    source_info=src,
-                    target_info=tgt,
-                    differences=differences
-                ))
-            else:
-                diffs.append(IndexDiff(
-                    index_name=src.name,
-                    diff_type=DiffType.UNCHANGED,
-                    source_info=src,
-                    target_info=tgt
-                ))
+        for name in sorted(common_names):
+            src = source_map[name]
+            tgt = target_map[name]
+            matched_source.add(name)
+            matched_target.add(name)
+            diffs.append(diff_builder(src=src, tgt=tgt))
 
         # 2단계: 미매칭 항목에서 rename 감지
         unmatched_source = {k: v for k, v in source_map.items() if k not in matched_source}
         unmatched_target = {k: v for k, v in target_map.items() if k not in matched_target}
 
         # 타겟 미매칭을 내용 기반으로 인덱싱
-        target_by_content = {}
+        target_by_content: Dict[tuple, List[str]] = {}
         for tgt_name, tgt in unmatched_target.items():
-            key = self._index_content_key(tgt)
+            key = content_key_fn(tgt)
             target_by_content.setdefault(key, []).append(tgt_name)
 
         renamed_target = set()
@@ -258,7 +245,7 @@ class SchemaComparator:
 
         for src_name in sorted(unmatched_source.keys()):
             src = unmatched_source[src_name]
-            content_key = self._index_content_key(src)
+            content_key = content_key_fn(src)
             candidates = target_by_content.get(content_key, [])
             # 아직 매칭 안 된 후보 찾기
             match_found = False
@@ -266,13 +253,8 @@ class SchemaComparator:
                 if tgt_name not in renamed_target:
                     tgt = unmatched_target[tgt_name]
                     renamed_target.add(tgt_name)
-                    diffs.append(IndexDiff(
-                        index_name=src.name,
-                        diff_type=DiffType.RENAMED,
-                        source_info=src,
-                        target_info=tgt,
-                        differences=[f"이름 변경: {tgt.name} → {src.name}"],
-                        old_name=tgt.name
+                    diffs.append(diff_builder(
+                        src=src, tgt=tgt, diff_type=DiffType.RENAMED, old_name=tgt.name
                     ))
                     match_found = True
                     break
@@ -282,45 +264,60 @@ class SchemaComparator:
 
         # 3단계: 남은 미매칭 → ADDED / REMOVED
         for src in source_added:
-            diffs.append(IndexDiff(
-                index_name=src.name,
-                diff_type=DiffType.ADDED,
-                source_info=src
-            ))
+            diffs.append(diff_builder(src=src, diff_type=DiffType.ADDED))
 
         for tgt_name in sorted(unmatched_target.keys()):
             if tgt_name not in renamed_target:
                 tgt = unmatched_target[tgt_name]
-                diffs.append(IndexDiff(
-                    index_name=tgt.name,
-                    diff_type=DiffType.REMOVED,
-                    target_info=tgt
-                ))
+                diffs.append(diff_builder(tgt=tgt, diff_type=DiffType.REMOVED))
 
         return diffs
 
-    def _compare_foreign_keys(
-        self,
-        source_fks: List[ForeignKeyInfo],
-        target_fks: List[ForeignKeyInfo]
-    ) -> List[ForeignKeyDiff]:
-        """외래 키 비교 (rename 감지 포함)"""
-        diffs = []
+    @staticmethod
+    def _build_index_diff(
+        src: Optional[IndexInfo] = None,
+        tgt: Optional[IndexInfo] = None,
+        diff_type: Optional[DiffType] = None,
+        old_name: Optional[str] = None,
+    ) -> IndexDiff:
+        """이름 매칭된 인덱스의 MODIFIED/UNCHANGED 판정, 또는
+        RENAMED/ADDED/REMOVED IndexDiff 생성."""
+        if diff_type is None:
+            differences = []
+            if src.columns != tgt.columns:
+                differences.append(f"컬럼: {src.columns} → {tgt.columns}")
+            if src.unique != tgt.unique:
+                differences.append(f"Unique: {src.unique} → {tgt.unique}")
+            return IndexDiff(
+                index_name=src.name,
+                diff_type=DiffType.MODIFIED if differences else DiffType.UNCHANGED,
+                source_info=src,
+                target_info=tgt,
+                differences=differences
+            )
+        if diff_type == DiffType.RENAMED:
+            return IndexDiff(
+                index_name=src.name,
+                diff_type=DiffType.RENAMED,
+                source_info=src,
+                target_info=tgt,
+                differences=[f"이름 변경: {tgt.name} → {src.name}"],
+                old_name=old_name
+            )
+        if diff_type == DiffType.ADDED:
+            return IndexDiff(index_name=src.name, diff_type=DiffType.ADDED, source_info=src)
+        return IndexDiff(index_name=tgt.name, diff_type=DiffType.REMOVED, target_info=tgt)
 
-        source_map = {f.name.lower(): f for f in source_fks}
-        target_map = {f.name.lower(): f for f in target_fks}
-
-        # 1단계: 이름으로 매칭
-        matched_source = set()
-        matched_target = set()
-
-        common_names = set(source_map.keys()) & set(target_map.keys())
-        for fk_name in sorted(common_names):
-            src = source_map[fk_name]
-            tgt = target_map[fk_name]
-            matched_source.add(fk_name)
-            matched_target.add(fk_name)
-
+    @staticmethod
+    def _build_fk_diff(
+        src: Optional[ForeignKeyInfo] = None,
+        tgt: Optional[ForeignKeyInfo] = None,
+        diff_type: Optional[DiffType] = None,
+        old_name: Optional[str] = None,
+    ) -> ForeignKeyDiff:
+        """이름 매칭된 FK의 MODIFIED/UNCHANGED 판정, 또는
+        RENAMED/ADDED/REMOVED ForeignKeyDiff 생성."""
+        if diff_type is None:
             differences = []
             if src.ref_table != tgt.ref_table:
                 differences.append(f"참조 테이블: {src.ref_table} → {tgt.ref_table}")
@@ -330,74 +327,46 @@ class SchemaComparator:
                 differences.append(f"ON DELETE: {src.on_delete} → {tgt.on_delete}")
             if src.on_update != tgt.on_update:
                 differences.append(f"ON UPDATE: {src.on_update} → {tgt.on_update}")
-
-            if differences:
-                diffs.append(ForeignKeyDiff(
-                    fk_name=src.name,
-                    diff_type=DiffType.MODIFIED,
-                    source_info=src,
-                    target_info=tgt,
-                    differences=differences
-                ))
-            else:
-                diffs.append(ForeignKeyDiff(
-                    fk_name=src.name,
-                    diff_type=DiffType.UNCHANGED,
-                    source_info=src,
-                    target_info=tgt
-                ))
-
-        # 2단계: 미매칭 항목에서 rename 감지
-        unmatched_source = {k: v for k, v in source_map.items() if k not in matched_source}
-        unmatched_target = {k: v for k, v in target_map.items() if k not in matched_target}
-
-        target_by_content = {}
-        for tgt_name, tgt in unmatched_target.items():
-            key = self._fk_content_key(tgt)
-            target_by_content.setdefault(key, []).append(tgt_name)
-
-        renamed_target = set()
-        source_added = []
-
-        for src_name in sorted(unmatched_source.keys()):
-            src = unmatched_source[src_name]
-            content_key = self._fk_content_key(src)
-            candidates = target_by_content.get(content_key, [])
-
-            match_found = False
-            for tgt_name in candidates:
-                if tgt_name not in renamed_target:
-                    tgt = unmatched_target[tgt_name]
-                    renamed_target.add(tgt_name)
-                    diffs.append(ForeignKeyDiff(
-                        fk_name=src.name,
-                        diff_type=DiffType.RENAMED,
-                        source_info=src,
-                        target_info=tgt,
-                        differences=[f"이름 변경: {tgt.name} → {src.name}"],
-                        old_name=tgt.name
-                    ))
-                    match_found = True
-                    break
-
-            if not match_found:
-                source_added.append(src)
-
-        # 3단계: 남은 미매칭 → ADDED / REMOVED
-        for src in source_added:
-            diffs.append(ForeignKeyDiff(
+            return ForeignKeyDiff(
                 fk_name=src.name,
-                diff_type=DiffType.ADDED,
-                source_info=src
-            ))
+                diff_type=DiffType.MODIFIED if differences else DiffType.UNCHANGED,
+                source_info=src,
+                target_info=tgt,
+                differences=differences
+            )
+        if diff_type == DiffType.RENAMED:
+            return ForeignKeyDiff(
+                fk_name=src.name,
+                diff_type=DiffType.RENAMED,
+                source_info=src,
+                target_info=tgt,
+                differences=[f"이름 변경: {tgt.name} → {src.name}"],
+                old_name=old_name
+            )
+        if diff_type == DiffType.ADDED:
+            return ForeignKeyDiff(fk_name=src.name, diff_type=DiffType.ADDED, source_info=src)
+        return ForeignKeyDiff(fk_name=tgt.name, diff_type=DiffType.REMOVED, target_info=tgt)
 
-        for tgt_name in sorted(unmatched_target.keys()):
-            if tgt_name not in renamed_target:
-                tgt = unmatched_target[tgt_name]
-                diffs.append(ForeignKeyDiff(
-                    fk_name=tgt.name,
-                    diff_type=DiffType.REMOVED,
-                    target_info=tgt
-                ))
+    def _compare_indexes(
+        self,
+        source_idx: List[IndexInfo],
+        target_idx: List[IndexInfo]
+    ) -> List[IndexDiff]:
+        """인덱스 비교 (rename 감지 포함)"""
+        source_map = {i.name.lower(): i for i in source_idx}
+        target_map = {i.name.lower(): i for i in target_idx}
+        return self._compare_named_entities(
+            source_map, target_map, self._index_content_key, self._build_index_diff
+        )
 
-        return diffs
+    def _compare_foreign_keys(
+        self,
+        source_fks: List[ForeignKeyInfo],
+        target_fks: List[ForeignKeyInfo]
+    ) -> List[ForeignKeyDiff]:
+        """외래 키 비교 (rename 감지 포함)"""
+        source_map = {f.name.lower(): f for f in source_fks}
+        target_map = {f.name.lower(): f for f in target_fks}
+        return self._compare_named_entities(
+            source_map, target_map, self._fk_content_key, self._build_fk_diff
+        )

--- a/src/core/schema_diff_models.py
+++ b/src/core/schema_diff_models.py
@@ -64,6 +64,38 @@ def _normalize_column_extra(extra: Optional[str]) -> str:
     return " ".join(cleaned.split())
 
 
+PRIMARY_KEY_INDEX_NAME = "PRIMARY"
+
+
+def is_primary_key_index(name: str) -> bool:
+    """인덱스 이름이 PRIMARY KEY 인덱스인지 확인 (대소문자 무시).
+
+    MySQL INFORMATION_SCHEMA는 항상 대문자 'PRIMARY'를 반환하므로
+    대소문자 무시 비교로 통일해도 런타임 영향이 없다.
+    """
+    return name.upper() == PRIMARY_KEY_INDEX_NAME
+
+
+# 컬럼 diff 메시지 접두어 - 생산자(SchemaComparator)와 소비자(SeverityClassifier)가 공유
+DIFF_PREFIX_TYPE = "타입:"
+DIFF_PREFIX_NULLABLE = "Nullable:"
+DIFF_PREFIX_DEFAULT = "Default:"
+DIFF_PREFIX_EXTRA = "Extra:"
+DIFF_PREFIX_CHARSET = "Charset:"
+DIFF_PREFIX_COLLATION = "Collation:"
+AUTO_INCREMENT_KEYWORD = "auto_increment"
+
+
+def _quote_ident(name: str) -> str:
+    """MySQL 식별자를 백틱으로 감싼다."""
+    return f"`{name}`"
+
+
+def _quote_idents(names: List[str]) -> str:
+    """MySQL 식별자 목록을 백틱으로 감싸 콤마로 join한다."""
+    return ", ".join(_quote_ident(n) for n in names)
+
+
 @dataclass
 class ColumnInfo:
     """컬럼 정보"""
@@ -78,7 +110,7 @@ class ColumnInfo:
 
     def to_sql_definition(self) -> str:
         """SQL 컬럼 정의 생성"""
-        parts = [f"`{self.name}`", self.data_type]
+        parts = [_quote_ident(self.name), self.data_type]
 
         if self.charset and self.charset not in self.data_type:
             parts.append(f"CHARACTER SET {self.charset}")
@@ -111,13 +143,13 @@ class IndexInfo:
 
     def to_sql_definition(self, table_name: str) -> str:
         """인덱스 생성 SQL"""
-        cols = ", ".join(f"`{c}`" for c in self.columns)
-        if self.name == "PRIMARY":
+        cols = _quote_idents(self.columns)
+        if is_primary_key_index(self.name):
             return f"PRIMARY KEY ({cols})"
         elif self.unique:
-            return f"UNIQUE INDEX `{self.name}` ({cols}) USING {self.type}"
+            return f"UNIQUE INDEX {_quote_ident(self.name)} ({cols}) USING {self.type}"
         else:
-            return f"INDEX `{self.name}` ({cols}) USING {self.type}"
+            return f"INDEX {_quote_ident(self.name)} ({cols}) USING {self.type}"
 
 
 @dataclass
@@ -132,11 +164,11 @@ class ForeignKeyInfo:
 
     def to_sql_definition(self) -> str:
         """FK 정의 SQL"""
-        cols = ", ".join(f"`{c}`" for c in self.columns)
-        ref_cols = ", ".join(f"`{c}`" for c in self.ref_columns)
+        cols = _quote_idents(self.columns)
+        ref_cols = _quote_idents(self.ref_columns)
         return (
-            f"CONSTRAINT `{self.name}` FOREIGN KEY ({cols}) "
-            f"REFERENCES `{self.ref_table}` ({ref_cols}) "
+            f"CONSTRAINT {_quote_ident(self.name)} FOREIGN KEY ({cols}) "
+            f"REFERENCES {_quote_ident(self.ref_table)} ({ref_cols}) "
             f"ON DELETE {self.on_delete} ON UPDATE {self.on_update}"
         )
 

--- a/src/core/schema_extractor.py
+++ b/src/core/schema_extractor.py
@@ -1,7 +1,7 @@
 """
 DB 스키마 구조 추출기
 """
-from typing import List, Dict, Optional, Tuple
+from typing import Callable, List, Dict, Optional, Tuple
 
 from src.core.logger import get_logger
 from src.core.schema_diff_models import (
@@ -21,6 +21,22 @@ class SchemaExtractor:
         """
         self.connector = connector
 
+    def _swallow_errors(
+        self, action: Callable[[], None], error_message: Optional[str] = None
+    ) -> None:
+        """action()을 실행하고 예외 발생 시 삼킨다 (반환값 없음).
+
+        action은 호출부의 지역 변수(리스트/딕셔너리 누산기 또는 outcome 딕셔너리)를
+        직접 채우는 클로저여야 하며, 호출부가 그 변수를 읽어 결과를 반환한다.
+        error_message가 주어지면 `f"{error_message}: {e}"` 형식으로 로깅하고,
+        None이면 조용히 삼킨다(로깅 없음) - 각 호출부의 기존 로깅 유무를 그대로 보존한다.
+        """
+        try:
+            action()
+        except Exception as e:
+            if error_message:
+                logger.error(f"{error_message}: {e}")
+
     def extract_table_schema(self, schema: str, table: str) -> Optional[TableSchema]:
         """테이블 스키마 정보 추출
 
@@ -31,23 +47,16 @@ class SchemaExtractor:
         Returns:
             TableSchema 또는 None
         """
-        try:
-            # 컬럼 정보
+        outcome = {}
+
+        def _fetch():
             columns = self._get_columns(schema, table)
-
-            # 인덱스 정보
             indexes = self._get_indexes(schema, table)
-
-            # 외래 키 정보
             foreign_keys = self._get_foreign_keys(schema, table)
-
-            # 테이블 옵션
             engine, charset, collation = self._get_table_options(schema, table)
-
-            # 행 수
             row_count = self._get_row_count(schema, table)
 
-            return TableSchema(
+            outcome['value'] = TableSchema(
                 name=table,
                 columns=columns,
                 indexes=indexes,
@@ -58,9 +67,8 @@ class SchemaExtractor:
                 row_count=row_count
             )
 
-        except Exception as e:
-            logger.error(f"테이블 스키마 추출 실패 ({schema}.{table}): {e}")
-            return None
+        self._swallow_errors(_fetch, f"테이블 스키마 추출 실패 ({schema}.{table})")
+        return outcome.get('value')
 
     def extract_all_tables(self, schema: str) -> Dict[str, TableSchema]:
         """스키마 내 모든 테이블 정보 추출
@@ -82,16 +90,15 @@ class SchemaExtractor:
             ORDER BY TABLE_NAME
         """
 
-        try:
+        def _fetch():
             result = self.connector.execute(query, (schema,))
             for row in result:
                 table_name = row['TABLE_NAME']
                 table_schema = self.extract_table_schema(schema, table_name)
                 if table_schema:
                     tables[table_name] = table_schema
-        except Exception as e:
-            logger.error(f"테이블 목록 조회 실패 ({schema}): {e}")
 
+        self._swallow_errors(_fetch, f"테이블 목록 조회 실패 ({schema})")
         return tables
 
     def _get_columns(self, schema: str, table: str) -> List[ColumnInfo]:
@@ -112,10 +119,11 @@ class SchemaExtractor:
         """
 
         columns = []
-        try:
+
+        def _fetch():
             result = self.connector.execute(query, (schema, table))
             for row in result:
-                col = ColumnInfo(
+                columns.append(ColumnInfo(
                     name=row['COLUMN_NAME'],
                     data_type=row['COLUMN_TYPE'],
                     nullable=(row['IS_NULLABLE'] == 'YES'),
@@ -124,11 +132,9 @@ class SchemaExtractor:
                     key=row['COLUMN_KEY'] or '',
                     charset=row['CHARACTER_SET_NAME'] or '',
                     collation=row['COLLATION_NAME'] or ''
-                )
-                columns.append(col)
-        except Exception as e:
-            logger.error(f"컬럼 정보 조회 실패: {e}")
+                ))
 
+        self._swallow_errors(_fetch, "컬럼 정보 조회 실패")
         return columns
 
     def _get_indexes(self, schema: str, table: str) -> List[IndexInfo]:
@@ -145,7 +151,8 @@ class SchemaExtractor:
         """
 
         index_map = {}
-        try:
+
+        def _fetch():
             result = self.connector.execute(query, (schema, table))
             for row in result:
                 idx_name = row['INDEX_NAME']
@@ -161,9 +168,8 @@ class SchemaExtractor:
                         type=idx_type
                     )
                 index_map[idx_name].columns.append(col_name)
-        except Exception as e:
-            logger.error(f"인덱스 정보 조회 실패: {e}")
 
+        self._swallow_errors(_fetch, "인덱스 정보 조회 실패")
         return list(index_map.values())
 
     def _get_foreign_keys(self, schema: str, table: str) -> List[ForeignKeyInfo]:
@@ -187,7 +193,8 @@ class SchemaExtractor:
         """
 
         fk_map = {}
-        try:
+
+        def _fetch():
             result = self.connector.execute(query, (schema, table))
             for row in result:
                 fk_name = row['CONSTRAINT_NAME']
@@ -208,9 +215,8 @@ class SchemaExtractor:
                     )
                 fk_map[fk_name].columns.append(col)
                 fk_map[fk_name].ref_columns.append(ref_col)
-        except Exception as e:
-            logger.error(f"FK 정보 조회 실패: {e}")
 
+        self._swallow_errors(_fetch, "FK 정보 조회 실패")
         return list(fk_map.values())
 
     def _get_table_options(self, schema: str, table: str) -> Tuple[str, str, str]:
@@ -221,7 +227,9 @@ class SchemaExtractor:
             WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
         """
 
-        try:
+        outcome = {}
+
+        def _fetch():
             result = self.connector.execute(query, (schema, table))
             if result:
                 row = result[0]
@@ -230,19 +238,20 @@ class SchemaExtractor:
 
                 # Collation에서 charset 추출
                 charset = collation.split('_')[0] if collation else 'utf8mb4'
-                return engine or 'InnoDB', charset, collation or ''
-        except Exception as e:
-            logger.error(f"테이블 옵션 조회 실패: {e}")
+                outcome['value'] = (engine or 'InnoDB', charset, collation or '')
 
-        return 'InnoDB', 'utf8mb4', 'utf8mb4_general_ci'
+        self._swallow_errors(_fetch, "테이블 옵션 조회 실패")
+        return outcome.get('value', ('InnoDB', 'utf8mb4', 'utf8mb4_general_ci'))
 
     def _get_row_count(self, schema: str, table: str) -> int:
         """테이블 행 수 조회"""
         query = f"SELECT COUNT(*) as cnt FROM `{schema}`.`{table}`"
-        try:
+        outcome = {}
+
+        def _fetch():
             result = self.connector.execute(query)
             if result:
-                return result[0]['cnt']
-        except Exception:
-            pass
-        return 0
+                outcome['value'] = result[0]['cnt']
+
+        self._swallow_errors(_fetch)
+        return outcome.get('value', 0)

--- a/src/core/schema_severity_classifier.py
+++ b/src/core/schema_severity_classifier.py
@@ -5,8 +5,11 @@ import re
 from typing import List, Optional, Tuple
 
 from src.core.schema_diff_models import (
-    ColumnDiff, DiffSeverity, DiffType, ForeignKeyDiff, IndexDiff,
-    SeveritySummary, TableDiff, VersionContext,
+    AUTO_INCREMENT_KEYWORD, ColumnDiff, DIFF_PREFIX_CHARSET,
+    DIFF_PREFIX_COLLATION, DIFF_PREFIX_DEFAULT, DIFF_PREFIX_EXTRA,
+    DIFF_PREFIX_NULLABLE, DIFF_PREFIX_TYPE, DiffSeverity, DiffType,
+    ForeignKeyDiff, IndexDiff, SeveritySummary, TableDiff, VersionContext,
+    is_primary_key_index,
 )
 
 
@@ -17,6 +20,13 @@ class SeverityClassifier:
     _INTEGER_TYPES = frozenset([
         'tinyint', 'smallint', 'mediumint', 'int', 'integer', 'bigint'
     ])
+
+    # 심각도 우선순위 (숫자가 클수록 심각) - _max_severity에서 참조
+    _SEVERITY_ORDER = {
+        DiffSeverity.CRITICAL: 3,
+        DiffSeverity.WARNING: 2,
+        DiffSeverity.INFO: 1,
+    }
 
     def __init__(self, version_context: Optional[VersionContext] = None):
         self.version_context = version_context
@@ -86,15 +96,15 @@ class SeverityClassifier:
         max_severity = None
 
         for d in diff.differences:
-            if d.startswith("타입:"):
-                sev = self._classify_type_change(d, diff)
-            elif d.startswith("Nullable:"):
+            if d.startswith(DIFF_PREFIX_TYPE):
+                sev = self._classify_type_change(diff)
+            elif d.startswith(DIFF_PREFIX_NULLABLE):
                 sev = DiffSeverity.WARNING
-            elif d.startswith("Default:"):
+            elif d.startswith(DIFF_PREFIX_DEFAULT):
                 sev = DiffSeverity.WARNING
-            elif d.startswith("Extra:"):
+            elif d.startswith(DIFF_PREFIX_EXTRA):
                 sev = self._classify_extra_change(d)
-            elif d.startswith("Charset:") or d.startswith("Collation:"):
+            elif d.startswith(DIFF_PREFIX_CHARSET) or d.startswith(DIFF_PREFIX_COLLATION):
                 sev = DiffSeverity.WARNING
             else:
                 sev = DiffSeverity.WARNING
@@ -104,7 +114,7 @@ class SeverityClassifier:
         return max_severity
 
     def _classify_type_change(
-        self, diff_text: str, col_diff: ColumnDiff
+        self, col_diff: ColumnDiff
     ) -> DiffSeverity:
         """타입 변경 심각도 판단"""
         src_type = col_diff.source_info.data_type if col_diff.source_info else ""
@@ -140,7 +150,7 @@ class SeverityClassifier:
     def _classify_extra_change(self, diff_text: str) -> DiffSeverity:
         """Extra 필드 변경 심각도 판단"""
         diff_lower = diff_text.lower()
-        if 'auto_increment' in diff_lower:
+        if AUTO_INCREMENT_KEYWORD in diff_lower:
             return DiffSeverity.CRITICAL
         return DiffSeverity.WARNING
 
@@ -154,7 +164,7 @@ class SeverityClassifier:
             return DiffSeverity.INFO
 
         # PRIMARY KEY 변경은 Critical
-        if diff.index_name.upper() == 'PRIMARY':
+        if is_primary_key_index(diff.index_name):
             return DiffSeverity.CRITICAL
 
         # 기타 인덱스 변경은 Warning
@@ -182,11 +192,6 @@ class SeverityClassifier:
         if new is None:
             return current
 
-        order = {
-            DiffSeverity.CRITICAL: 3,
-            DiffSeverity.WARNING: 2,
-            DiffSeverity.INFO: 1,
-        }
-        if order.get(new, 0) > order.get(current, 0):
+        if self._SEVERITY_ORDER.get(new, 0) > self._SEVERITY_ORDER.get(current, 0):
             return new
         return current

--- a/src/core/schema_sync_script_generator.py
+++ b/src/core/schema_sync_script_generator.py
@@ -3,7 +3,9 @@
 """
 from typing import List
 
-from src.core.schema_diff_models import DiffType, TableDiff, TableSchema
+from src.core.schema_diff_models import (
+    DiffType, TableDiff, TableSchema, _quote_ident, is_primary_key_index,
+)
 
 
 class SyncScriptGenerator:
@@ -30,137 +32,31 @@ class SyncScriptGenerator:
             ""
         ]
 
-        # 1. FK 삭제 (의존성 해제)
-        fk_drops = []
-        for diff in diffs:
-            if diff.diff_type == DiffType.REMOVED:
-                if diff.target_schema:
-                    for fk in diff.target_schema.foreign_keys:
-                        fk_drops.append(
-                            f"ALTER TABLE `{target_schema}`.`{diff.table_name}` "
-                            f"DROP FOREIGN KEY `{fk.name}`;"
-                        )
-            elif diff.diff_type == DiffType.MODIFIED:
-                for fk_diff in diff.fk_diffs:
-                    if fk_diff.diff_type in [DiffType.REMOVED, DiffType.MODIFIED]:
-                        fk_drops.append(
-                            f"ALTER TABLE `{target_schema}`.`{diff.table_name}` "
-                            f"DROP FOREIGN KEY `{fk_diff.fk_name}`;"
-                        )
-                    elif fk_diff.diff_type == DiffType.RENAMED and fk_diff.old_name:
-                        # FK rename = DROP old + ADD new (MySQL에 RENAME FK 없음)
-                        fk_drops.append(
-                            f"ALTER TABLE `{target_schema}`.`{diff.table_name}` "
-                            f"DROP FOREIGN KEY `{fk_diff.old_name}`; "
-                            f"-- renamed → {fk_diff.fk_name}"
-                        )
-
+        fk_drops = self._generate_fk_drops(diffs, target_schema)
         if fk_drops:
             lines.append("-- FK 삭제")
             lines.extend(fk_drops)
             lines.append("")
 
-        # 2. 테이블 삭제 (소스에 없는 테이블)
-        table_drops = []
-        for diff in diffs:
-            if diff.diff_type == DiffType.REMOVED:
-                table_drops.append(f"DROP TABLE IF EXISTS `{target_schema}`.`{diff.table_name}`;")
-
+        table_drops = self._generate_table_drops(diffs, target_schema)
         if table_drops:
             lines.append("-- 테이블 삭제")
             lines.extend(table_drops)
             lines.append("")
 
-        # 3. 테이블 생성 (타겟에 없는 테이블)
-        table_creates = []
-        for diff in diffs:
-            if diff.diff_type == DiffType.ADDED and diff.source_schema:
-                table_creates.append(
-                    self._generate_create_table(target_schema, diff.source_schema)
-                )
-
+        table_creates = self._generate_table_creates(diffs, target_schema)
         if table_creates:
             lines.append("-- 테이블 생성")
             lines.extend(table_creates)
             lines.append("")
 
-        # 4. 컬럼/인덱스 변경
-        alter_statements = []
-        for diff in diffs:
-            if diff.diff_type == DiffType.MODIFIED:
-                # 컬럼 변경
-                for col_diff in diff.column_diffs:
-                    if col_diff.diff_type == DiffType.ADDED and col_diff.source_info:
-                        alter_statements.append(
-                            f"ALTER TABLE `{target_schema}`.`{diff.table_name}` "
-                            f"ADD COLUMN {col_diff.source_info.to_sql_definition()};"
-                        )
-                    elif col_diff.diff_type == DiffType.REMOVED:
-                        alter_statements.append(
-                            f"ALTER TABLE `{target_schema}`.`{diff.table_name}` "
-                            f"DROP COLUMN `{col_diff.column_name}`;"
-                        )
-                    elif col_diff.diff_type == DiffType.MODIFIED and col_diff.source_info:
-                        alter_statements.append(
-                            f"ALTER TABLE `{target_schema}`.`{diff.table_name}` "
-                            f"MODIFY COLUMN {col_diff.source_info.to_sql_definition()};"
-                        )
-
-                # 인덱스 변경
-                for idx_diff in diff.index_diffs:
-                    if idx_diff.index_name == 'PRIMARY':
-                        continue  # PRIMARY KEY는 별도 처리 필요
-
-                    if idx_diff.diff_type == DiffType.ADDED and idx_diff.source_info:
-                        idx_sql = idx_diff.source_info.to_sql_definition(diff.table_name)
-                        alter_statements.append(
-                            f"ALTER TABLE `{target_schema}`.`{diff.table_name}` ADD {idx_sql};"
-                        )
-                    elif idx_diff.diff_type == DiffType.REMOVED:
-                        alter_statements.append(
-                            f"ALTER TABLE `{target_schema}`.`{diff.table_name}` "
-                            f"DROP INDEX `{idx_diff.index_name}`;"
-                        )
-                    elif idx_diff.diff_type == DiffType.MODIFIED and idx_diff.source_info:
-                        # 인덱스 수정 = 삭제 후 재생성
-                        alter_statements.append(
-                            f"ALTER TABLE `{target_schema}`.`{diff.table_name}` "
-                            f"DROP INDEX `{idx_diff.index_name}`;"
-                        )
-                        idx_sql = idx_diff.source_info.to_sql_definition(diff.table_name)
-                        alter_statements.append(
-                            f"ALTER TABLE `{target_schema}`.`{diff.table_name}` ADD {idx_sql};"
-                        )
-                    elif idx_diff.diff_type == DiffType.RENAMED and idx_diff.old_name:
-                        # MySQL 5.7+ RENAME INDEX
-                        alter_statements.append(
-                            f"ALTER TABLE `{target_schema}`.`{diff.table_name}` "
-                            f"RENAME INDEX `{idx_diff.old_name}` TO `{idx_diff.index_name}`;"
-                        )
-
+        alter_statements = self._generate_alter_statements(diffs, target_schema)
         if alter_statements:
             lines.append("-- 컬럼/인덱스 변경")
             lines.extend(alter_statements)
             lines.append("")
 
-        # 5. FK 추가 (의존성 복원)
-        fk_adds = []
-        for diff in diffs:
-            if diff.diff_type == DiffType.ADDED and diff.source_schema:
-                for fk in diff.source_schema.foreign_keys:
-                    fk_adds.append(
-                        f"ALTER TABLE `{target_schema}`.`{diff.table_name}` "
-                        f"ADD {fk.to_sql_definition()};"
-                    )
-            elif diff.diff_type == DiffType.MODIFIED:
-                for fk_diff in diff.fk_diffs:
-                    if fk_diff.diff_type in [DiffType.ADDED, DiffType.MODIFIED, DiffType.RENAMED]:
-                        if fk_diff.source_info:
-                            fk_adds.append(
-                                f"ALTER TABLE `{target_schema}`.`{diff.table_name}` "
-                                f"ADD {fk_diff.source_info.to_sql_definition()};"
-                            )
-
+        fk_adds = self._generate_fk_adds(diffs, target_schema)
         if fk_adds:
             lines.append("-- FK 추가")
             lines.extend(fk_adds)
@@ -172,9 +68,138 @@ class SyncScriptGenerator:
 
         return "\n".join(lines)
 
+    def _alter_table(self, target_schema: str, table_name: str, clause: str) -> str:
+        """`ALTER TABLE \\`{target_schema}\\`.\\`{table_name}\\` {clause}` 문 생성.
+
+        clause에는 후행 세미콜론(및 필요 시 후행 주석)까지 포함해서 전달한다.
+        """
+        return f"ALTER TABLE {_quote_ident(target_schema)}.{_quote_ident(table_name)} {clause}"
+
+    def _generate_fk_drops(self, diffs: List[TableDiff], target_schema: str) -> List[str]:
+        """FK 삭제 문 목록 생성 (의존성 해제)"""
+        fk_drops = []
+        for diff in diffs:
+            if diff.diff_type == DiffType.REMOVED:
+                if diff.target_schema:
+                    for fk in diff.target_schema.foreign_keys:
+                        fk_drops.append(self._alter_table(
+                            target_schema, diff.table_name,
+                            f"DROP FOREIGN KEY {_quote_ident(fk.name)};"
+                        ))
+            elif diff.diff_type == DiffType.MODIFIED:
+                for fk_diff in diff.fk_diffs:
+                    if fk_diff.diff_type in [DiffType.REMOVED, DiffType.MODIFIED]:
+                        fk_drops.append(self._alter_table(
+                            target_schema, diff.table_name,
+                            f"DROP FOREIGN KEY {_quote_ident(fk_diff.fk_name)};"
+                        ))
+                    elif fk_diff.diff_type == DiffType.RENAMED and fk_diff.old_name:
+                        # FK rename = DROP old + ADD new (MySQL에 RENAME FK 없음)
+                        fk_drops.append(self._alter_table(
+                            target_schema, diff.table_name,
+                            f"DROP FOREIGN KEY {_quote_ident(fk_diff.old_name)}; "
+                            f"-- renamed → {fk_diff.fk_name}"
+                        ))
+        return fk_drops
+
+    def _generate_table_drops(self, diffs: List[TableDiff], target_schema: str) -> List[str]:
+        """테이블 삭제 문 목록 생성 (소스에 없는 테이블)"""
+        return [
+            f"DROP TABLE IF EXISTS {_quote_ident(target_schema)}.{_quote_ident(diff.table_name)};"
+            for diff in diffs
+            if diff.diff_type == DiffType.REMOVED
+        ]
+
+    def _generate_table_creates(self, diffs: List[TableDiff], target_schema: str) -> List[str]:
+        """테이블 생성 문 목록 생성 (타겟에 없는 테이블)"""
+        return [
+            self._generate_create_table(target_schema, diff.source_schema)
+            for diff in diffs
+            if diff.diff_type == DiffType.ADDED and diff.source_schema
+        ]
+
+    def _generate_alter_statements(self, diffs: List[TableDiff], target_schema: str) -> List[str]:
+        """컬럼/인덱스 변경 ALTER 문 목록 생성"""
+        alter_statements = []
+        for diff in diffs:
+            if diff.diff_type != DiffType.MODIFIED:
+                continue
+
+            # 컬럼 변경
+            for col_diff in diff.column_diffs:
+                if col_diff.diff_type == DiffType.ADDED and col_diff.source_info:
+                    alter_statements.append(self._alter_table(
+                        target_schema, diff.table_name,
+                        f"ADD COLUMN {col_diff.source_info.to_sql_definition()};"
+                    ))
+                elif col_diff.diff_type == DiffType.REMOVED:
+                    alter_statements.append(self._alter_table(
+                        target_schema, diff.table_name,
+                        f"DROP COLUMN {_quote_ident(col_diff.column_name)};"
+                    ))
+                elif col_diff.diff_type == DiffType.MODIFIED and col_diff.source_info:
+                    alter_statements.append(self._alter_table(
+                        target_schema, diff.table_name,
+                        f"MODIFY COLUMN {col_diff.source_info.to_sql_definition()};"
+                    ))
+
+            # 인덱스 변경
+            for idx_diff in diff.index_diffs:
+                if is_primary_key_index(idx_diff.index_name):
+                    continue  # PRIMARY KEY는 별도 처리 필요
+
+                if idx_diff.diff_type == DiffType.ADDED and idx_diff.source_info:
+                    idx_sql = idx_diff.source_info.to_sql_definition(diff.table_name)
+                    alter_statements.append(self._alter_table(
+                        target_schema, diff.table_name, f"ADD {idx_sql};"
+                    ))
+                elif idx_diff.diff_type == DiffType.REMOVED:
+                    alter_statements.append(self._alter_table(
+                        target_schema, diff.table_name,
+                        f"DROP INDEX {_quote_ident(idx_diff.index_name)};"
+                    ))
+                elif idx_diff.diff_type == DiffType.MODIFIED and idx_diff.source_info:
+                    # 인덱스 수정 = 삭제 후 재생성
+                    alter_statements.append(self._alter_table(
+                        target_schema, diff.table_name,
+                        f"DROP INDEX {_quote_ident(idx_diff.index_name)};"
+                    ))
+                    idx_sql = idx_diff.source_info.to_sql_definition(diff.table_name)
+                    alter_statements.append(self._alter_table(
+                        target_schema, diff.table_name, f"ADD {idx_sql};"
+                    ))
+                elif idx_diff.diff_type == DiffType.RENAMED and idx_diff.old_name:
+                    # MySQL 5.7+ RENAME INDEX
+                    alter_statements.append(self._alter_table(
+                        target_schema, diff.table_name,
+                        f"RENAME INDEX {_quote_ident(idx_diff.old_name)} "
+                        f"TO {_quote_ident(idx_diff.index_name)};"
+                    ))
+
+        return alter_statements
+
+    def _generate_fk_adds(self, diffs: List[TableDiff], target_schema: str) -> List[str]:
+        """FK 추가 문 목록 생성 (의존성 복원)"""
+        fk_adds = []
+        for diff in diffs:
+            if diff.diff_type == DiffType.ADDED and diff.source_schema:
+                for fk in diff.source_schema.foreign_keys:
+                    fk_adds.append(self._alter_table(
+                        target_schema, diff.table_name, f"ADD {fk.to_sql_definition()};"
+                    ))
+            elif diff.diff_type == DiffType.MODIFIED:
+                for fk_diff in diff.fk_diffs:
+                    if fk_diff.diff_type in [DiffType.ADDED, DiffType.MODIFIED, DiffType.RENAMED]:
+                        if fk_diff.source_info:
+                            fk_adds.append(self._alter_table(
+                                target_schema, diff.table_name,
+                                f"ADD {fk_diff.source_info.to_sql_definition()};"
+                            ))
+        return fk_adds
+
     def _generate_create_table(self, schema: str, table: TableSchema) -> str:
         """CREATE TABLE 문 생성"""
-        lines = [f"CREATE TABLE `{schema}`.`{table.name}` ("]
+        lines = [f"CREATE TABLE {_quote_ident(schema)}.{_quote_ident(table.name)} ("]
 
         # 컬럼
         col_defs = [f"    {col.to_sql_definition()}" for col in table.columns]
@@ -188,7 +213,7 @@ class SyncScriptGenerator:
 
         # 인덱스 (PRIMARY 제외)
         for idx in table.indexes:
-            if idx.name.upper() != "PRIMARY":
+            if not is_primary_key_index(idx.name):
                 col_defs.append(f"    {idx.to_sql_definition(table.name)}")
 
         # FK


### PR DESCRIPTION
## 요약

Clean Code Round 2 [WP-2.5] — `src/core/schema_*` 5개 파일의 순수 동작 보존 리팩터링. Round 1 머지 이후 코드베이스 기준으로 스펙(`_WP_SPEC.md`)의 라인번호가 무효화되어 있어, 심볼명 기준으로 현재 코드를 찾아 작업했습니다.

## 변경 내역 (findings)

- **CC-096** `SchemaComparator._compare_indexes`/`_compare_foreign_keys`: "이름 매칭 → content-key 기반 rename 감지(첫 미점유 후보 win) → 잔여 ADDED/REMOVED" 3단계 알고리즘이 두 메서드에 중복 구현되어 있던 것을 제네릭 헬퍼 `_compare_named_entities(source_map, target_map, content_key_fn, diff_builder)`로 통합. 각 메서드는 content_key 함수와 엔티티별 diff-builder(`_build_index_diff`/`_build_fk_diff`)를 넘기는 wrapper로 축소. sorted() 순회 순서와 매칭 우선순위 100% 보존.
- **CC-097/CC-105** `SyncScriptGenerator.generate_sync_script`(163줄)를 `_generate_fk_drops`/`_generate_table_drops`/`_generate_table_creates`/`_generate_alter_statements`/`_generate_fk_adds` 5개 phase 메서드로 분해. 13개소 반복되던 `` ALTER TABLE `{schema}`.`{table}` `` 접두어를 `_alter_table` 헬퍼로 통일.
- **CC-106** `schema_diff_models.py`에 `PRIMARY_KEY_INDEX_NAME`/`is_primary_key_index()` 추가, 4개 call site(sync_script_generator ×2, diff_models, severity_classifier)를 헬퍼 호출로 교체. exact-case였던 2곳이 case-insensitive로 통일되지만 MySQL INFORMATION_SCHEMA는 항상 대문자 'PRIMARY' 반환이라 런타임 영향 없음.
- **CC-098** `DIFF_PREFIX_TYPE`/`_NULLABLE`/`_DEFAULT`/`_EXTRA`/`_CHARSET`/`_COLLATION`, `AUTO_INCREMENT_KEYWORD` 공유 상수 추가. 생산자(`_compare_columns`)와 소비자(`_classify_column`/`_classify_extra_change`)가 리터럴 문자열 대신 상수 참조.
- **CC-109** `_quote_ident`/`_quote_idents` 헬퍼 추가, `ColumnInfo`/`IndexInfo`/`ForeignKeyInfo.to_sql_definition()` 및 `SyncScriptGenerator`의 인라인 백틱 조립을 헬퍼로 교체.
- **CC-110/CC-111** `SeverityClassifier._max_severity`의 매 호출 재생성 order dict → 클래스 상수 `_SEVERITY_ORDER` 승격. `_classify_type_change`의 미사용 `diff_text` 파라미터 제거.
- **CC-107** `SchemaExtractor`의 5개 `_get_*` + `extract_table_schema` + `extract_all_tables`가 반복하던 `try/except Exception as e: logger.error(...)` 보일러플레이트를 `_swallow_errors` 헬퍼로 정리. 각 메서드의 반환 계약·로깅 문구·예외 swallow 동작(로깅 있음/없음 포함)을 완전히 보존.

## 이월 (skip)

- **CC-107 심층 수정** (re-raise 도입, error/empty 구분 sentinel): 관찰 가능한 동작 변경이며 `test_get_table_options_defaults_on_failure`/`test_get_row_count_exception_returns_zero`를 깰 수 있어 별도 기능 변경 작업으로 이월.
- **CC-108** (TABLE_ROWS 근사치 교체, N+1 배치화, `_get_table_options`/`_get_row_count` 시그니처 변경): 결과값/쿼리 형태를 바꾸는 기능·성능 변경이라 behavior-preserving 제약과 충돌. 별도 성능 작업으로 이월.

## 검증

- `python -m py_compile` 5개 파일: 통과
- `pytest tests/test_schema_diff.py tests/test_severity_classifier.py tests/test_diff_dialog.py -q`: **98 passed**
- `pytest -q` (전체): **1836 passed, 1 failed** — 실패는 `test_rust_core_packaging.py::test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`로 GitHub CI 의존적인 기존 로컬 flaky 테스트(변경 파일과 무관, 알려진 케이스)

## 위험

- byte-identical 출력 요구(정확한 SQL 문자열 assert하는 테스트 2건)를 만족하는지 전체 테스트로 확인 완료
- Round 1에서 이미 병합된 schema_diff god-file 분리와는 의존성 없음 (본 WP는 별도 5개 파일만 수정)
- 재수출 루트 `src/core/schema_diff.py`는 미변경 (소비자 `diff_dialog.py`/`diff_workers.py` 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)