### PR TITLE
refactor(infra-net-sql): DB delegate 위임 + GitHub 오류요약/SQL 히스토리·파서 정리 (WP-2.9)

### DIFF
--- a/scripts/github_app_secret_codec.py
+++ b/scripts/github_app_secret_codec.py
@@ -1,0 +1,49 @@
+"""GitHub App 자격증명 난독화 코덱 (빌드타임 전용)
+
+src/core/github_app_auth.py의 GitHubAppAuth._obfuscate/generate_embedded_code가
+이 모듈에 위임한다. 런타임 경로인 GitHubAppAuth._deobfuscate는 패키징된 exe에
+scripts/가 포함되지 않으므로 이 모듈을 참조하지 않고 github_app_auth.py 내부에
+그대로 유지한다.
+
+scripts/embed_github_credentials.py도 동일한 난독화 로직 사본을 갖고 있다
+(빌드 파이프라인 독립성을 위한 의도적 중복 — 이 모듈로의 통합은 범위 밖).
+"""
+import base64
+
+# github_app_auth.py의 GitHubAppAuth._OBFUSCATION_KEY와 동일해야 한다.
+OBFUSCATION_KEY = b"TunnelForgeGitHubApp2024"
+
+
+def obfuscate(plain_text: str) -> str:
+    """문자열 난독화"""
+    key = OBFUSCATION_KEY
+    data = plain_text.encode('utf-8')
+    obfuscated = bytes(d ^ key[i % len(key)] for i, d in enumerate(data))
+    return base64.b64encode(obfuscated).decode('ascii')
+
+
+def deobfuscate(obfuscated: str) -> str:
+    """난독화 해제"""
+    try:
+        key = OBFUSCATION_KEY
+        data = base64.b64decode(obfuscated.encode('ascii'))
+        plain = bytes(d ^ key[i % len(key)] for i, d in enumerate(data))
+        return plain.decode('utf-8')
+    except Exception:
+        return ""
+
+
+def generate_embedded_code(app_id: str, private_key: str,
+                            installation_id: str, repo: str) -> str:
+    """빌드 시 GitHubAppAuth에 삽입할 코드 생성"""
+    obf_app_id = obfuscate(app_id)
+    obf_private_key = obfuscate(private_key)
+    obf_installation_id = obfuscate(installation_id)
+    obf_repo = obfuscate(repo)
+
+    return f'''    # 빌드 시 자동 생성된 GitHub App 인증 정보
+    _EMBEDDED_APP_ID: Optional[str] = "{obf_app_id}"
+    _EMBEDDED_PRIVATE_KEY: Optional[str] = "{obf_private_key}"
+    _EMBEDDED_INSTALLATION_ID: Optional[str] = "{obf_installation_id}"
+    _EMBEDDED_REPO: Optional[str] = "{obf_repo}"
+'''

--- a/src/core/db_connector.py
+++ b/src/core/db_connector.py
@@ -6,11 +6,11 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from src.core.logger import get_logger
-from src.core.constants import SYSTEM_SCHEMAS
 from src.core.db_core_service import (
     RustDbConnection,
     RustDbConnector,
     get_shared_db_core_facade,
+    parse_db_version_tuple,
     quote_mysql_ident,
 )
 
@@ -165,6 +165,8 @@ class MySQLConnector:
     def get_schemas(self, use_cache: bool = True) -> List[str]:
         """스키마(데이터베이스) 목록 조회 (시스템 DB 제외)
 
+        조회 자체는 RustDbConnector delegate에 위임하고, TTL 캐시만 이 wrapper가 감싼다.
+
         Args:
             use_cache: 캐시 사용 여부 (기본 True)
 
@@ -182,30 +184,29 @@ class MySQLConnector:
                 return cached
 
         try:
-            with self.connection.cursor() as cursor:
-                cursor.execute("SHOW DATABASES")
-                exclude = SYSTEM_SCHEMAS
-                result = [row['Database'] for row in cursor.fetchall()
-                          if row['Database'] not in exclude]
+            self._delegate.connection = self.connection
+            result = self._delegate.get_schemas()
 
-                # 캐시에 저장
-                if use_cache and self._cache:
-                    self._cache.set(cache_key, result)
+            # 캐시에 저장
+            if use_cache and self._cache:
+                self._cache.set(cache_key, result)
 
-                return result
+            return result
         except Exception as e:
             logger.error(f"스키마 조회 오류: {e}")
             return []
 
     def schema_exists(self, schema_name: str) -> bool:
-        """특정 스키마 존재 여부 확인 (시스템 DB 포함)"""
+        """특정 스키마 존재 여부 확인 (시스템 DB 포함)
+
+        조회는 RustDbConnector delegate에 위임한다.
+        """
         if not self.connection:
             return False
 
         try:
-            with self.connection.cursor() as cursor:
-                cursor.execute("SHOW DATABASES LIKE %s", (schema_name,))
-                return cursor.fetchone() is not None
+            self._delegate.connection = self.connection
+            return self._delegate.schema_exists(schema_name)
         except Exception:
             return False
 
@@ -305,26 +306,7 @@ class MySQLConnector:
         Returns:
             버전 튜플 (major, minor, patch) 또는 연결 실패 시 (0, 0, 0)
         """
-        if not self.connection:
-            return (0, 0, 0)
-
-        try:
-            with self.connection.cursor() as cursor:
-                cursor.execute("SELECT VERSION()")
-                result = cursor.fetchone()
-                if result:
-                    version_str = list(result.values())[0]
-                    # "8.0.32-ubuntu" → "8.0.32"
-                    version_clean = version_str.split('-')[0]
-                    parts = version_clean.split('.')
-                    major = int(parts[0]) if len(parts) > 0 else 0
-                    minor = int(parts[1]) if len(parts) > 1 else 0
-                    patch = int(parts[2]) if len(parts) > 2 else 0
-                    return (major, minor, patch)
-        except Exception as e:
-            logger.error(f"버전 조회 오류: {e}")
-
-        return (0, 0, 0)
+        return parse_db_version_tuple(self.get_db_version_string())
 
     def get_db_version_string(self) -> str:
         """DB 버전 문자열 반환 (원본)"""

--- a/src/core/error_summary_builder.py
+++ b/src/core/error_summary_builder.py
@@ -1,0 +1,186 @@
+"""오류 요약 생성 순수 로직 (네트워크 의존 없음)
+
+GitHubIssueReporter가 사용하던 오류 메시지 정리/핵심 오류 추출/핑거프린트
+생성/이슈 본문 생성 로직을 requests 등 네트워크 의존 없이 분리한 모듈.
+GitHubIssueReporter는 이 클래스의 인스턴스를 보유하고 얇은 위임 메서드로
+기존 private 메서드(_sanitize_error_message 등)를 유지한다.
+"""
+import re
+import hashlib
+from datetime import datetime
+from typing import Dict, Optional
+
+
+class ErrorSummaryBuilder:
+    """오류 요약(제목/본문/라벨/핑거프린트) 생성기 — 순수 로직, 네트워크 비의존"""
+
+    # 이슈 제목에 포함할 핵심 오류 미리보기 길이
+    TITLE_PREVIEW_LEN = 80
+    # _extract_core_error가 잘라내는 핵심 오류 문자열 최대 길이
+    CORE_ERROR_MAX_LEN = 100
+    # 이슈 본문에 포함할 전체 오류 메시지 미리보기 길이
+    BODY_PREVIEW_LEN = 2000
+
+    def sanitize_error_message(self, message: str) -> str:
+        """민감 정보 제거 (IP, 비밀번호, 경로 등)"""
+        sanitized = message
+
+        # IP 주소 마스킹
+        sanitized = re.sub(
+            r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b',
+            '[IP_HIDDEN]',
+            sanitized
+        )
+
+        # 비밀번호 패턴 마스킹
+        sanitized = re.sub(
+            r'(password[=:]\s*)[^\s]+',
+            r'\1[HIDDEN]',
+            sanitized,
+            flags=re.IGNORECASE
+        )
+
+        # 파일 경로 마스킹 (사용자명 부분)
+        sanitized = re.sub(
+            r'(C:\\Users\\)[^\\]+',
+            r'\1[USER]',
+            sanitized
+        )
+        sanitized = re.sub(
+            r'(/home/|/Users/)[^/]+',
+            r'\1[USER]',
+            sanitized
+        )
+
+        return sanitized
+
+    def extract_core_error(self, message: str) -> str:
+        """오류 메시지에서 핵심 오류 추출"""
+        # MySQL 오류 코드 패턴
+        mysql_error = re.search(r'(ERROR \d+.*?)(?:\n|$)', message)
+        if mysql_error:
+            return mysql_error.group(1).strip()
+
+        # 외부 도구 오류 패턴
+        tool_error = re.search(r'(?:Error|ERROR):\s*(.+?)(?:\n|$)', message)
+        if tool_error:
+            return tool_error.group(1).strip()
+
+        # Duplicate entry 등 특정 패턴
+        dup_error = re.search(r"(Duplicate entry .+ for key .+)", message)
+        if dup_error:
+            return dup_error.group(1).strip()
+
+        # Foreign key 오류
+        fk_error = re.search(r"(Cannot add or update a child row.*)", message)
+        if fk_error:
+            return fk_error.group(1)[:self.CORE_ERROR_MAX_LEN].strip()
+
+        # Deadlock
+        if 'deadlock' in message.lower():
+            return "Deadlock detected during operation"
+
+        # Timeout
+        if 'timeout' in message.lower() or '시간 초과' in message:
+            return "Operation timeout"
+
+        # 기본: 첫 줄 또는 100자
+        first_line = message.split('\n')[0].strip()
+        return first_line[:self.CORE_ERROR_MAX_LEN] if len(first_line) > self.CORE_ERROR_MAX_LEN else first_line
+
+    def generate_fingerprint(self, error_type: str, core_error: str) -> str:
+        """중복 검사용 핑거프린트 생성"""
+        # 숫자와 특수 문자를 제거하여 일반화
+        normalized = re.sub(r'[\d\'"`]', '', core_error.lower())
+        normalized = re.sub(r'\s+', ' ', normalized).strip()
+
+        # 해시 생성
+        hash_input = f"{error_type}:{normalized}"
+        return hashlib.md5(hash_input.encode()).hexdigest()[:16]
+
+    def generate_issue_body(self, operation: str, core_error: str,
+                             full_message: str, context: Dict) -> str:
+        """이슈 본문 생성"""
+        timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+        body = f"""## 오류 요약
+**작업 유형**: {operation}
+**핵심 오류**: `{core_error}`
+**발생 시간**: {timestamp}
+
+## 상세 오류 메시지
+```
+{full_message[:self.BODY_PREVIEW_LEN]}
+```
+
+"""
+        # 컨텍스트 정보 추가
+        if context:
+            body += "## 컨텍스트 정보\n"
+            if context.get('schema'):
+                body += f"- **스키마**: `{context['schema']}`\n"
+            if context.get('tables'):
+                tables = context['tables']
+                if len(tables) <= 5:
+                    body += f"- **테이블**: `{', '.join(tables)}`\n"
+                else:
+                    body += f"- **테이블**: `{', '.join(tables[:5])}` 외 {len(tables)-5}개\n"
+            if context.get('mode'):
+                body += f"- **모드**: `{context['mode']}`\n"
+            if context.get('failed_tables'):
+                failed = context['failed_tables']
+                body += f"- **실패한 테이블**: `{', '.join(failed[:10])}`\n"
+            body += "\n"
+
+        body += """---
+> 이 이슈는 TunnelForge에서 자동으로 생성되었습니다.
+"""
+        return body
+
+    def summarize_error(self, error_type: str, error_message: str,
+                         context: Optional[Dict] = None) -> Dict:
+        """
+        오류를 요약하여 이슈 제목과 본문 생성
+
+        Args:
+            error_type: 오류 유형 ("export" 또는 "import")
+            error_message: 오류 메시지
+            context: 추가 컨텍스트 (schema, tables, timestamp 등)
+
+        Returns:
+            Dict with 'title', 'body', 'labels', 'fingerprint', 'core_error', 'full_message'
+        """
+        context = context or {}
+
+        # 오류 메시지 정리 (민감 정보 제거)
+        sanitized_message = self.sanitize_error_message(error_message)
+
+        # 핵심 오류 추출
+        core_error = self.extract_core_error(sanitized_message)
+
+        # 이슈 제목 생성
+        operation = "Export" if error_type == "export" else "Import"
+        title = f"[{operation} Error] {core_error[:self.TITLE_PREVIEW_LEN]}"
+
+        # 이슈 본문 생성
+        body = self.generate_issue_body(
+            operation=operation,
+            core_error=core_error,
+            full_message=sanitized_message,
+            context=context
+        )
+
+        # 라벨 설정
+        labels = ["bug", f"{error_type}-error", "auto-reported"]
+
+        # 중복 검사용 핑거프린트 (핵심 오류 기반)
+        fingerprint = self.generate_fingerprint(error_type, core_error)
+
+        return {
+            "title": title,
+            "body": body,
+            "labels": labels,
+            "fingerprint": fingerprint,
+            "core_error": core_error,
+            "full_message": sanitized_message,
+        }

--- a/src/core/github_app_auth.py
+++ b/src/core/github_app_auth.py
@@ -42,6 +42,10 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 
+from src.core.logger import get_logger
+
+logger = get_logger(__name__)
+
 
 class GitHubAppAuth:
     """GitHub App 인증 관리"""
@@ -245,7 +249,7 @@ class GitHubAppAuth:
             return self._cached_token
 
         except Exception as e:
-            print(f"Installation Token 발급 실패: {e}")
+            logger.error(f"Installation Token 발급 실패: {e}")
             return None
 
     def get_headers(self) -> dict:
@@ -319,19 +323,21 @@ class GitHubAppAuth:
             return False, f"예상치 못한 오류: {str(e)}"
 
     # === 난독화 유틸리티 ===
+    #
+    # _obfuscate/generate_embedded_code는 빌드타임 전용 도구라
+    # scripts/github_app_secret_codec.py로 위임한다. _deobfuscate는 런타임에
+    # _EMBEDDED_PRIVATE_KEY를 복호화하는 경로이므로(패키징된 exe에 scripts/가
+    # 포함되지 않음) scripts import 없이 이 클래스 내부 구현을 그대로 유지한다.
 
     @classmethod
     def _obfuscate(cls, plain_text: str) -> str:
-        """문자열 난독화"""
-        import base64
-        key = cls._OBFUSCATION_KEY
-        data = plain_text.encode('utf-8')
-        obfuscated = bytes(d ^ key[i % len(key)] for i, d in enumerate(data))
-        return base64.b64encode(obfuscated).decode('ascii')
+        """문자열 난독화 (빌드타임 전용 — scripts/github_app_secret_codec에 위임)"""
+        from scripts.github_app_secret_codec import obfuscate
+        return obfuscate(plain_text)
 
     @classmethod
     def _deobfuscate(cls, obfuscated: str) -> str:
-        """난독화 해제"""
+        """난독화 해제 (런타임 경로 — _EMBEDDED_PRIVATE_KEY 복호화에 사용)"""
         try:
             import base64
             key = cls._OBFUSCATION_KEY
@@ -344,18 +350,9 @@ class GitHubAppAuth:
     @classmethod
     def generate_embedded_code(cls, app_id: str, private_key: str,
                                 installation_id: str, repo: str) -> str:
-        """빌드 시 삽입할 코드 생성"""
-        obf_app_id = cls._obfuscate(app_id)
-        obf_private_key = cls._obfuscate(private_key)
-        obf_installation_id = cls._obfuscate(installation_id)
-        obf_repo = cls._obfuscate(repo)
-
-        return f'''    # 빌드 시 자동 생성된 GitHub App 인증 정보
-    _EMBEDDED_APP_ID: Optional[str] = "{obf_app_id}"
-    _EMBEDDED_PRIVATE_KEY: Optional[str] = "{obf_private_key}"
-    _EMBEDDED_INSTALLATION_ID: Optional[str] = "{obf_installation_id}"
-    _EMBEDDED_REPO: Optional[str] = "{obf_repo}"
-'''
+        """빌드 시 삽입할 코드 생성 (빌드타임 전용 — scripts/github_app_secret_codec에 위임)"""
+        from scripts.github_app_secret_codec import generate_embedded_code
+        return generate_embedded_code(app_id, private_key, installation_id, repo)
 
 
 def get_github_app_auth() -> Optional[GitHubAppAuth]:

--- a/src/core/github_issue_reporter.py
+++ b/src/core/github_issue_reporter.py
@@ -8,10 +8,11 @@ Export/Import 오류 발생 시:
 """
 
 import re
-import hashlib
 from datetime import datetime
 from typing import Optional, Tuple, Dict
 from difflib import SequenceMatcher
+
+from src.core.error_summary_builder import ErrorSummaryBuilder
 
 try:
     import requests
@@ -28,6 +29,9 @@ class GitHubIssueReporter:
     # 유사도 임계값 (0.0 ~ 1.0)
     SIMILARITY_THRESHOLD = 0.6
 
+    # add_comment가 재발생 코멘트에 포함하는 오류 메시지 미리보기 길이
+    COMMENT_PREVIEW_LEN = 1000
+
     def __init__(self, token: str, repo: str, headers: Optional[Dict] = None):
         """
         Args:
@@ -39,6 +43,7 @@ class GitHubIssueReporter:
         self.repo = repo
         self._github_app = None  # GitHub App 인스턴스 (동적 토큰 갱신용)
         self._last_error_status: Optional[int] = None  # 마지막 API 실패의 HTTP status (재시도 판단용)
+        self._summary = ErrorSummaryBuilder()  # 오류 요약 순수 로직 (네트워크 비의존)
 
         if headers:
             self._headers = headers
@@ -78,7 +83,7 @@ class GitHubIssueReporter:
     def summarize_error(self, error_type: str, error_message: str,
                         context: Optional[Dict] = None) -> Dict:
         """
-        오류를 요약하여 이슈 제목과 본문 생성
+        오류를 요약하여 이슈 제목과 본문 생성 (ErrorSummaryBuilder에 위임)
 
         Args:
             error_type: 오류 유형 ("export" 또는 "import")
@@ -86,157 +91,26 @@ class GitHubIssueReporter:
             context: 추가 컨텍스트 (schema, tables, timestamp 등)
 
         Returns:
-            Dict with 'title', 'body', 'labels', 'fingerprint'
+            Dict with 'title', 'body', 'labels', 'fingerprint', 'core_error', 'full_message'
         """
-        context = context or {}
-
-        # 오류 메시지 정리 (민감 정보 제거)
-        sanitized_message = self._sanitize_error_message(error_message)
-
-        # 핵심 오류 추출
-        core_error = self._extract_core_error(sanitized_message)
-
-        # 이슈 제목 생성
-        operation = "Export" if error_type == "export" else "Import"
-        title = f"[{operation} Error] {core_error[:80]}"
-
-        # 이슈 본문 생성
-        body = self._generate_issue_body(
-            operation=operation,
-            core_error=core_error,
-            full_message=sanitized_message,
-            context=context
-        )
-
-        # 라벨 설정
-        labels = ["bug", f"{error_type}-error", "auto-reported"]
-
-        # 중복 검사용 핑거프린트 (핵심 오류 기반)
-        fingerprint = self._generate_fingerprint(error_type, core_error)
-
-        return {
-            "title": title,
-            "body": body,
-            "labels": labels,
-            "fingerprint": fingerprint,
-            "core_error": core_error
-        }
+        return self._summary.summarize_error(error_type, error_message, context)
 
     def _sanitize_error_message(self, message: str) -> str:
-        """민감 정보 제거 (IP, 비밀번호, 경로 등)"""
-        sanitized = message
-
-        # IP 주소 마스킹
-        sanitized = re.sub(
-            r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b',
-            '[IP_HIDDEN]',
-            sanitized
-        )
-
-        # 비밀번호 패턴 마스킹
-        sanitized = re.sub(
-            r'(password[=:]\s*)[^\s]+',
-            r'\1[HIDDEN]',
-            sanitized,
-            flags=re.IGNORECASE
-        )
-
-        # 파일 경로 마스킹 (사용자명 부분)
-        sanitized = re.sub(
-            r'(C:\\Users\\)[^\\]+',
-            r'\1[USER]',
-            sanitized
-        )
-        sanitized = re.sub(
-            r'(/home/|/Users/)[^/]+',
-            r'\1[USER]',
-            sanitized
-        )
-
-        return sanitized
+        """민감 정보 제거 (IP, 비밀번호, 경로 등) — ErrorSummaryBuilder에 위임"""
+        return self._summary.sanitize_error_message(message)
 
     def _extract_core_error(self, message: str) -> str:
-        """오류 메시지에서 핵심 오류 추출"""
-        # MySQL 오류 코드 패턴
-        mysql_error = re.search(r'(ERROR \d+.*?)(?:\n|$)', message)
-        if mysql_error:
-            return mysql_error.group(1).strip()
-
-        # 외부 도구 오류 패턴
-        tool_error = re.search(r'(?:Error|ERROR):\s*(.+?)(?:\n|$)', message)
-        if tool_error:
-            return tool_error.group(1).strip()
-
-        # Duplicate entry 등 특정 패턴
-        dup_error = re.search(r"(Duplicate entry .+ for key .+)", message)
-        if dup_error:
-            return dup_error.group(1).strip()
-
-        # Foreign key 오류
-        fk_error = re.search(r"(Cannot add or update a child row.*)", message)
-        if fk_error:
-            return fk_error.group(1)[:100].strip()
-
-        # Deadlock
-        if 'deadlock' in message.lower():
-            return "Deadlock detected during operation"
-
-        # Timeout
-        if 'timeout' in message.lower() or '시간 초과' in message:
-            return "Operation timeout"
-
-        # 기본: 첫 줄 또는 100자
-        first_line = message.split('\n')[0].strip()
-        return first_line[:100] if len(first_line) > 100 else first_line
+        """오류 메시지에서 핵심 오류 추출 — ErrorSummaryBuilder에 위임"""
+        return self._summary.extract_core_error(message)
 
     def _generate_issue_body(self, operation: str, core_error: str,
                              full_message: str, context: Dict) -> str:
-        """이슈 본문 생성"""
-        timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-
-        body = f"""## 오류 요약
-**작업 유형**: {operation}
-**핵심 오류**: `{core_error}`
-**발생 시간**: {timestamp}
-
-## 상세 오류 메시지
-```
-{full_message[:2000]}
-```
-
-"""
-        # 컨텍스트 정보 추가
-        if context:
-            body += "## 컨텍스트 정보\n"
-            if context.get('schema'):
-                body += f"- **스키마**: `{context['schema']}`\n"
-            if context.get('tables'):
-                tables = context['tables']
-                if len(tables) <= 5:
-                    body += f"- **테이블**: `{', '.join(tables)}`\n"
-                else:
-                    body += f"- **테이블**: `{', '.join(tables[:5])}` 외 {len(tables)-5}개\n"
-            if context.get('mode'):
-                body += f"- **모드**: `{context['mode']}`\n"
-            if context.get('failed_tables'):
-                failed = context['failed_tables']
-                body += f"- **실패한 테이블**: `{', '.join(failed[:10])}`\n"
-            body += "\n"
-
-        body += """---
-> 이 이슈는 TunnelForge에서 자동으로 생성되었습니다.
-"""
-        return body
+        """이슈 본문 생성 — ErrorSummaryBuilder에 위임"""
+        return self._summary.generate_issue_body(operation, core_error, full_message, context)
 
     def _generate_fingerprint(self, error_type: str, core_error: str) -> str:
-        """중복 검사용 핑거프린트 생성"""
-        # 숫자와 특수 문자를 제거하여 일반화
-        normalized = re.sub(r'[\d\'"`]', '', core_error.lower())
-        normalized = re.sub(r'\s+', ' ', normalized).strip()
-
-        # 해시 생성
-        hash_input = f"{error_type}:{normalized}"
-        return hashlib.md5(hash_input.encode()).hexdigest()[:16]
+        """중복 검사용 핑거프린트 생성 — ErrorSummaryBuilder에 위임"""
+        return self._summary.generate_fingerprint(error_type, core_error)
 
     def find_similar_issue(self, summary: Dict) -> Optional[Dict]:
         """
@@ -380,12 +254,13 @@ class GitHubIssueReporter:
             url = f"{self.GITHUB_API_BASE}/repos/{self.repo}/issues/{issue_number}/comments"
 
             timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+            error_preview = (summary.get('full_message') or summary.get('core_error', ''))[:self.COMMENT_PREVIEW_LEN]
             comment_body = f"""## 동일 오류 재발생
 **발생 시간**: {timestamp}
 
 ### 오류 메시지
 ```
-{summary.get('body', '').split('## 상세 오류 메시지')[1].split('```')[1][:1000] if '## 상세 오류 메시지' in summary.get('body', '') else summary.get('core_error', '')}
+{error_preview}
 ```
 
 ---

--- a/src/core/postgres_connector.py
+++ b/src/core/postgres_connector.py
@@ -1,7 +1,12 @@
 """PostgreSQL database connection helpers."""
 from typing import Any, Optional, Tuple
 
-from src.core.db_core_service import DbEndpoint, RustDbConnection, get_shared_db_core_facade
+from src.core.db_core_service import (
+    DbEndpoint,
+    RustDbConnection,
+    RustDbConnector,
+    get_shared_db_core_facade,
+)
 
 
 class PostgresConnector:
@@ -45,14 +50,15 @@ class PostgresConnector:
                 self.connection = None
 
     def schema_exists(self, schema_name: Optional[str]) -> bool:
+        """스키마 존재 여부 확인 (조회는 RustDbConnector delegate에 위임)"""
         if not schema_name or not self.connection:
             return True
         try:
-            with self.connection.cursor() as cursor:
-                cursor.execute(
-                    "SELECT 1 FROM information_schema.schemata WHERE schema_name = %s",
-                    (schema_name,),
-                )
-                return cursor.fetchone() is not None
+            delegate = RustDbConnector(
+                "postgresql", self.host, self.port, self.user, self.password,
+                database=self.database, facade=self.facade,
+            )
+            delegate.connection = self.connection
+            return delegate.schema_exists(schema_name)
         except Exception:
             return False

--- a/src/core/sql_history.py
+++ b/src/core/sql_history.py
@@ -9,10 +9,29 @@ SQL 쿼리 히스토리 관리
 import os
 import json
 import uuid
+from dataclasses import dataclass
 from datetime import datetime
 from typing import List, Dict, Any, Tuple, Optional
 
+from src.core.logger import get_logger
 from src.core.platform_paths import sql_history_file
+
+logger = get_logger('sql_history')
+
+
+def _matches_history_id(entry: Dict[str, Any], history_id: str) -> bool:
+    """엔트리가 특정 history_id(UUID 또는 timestamp, 하위 호환성)와 일치하는지 확인"""
+    return entry.get('id') == history_id or entry.get('timestamp') == history_id
+
+
+@dataclass
+class HistorySearchFilter:
+    """search_advanced의 다중 필터 조건"""
+    keyword: Optional[str] = None
+    date_from: Optional[datetime] = None
+    date_to: Optional[datetime] = None
+    success_only: Optional[bool] = None
+    favorites_only: bool = False
 
 
 class SQLHistory:
@@ -42,7 +61,8 @@ class SQLHistory:
             with open(self.history_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
                 return data.get('history', [])
-        except (json.JSONDecodeError, IOError):
+        except (json.JSONDecodeError, IOError) as e:
+            logger.warning(f"히스토리 파일 로드 실패: {e}")
             return []
 
     def _save_history(self, history: List[Dict[str, Any]]):
@@ -51,7 +71,7 @@ class SQLHistory:
             with open(self.history_file, 'w', encoding='utf-8') as f:
                 json.dump({'history': history}, f, ensure_ascii=False, indent=2)
         except IOError as e:
-            print(f"히스토리 저장 오류: {e}")
+            logger.error(f"히스토리 저장 오류: {e}")
 
     def add_query(self, query: str, success: bool, result_count: int = 0,
                   execution_time: float = 0.0, status: str = 'completed', error: str = None) -> str:
@@ -105,8 +125,7 @@ class SQLHistory:
         history = self._load_history()
 
         for entry in history:
-            # ID 또는 timestamp로 매칭 (하위 호환성)
-            if entry.get('id') == history_id or entry.get('timestamp') == history_id:
+            if _matches_history_id(entry, history_id):
                 entry['status'] = new_status
                 break
 
@@ -124,12 +143,9 @@ class SQLHistory:
             return
 
         history = self._load_history()
-        ids_set = set(history_ids)
 
         for entry in history:
-            # ID 또는 timestamp로 매칭 (하위 호환성)
-            entry_id = entry.get('id') or entry.get('timestamp')
-            if entry_id in ids_set or entry.get('timestamp') in ids_set:
+            if any(_matches_history_id(entry, hid) for hid in history_ids):
                 entry['status'] = new_status
 
         self._save_history(history)
@@ -227,35 +243,50 @@ class SQLHistory:
             (결과 목록, 전체 결과 수) 튜플
         """
         history = self._load_history()
+        filt = HistorySearchFilter(
+            keyword=keyword,
+            date_from=date_from,
+            date_to=date_to,
+            success_only=success_only,
+            favorites_only=favorites_only,
+        )
+        results = self._apply_filters(history, filt)
+
+        total = len(results)
+        return results[offset:offset + limit], total
+
+    def _apply_filters(
+        self, history: List[Dict[str, Any]], filt: HistorySearchFilter
+    ) -> List[Dict[str, Any]]:
+        """HistorySearchFilter 조건에 따라 히스토리 목록을 순차 필터링"""
         results = history
 
         # 키워드 필터
-        if keyword:
-            keyword_lower = keyword.lower()
+        if filt.keyword:
+            keyword_lower = filt.keyword.lower()
             results = [r for r in results
                        if keyword_lower in r.get('query', '').lower()]
 
         # 날짜 범위 필터
-        if date_from:
+        if filt.date_from:
             results = [r for r in results
-                       if self._parse_timestamp(r.get('timestamp', '')) >= date_from]
+                       if self._parse_timestamp(r.get('timestamp', '')) >= filt.date_from]
 
-        if date_to:
+        if filt.date_to:
             # date_to를 하루의 끝으로 설정 (23:59:59)
-            date_to_end = datetime(date_to.year, date_to.month, date_to.day, 23, 59, 59)
+            date_to_end = datetime(filt.date_to.year, filt.date_to.month, filt.date_to.day, 23, 59, 59)
             results = [r for r in results
                        if self._parse_timestamp(r.get('timestamp', '')) <= date_to_end]
 
         # 성공/실패 필터
-        if success_only is not None:
-            results = [r for r in results if r.get('success') == success_only]
+        if filt.success_only is not None:
+            results = [r for r in results if r.get('success') == filt.success_only]
 
         # 즐겨찾기 필터
-        if favorites_only:
+        if filt.favorites_only:
             results = [r for r in results if r.get('is_favorite', False)]
 
-        total = len(results)
-        return results[offset:offset + limit], total
+        return results
 
     def _parse_timestamp(self, timestamp_str: str) -> datetime:
         """타임스탬프 문자열을 datetime으로 변환"""
@@ -277,8 +308,7 @@ class SQLHistory:
         history = self._load_history()
 
         for entry in history:
-            # ID 또는 timestamp로 매칭
-            if entry.get('id') == history_id or entry.get('timestamp') == history_id:
+            if _matches_history_id(entry, history_id):
                 entry['is_favorite'] = not entry.get('is_favorite', False)
                 self._save_history(history)
                 return entry['is_favorite']

--- a/src/core/sql_statement_parser.py
+++ b/src/core/sql_statement_parser.py
@@ -1,6 +1,6 @@
 """SQL statement splitting helpers shared by execution entry points."""
 from dataclasses import dataclass
-from typing import Optional
+from typing import Callable, Optional, Tuple
 
 
 @dataclass
@@ -84,41 +84,19 @@ def parse_sql_statement_ranges(sql_text: str) -> list[SqlStatement]:
                     continue
 
         if line_comment:
-            append_text(char, i)
-            if char == "\n":
-                line_comment = False
-            i += 1
+            i, line_comment = _consume_line_comment(sql_text, i, append_text)
             continue
 
         if block_comment:
-            append_text(char, i)
-            if char == "*" and next_char == "/":
-                append_text(next_char, i + 1)
-                block_comment = False
-                i += 2
-            else:
-                i += 1
+            i, block_comment = _consume_block_comment(sql_text, i, append_text)
             continue
 
         if dollar_quote:
-            if sql_text.startswith(dollar_quote, i):
-                append_text(dollar_quote, i)
-                i += len(dollar_quote)
-                dollar_quote = None
-            else:
-                append_text(char, i)
-                i += 1
+            i, dollar_quote = _consume_dollar_quote(sql_text, i, dollar_quote, append_text)
             continue
 
         if quote:
-            append_text(char, i)
-            if escape_next:
-                escape_next = False
-            elif char == "\\":
-                escape_next = True
-            elif char == quote:
-                quote = None
-            i += 1
+            i, quote, escape_next = _consume_quoted_string(sql_text, i, quote, escape_next, append_text)
             continue
 
         if delimiter != ";" and delimiter and sql_text.startswith(delimiter, i):
@@ -168,6 +146,59 @@ def parse_sql_statement_ranges(sql_text: str) -> list[SqlStatement]:
 
     flush(len(sql_text), len(sql_text))
     return statements
+
+
+AppendText = Callable[[str, int], None]
+
+
+def _consume_line_comment(sql_text: str, i: int, append_text: AppendText) -> Tuple[int, bool]:
+    """줄 주석(`--`/`#`) 내부 문자 1개를 소비. Returns (다음 커서 위치, 주석 지속 여부)."""
+    char = sql_text[i]
+    append_text(char, i)
+    if char == "\n":
+        return i + 1, False
+    return i + 1, True
+
+
+def _consume_block_comment(sql_text: str, i: int, append_text: AppendText) -> Tuple[int, bool]:
+    """블록 주석(`/* ... */`) 내부 문자를 소비. Returns (다음 커서 위치, 주석 지속 여부)."""
+    char = sql_text[i]
+    next_char = sql_text[i + 1] if i + 1 < len(sql_text) else ""
+    append_text(char, i)
+    if char == "*" and next_char == "/":
+        append_text(next_char, i + 1)
+        return i + 2, False
+    return i + 1, True
+
+
+def _consume_dollar_quote(
+    sql_text: str, i: int, dollar_quote: str, append_text: AppendText
+) -> Tuple[int, Optional[str]]:
+    """PostgreSQL `$tag$ ... $tag$` 내부 문자를 소비. Returns (다음 커서 위치, 갱신된 dollar_quote 상태(None이면 종료))."""
+    if sql_text.startswith(dollar_quote, i):
+        append_text(dollar_quote, i)
+        return i + len(dollar_quote), None
+    char = sql_text[i]
+    append_text(char, i)
+    return i + 1, dollar_quote
+
+
+def _consume_quoted_string(
+    sql_text: str, i: int, quote: str, escape_next: bool, append_text: AppendText
+) -> Tuple[int, Optional[str], bool]:
+    """따옴표(`'`/`"`/backtick) 문자열 내부 문자를 소비.
+
+    Returns (다음 커서 위치, 갱신된 quote 상태(None이면 종료), 갱신된 escape_next).
+    """
+    char = sql_text[i]
+    append_text(char, i)
+    if escape_next:
+        return i + 1, quote, False
+    if char == "\\":
+        return i + 1, quote, True
+    if char == quote:
+        return i + 1, None, False
+    return i + 1, quote, False
 
 
 def read_dollar_quote(sql_text: str, start: int) -> str:

--- a/src/core/update_downloader.py
+++ b/src/core/update_downloader.py
@@ -201,7 +201,7 @@ class UpdateDownloader:
             response = requests.get(
                 self.download_url,
                 stream=True,
-                timeout=30
+                timeout=self.timeout
             )
             response.raise_for_status()
 

--- a/tests/test_error_summary_builder.py
+++ b/tests/test_error_summary_builder.py
@@ -1,0 +1,135 @@
+"""
+ErrorSummaryBuilder 단위 테스트
+
+GitHubIssueReporter에서 분리된 순수 오류 요약 로직(민감정보 제거, 핵심 오류
+추출, 핑거프린트 생성, 이슈 본문 생성)을 네트워크 의존 없이 검증합니다.
+"""
+import pytest
+
+from src.core.error_summary_builder import ErrorSummaryBuilder
+
+
+@pytest.fixture
+def builder():
+    return ErrorSummaryBuilder()
+
+
+class TestSanitizeErrorMessage:
+
+    def test_ip_address_masked(self, builder):
+        msg = "Connection failed to 192.168.1.100:3306"
+        result = builder.sanitize_error_message(msg)
+        assert '192.168.1.100' not in result
+        assert '[IP_HIDDEN]' in result
+
+    def test_password_masked(self, builder):
+        msg = "Access denied for password=mysecret123"
+        result = builder.sanitize_error_message(msg)
+        assert 'mysecret123' not in result
+        assert '[HIDDEN]' in result
+
+    def test_windows_user_path_masked(self, builder):
+        msg = r"Error in C:\Users\JohnDoe\Documents\file.txt"
+        result = builder.sanitize_error_message(msg)
+        assert 'JohnDoe' not in result
+        assert '[USER]' in result
+
+    def test_clean_message_unchanged(self, builder):
+        msg = "Table 'users' doesn't exist"
+        assert builder.sanitize_error_message(msg) == msg
+
+
+class TestExtractCoreError:
+
+    def test_mysql_error_code(self, builder):
+        msg = "ERROR 1045 (28000): Access denied for user"
+        assert 'ERROR 1045' in builder.extract_core_error(msg)
+
+    def test_duplicate_entry(self, builder):
+        msg = "Duplicate entry '42' for key 'PRIMARY'"
+        result = builder.extract_core_error(msg)
+        assert 'Duplicate entry' in result
+        assert 'PRIMARY' in result
+
+    def test_deadlock(self, builder):
+        msg = "Lock wait timeout exceeded; try restarting transaction (deadlock)"
+        assert builder.extract_core_error(msg) == "Deadlock detected during operation"
+
+    def test_korean_timeout(self, builder):
+        assert builder.extract_core_error("작업 시간 초과") == "Operation timeout"
+
+    def test_long_message_truncated_to_core_error_max_len(self, builder):
+        msg = "x" * 200
+        result = builder.extract_core_error(msg)
+        assert len(result) == builder.CORE_ERROR_MAX_LEN
+
+
+class TestGenerateFingerprint:
+
+    def test_same_error_same_fingerprint(self, builder):
+        fp1 = builder.generate_fingerprint("export", "Access denied")
+        fp2 = builder.generate_fingerprint("export", "Access denied")
+        assert fp1 == fp2
+
+    def test_different_type_different_fingerprint(self, builder):
+        fp1 = builder.generate_fingerprint("export", "Access denied")
+        fp2 = builder.generate_fingerprint("import", "Access denied")
+        assert fp1 != fp2
+
+    def test_fingerprint_length(self, builder):
+        assert len(builder.generate_fingerprint("export", "some error")) == 16
+
+
+class TestGenerateIssueBody:
+
+    def test_contains_core_error(self, builder):
+        body = builder.generate_issue_body("Export", "ERROR 1045", "ERROR 1045: full", {})
+        assert 'ERROR 1045' in body
+
+    def test_context_included(self, builder):
+        context = {'schema': 'mydb', 'tables': ['users', 'orders'], 'mode': 'full'}
+        body = builder.generate_issue_body("Export", "err", "full message", context)
+        assert 'mydb' in body
+        assert 'users' in body
+
+    def test_many_tables_truncated(self, builder):
+        tables = [f'table_{i}' for i in range(10)]
+        body = builder.generate_issue_body("Export", "err", "msg", {'tables': tables})
+        assert '외' in body
+
+    def test_body_preview_truncated_to_body_preview_len(self, builder):
+        long_message = "x" * (builder.BODY_PREVIEW_LEN + 500)
+        body = builder.generate_issue_body("Export", "err", long_message, {})
+        assert long_message not in body
+
+
+class TestSummarizeError:
+
+    def test_title_format(self, builder):
+        summary = builder.summarize_error("export", "ERROR 1045: Access denied")
+        assert summary['title'].startswith('[Export Error]')
+
+    def test_labels_include_error_type(self, builder):
+        summary = builder.summarize_error("export", "some error")
+        assert "bug" in summary['labels']
+        assert "export-error" in summary['labels']
+        assert "auto-reported" in summary['labels']
+
+    def test_full_message_present_and_sanitized(self, builder):
+        summary = builder.summarize_error(
+            "export", "Failed connecting to 10.0.0.1 with password=secret123"
+        )
+        assert 'full_message' in summary
+        assert '10.0.0.1' not in summary['full_message']
+        assert 'secret123' not in summary['full_message']
+
+    def test_fingerprint_present(self, builder):
+        summary = builder.summarize_error("export", "some error")
+        assert len(summary['fingerprint']) == 16
+
+    def test_sensitive_info_removed_from_body(self, builder):
+        summary = builder.summarize_error(
+            "export", "Failed connecting to 10.0.0.1 with password=secret123"
+        )
+        assert '10.0.0.1' not in summary['body']
+        assert 'secret123' not in summary['body']

--- a/tests/test_github_app_secret_codec.py
+++ b/tests/test_github_app_secret_codec.py
@@ -1,0 +1,59 @@
+"""
+scripts/github_app_secret_codec.py 단위 테스트
+
+빌드타임 전용 난독화 코덱의 왕복(round-trip) 및 코드 생성 로직을 검증합니다.
+"""
+from scripts.github_app_secret_codec import (
+    OBFUSCATION_KEY,
+    obfuscate,
+    deobfuscate,
+    generate_embedded_code,
+)
+
+
+class TestObfuscationRoundtrip:
+    """난독화/해독 왕복 검증"""
+
+    def test_roundtrip(self):
+        original = "test-secret-value-12345"
+        obfuscated = obfuscate(original)
+        assert obfuscated != original
+        assert deobfuscate(obfuscated) == original
+
+    def test_roundtrip_with_special_chars(self):
+        original = "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----"
+        obfuscated = obfuscate(original)
+        assert deobfuscate(obfuscated) == original
+
+    def test_deobfuscate_invalid_returns_empty(self):
+        assert deobfuscate("not-valid-base64!!!") == ""
+
+    def test_key_matches_github_app_auth(self):
+        """github_app_auth.GitHubAppAuth._OBFUSCATION_KEY와 동일한 키를 사용해야 런타임 복호화가 호환된다"""
+        from src.core.github_app_auth import GitHubAppAuth
+        assert OBFUSCATION_KEY == GitHubAppAuth._OBFUSCATION_KEY
+
+
+class TestGenerateEmbeddedCode:
+    """빌드 시 삽입할 코드 생성 검증"""
+
+    def test_generates_all_four_fields(self):
+        code = generate_embedded_code("123", "fake-pem", "456", "owner/repo")
+        assert "_EMBEDDED_APP_ID" in code
+        assert "_EMBEDDED_PRIVATE_KEY" in code
+        assert "_EMBEDDED_INSTALLATION_ID" in code
+        assert "_EMBEDDED_REPO" in code
+
+    def test_generated_values_roundtrip(self):
+        code = generate_embedded_code("123", "fake-pem", "456", "owner/repo")
+
+        # 생성된 코드에서 난독화된 app_id 값을 추출해 왕복 검증
+        obf_app_id = code.split('_EMBEDDED_APP_ID: Optional[str] = "')[1].split('"')[0]
+        assert deobfuscate(obf_app_id) == "123"
+
+    def test_compatible_with_github_app_auth_delegation(self):
+        """GitHubAppAuth.generate_embedded_code가 위임한 결과와 동일해야 한다"""
+        from src.core.github_app_auth import GitHubAppAuth
+        direct = generate_embedded_code("123", "fake-pem", "456", "owner/repo")
+        via_delegate = GitHubAppAuth.generate_embedded_code("123", "fake-pem", "456", "owner/repo")
+        assert direct == via_delegate

--- a/tests/test_sql_history.py
+++ b/tests/test_sql_history.py
@@ -387,3 +387,16 @@ class TestSQLHistory:
 
         result = self.history._load_history()
         assert result == []
+
+    def test_load_history_invalid_json_logs_warning(self):
+        """손상된 JSON 파일 로드 시 경고 로그를 남김 (CC-011 회귀)"""
+        from unittest.mock import patch
+
+        with open(self.history.history_file, 'w') as f:
+            f.write('{invalid json}')
+
+        with patch('src.core.sql_history.logger.warning') as mock_warning:
+            result = self.history._load_history()
+
+        assert result == []
+        mock_warning.assert_called_once()

--- a/tests/test_update_downloader.py
+++ b/tests/test_update_downloader.py
@@ -1,4 +1,6 @@
-from src.core.update_downloader import select_release_asset
+from unittest.mock import MagicMock, patch
+
+from src.core.update_downloader import UpdateDownloader, select_release_asset
 
 
 def test_select_release_asset_prefers_windows_offline_installer():
@@ -54,3 +56,24 @@ def test_select_release_asset_returns_none_when_platform_asset_missing():
     ]
 
     assert select_release_asset(assets, platform_name="Darwin") is None
+
+
+def test_download_installer_uses_configurable_timeout():
+    """download_installer가 하드코딩된 30초 대신 self.timeout을 전달해야 한다 (CC-048 회귀)"""
+    downloader = UpdateDownloader()
+    downloader.download_url = "https://example.com/TunnelForge-Setup-2.0.5.exe"
+    downloader.file_size = 10
+
+    config_manager = MagicMock()
+    config_manager.get_network_timeout_download.return_value = 77
+    downloader._config_manager = config_manager
+
+    mock_response = MagicMock()
+    mock_response.headers = {'content-length': '10'}
+    mock_response.iter_content.return_value = [b'0123456789']
+
+    with patch('src.core.update_downloader.requests.get', return_value=mock_response) as mock_get, \
+         patch('src.core.update_downloader.open', create=True):
+        downloader.download_installer()
+
+    assert mock_get.call_args.kwargs['timeout'] == 77


### PR DESCRIPTION
## 요약

Clean Code 리팩토링 Round 2 WP-2.9. `_WP_SPEC.md`의 12개 finding(CC-004, CC-005, CC-011, CC-012, CC-013, CC-015, CC-036, CC-037, CC-038, CC-039, CC-040, CC-048)을 처리했습니다. 스펙은 Round 1 머지 이전 코드 기준으로 라인번호가 무효화되어 있어, 심볼명으로 현재 코드를 찾아 작업했습니다(무효화된 finding은 없었음 — 모두 유효했음).

### db_connector.py / postgres_connector.py (CC-004, CC-005)
- `MySQLConnector.get_schemas`/`schema_exists`가 직접 `SHOW DATABASES` 커서를 실행하는 대신 `RustDbConnector` delegate에 위임하도록 정리했습니다. 위임 직전 `self._delegate.connection = self.connection`으로 라이브 커넥션을 동기화하고, TTL 캐시는 wrapper에만 유지합니다.
- `PostgresConnector.schema_exists`도 동일하게 `RustDbConnector` delegate에 위임합니다(이 파일은 전용 유닛테스트가 없어 스크래치 스크립트로 수동 검증했습니다).
- `MySQLConnector.get_db_version`의 수기 파싱을 제거하고 `db_core_service.parse_db_version_tuple`을 재사용합니다.

### sql_history.py (CC-011, CC-012, CC-015)
- `print` 대신 `logger.warning`/`logger.error` 로깅 도입.
- `_matches_history_id` 헬퍼로 `update_status`/`update_status_batch`/`toggle_favorite`의 중복 ID 매칭 로직을 통합.
- `HistorySearchFilter` dataclass + `_apply_filters` 헬퍼로 `search_advanced`의 필터링 로직을 분리했습니다. **`search_advanced`의 외부 시그니처(`keyword=None, ..., limit=50, offset=0`)는 변경하지 않았습니다** — `sql_editor_history_dialog.py`(범위 밖)가 keyword 인자로 호출하기 때문입니다.

### sql_statement_parser.py (CC-013)
- `parse_sql_statement_ranges`의 상태별(줄 주석/블록 주석/dollar-quote/따옴표 문자열) 소비 로직을 `_consume_line_comment`/`_consume_block_comment`/`_consume_dollar_quote`/`_consume_quoted_string` 헬퍼로 기계적으로 추출했습니다(append/분기/커서 증가 순서를 원본과 동일하게 유지). 최상위 while 루프는 진입 감지(DELIMITER 라인, 인용 시작 등) + dispatcher로 축소됐습니다. LOW 심각도라 스킵도 허용됐지만, 순수 추출이라 판단해 적용 후 `test_sql_execution_worker.py`의 delimiter/dollar-quote/comment 회귀 테스트로 확인했습니다.

### github_app_auth.py (CC-036, CC-037) + 신규 scripts/github_app_secret_codec.py
- `print` 대신 `logger.error` 로깅 도입.
- 빌드타임 전용 난독화 로직(`obfuscate`/`generate_embedded_code`)을 신규 `scripts/github_app_secret_codec.py`로 분리했습니다. `GitHubAppAuth._obfuscate`/`generate_embedded_code`는 lazy-import 위임 wrapper로 남겼습니다. **런타임 경로인 `_deobfuscate`(`_EMBEDDED_PRIVATE_KEY` 복호화)는 패키징된 exe에 `scripts/`가 포함되지 않으므로 scripts import 없이 클래스 내부 구현을 그대로 유지**했습니다.

### github_issue_reporter.py (CC-038, CC-039, CC-040) + 신규 src/core/error_summary_builder.py
- 네트워크 비의존 순수 로직(`sanitize_error_message`/`extract_core_error`/`generate_fingerprint`/`generate_issue_body`/`summarize_error`)을 신규 `ErrorSummaryBuilder` 클래스로 분리했습니다. `GitHubIssueReporter`는 `self._summary = ErrorSummaryBuilder()`를 보유하고 기존 `_sanitize_error_message` 등 private 메서드는 얇은 위임으로 유지했습니다(테스트가 이 메서드들을 직접 호출하기 때문). `GitHubIssueReporter` 클래스명과 public API는 변경하지 않았습니다.
- `summarize_error` 반환 dict에 `full_message` 필드를 추가하고, `add_comment`의 취약한 마크다운 파싱(`body.split('## 상세 오류 메시지')[1].split('```')[1]`)을 `(full_message or core_error)[:COMMENT_PREVIEW_LEN]`로 교체했습니다.
- 흩어진 truncation 리터럴(80/100/2000/1000)을 `TITLE_PREVIEW_LEN`/`CORE_ERROR_MAX_LEN`/`BODY_PREVIEW_LEN`(ErrorSummaryBuilder)과 `COMMENT_PREVIEW_LEN`(GitHubIssueReporter)으로 명명했습니다.

### update_downloader.py (CC-048)
- `download_installer`의 하드코딩된 `timeout=30`을 `self.timeout`(설정 가능한 `get_network_timeout_download`)으로 교체해 `get_installer_info`와 일관성을 확보했습니다.

## 검증

- `py_compile`: 수정/신규 파일 전체 통과
- 타겟 pytest (`test_db_connector`, `test_sql_history`, `test_github_app_auth`, `test_github_issue_reporter`, `test_update_downloader`, `test_sql_execution_worker`): **179 passed**
- 신규 테스트 (`test_github_app_secret_codec`, `test_error_summary_builder`): **28 passed**
- 전체 `pytest -q`: **1866 passed, 1 failed** — 실패는 `test_rust_core_packaging.py::test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`로, GitHub Actions 워크플로/`gh` CLI 네트워크에 의존하는 macOS 패키징 검증 테스트입니다. 이 브랜치의 변경과 무관하며 로컬 환경에서 항상 실패하는 known flaky 테스트입니다(회귀 아님).
- `postgres_connector.py`는 전용 유닛테스트가 없어(스펙에 명시된 리스크) mock 커넥션으로 위임 배선(존재/미존재/빈 schema_name/미연결 가드)을 수동 검증했습니다.

## 위험 / 참고사항

- `search_advanced`, `GitHubIssueReporter` public API, `_deobfuscate` 런타임 경로는 스펙의 하드 제약에 따라 변경하지 않았습니다.
- `postgres_connector.py` 변경은 다른 WP와 동시 수정 시 충돌 가능성이 있다고 스펙에 명시되어 있었으나, 이번 라운드 파일 목록상 이 WP에만 배정된 것으로 확인했습니다.
- `scripts/embed_github_credentials.py`의 중복 난독화 로직은 스펙 지시대로 이번 WP에서 통합하지 않고 그대로 두었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)