### PR TITLE
refactor(infra): 터널/플랫폼 소파일 15건 정리 (CC-023~035, CC-047, CC-049)

### DIFF
--- a/src/core/logger.py
+++ b/src/core/logger.py
@@ -168,9 +168,8 @@ def filter_log_by_level(content: str, level: str) -> str:
 
     for line in content.splitlines():
         # 로그 레벨 확인 (포맷: [timestamp] LEVEL [module] message)
+        # level_upper == 'ERROR'인 경우는 위의 if에서 이미 처리되므로 별도 elif 불필요
         if f'] {level_upper} [' in line:
-            filtered_lines.append(line)
-        elif level_upper == 'ERROR' and '] ERROR [' in line:
             filtered_lines.append(line)
         elif level_upper == 'WARNING' and ('] WARNING [' in line or '] ERROR [' in line):
             filtered_lines.append(line)

--- a/src/core/mysql_login_path.py
+++ b/src/core/mysql_login_path.py
@@ -31,6 +31,7 @@ _KEY_LEN = 20        # login key 길이 (고정)
 _HEADER_LEN = 4      # 파일 앞 4바이트 key_len (uint32 LE, = _KEY_LEN)
 _KEY_OFFSET = _HEADER_LEN          # key 시작 위치
 _DATA_OFFSET = _KEY_OFFSET + _KEY_LEN  # 데이터 섹션 시작 위치 (= 24)
+_AES_BLOCK_SIZE_BITS = 128  # AES 블록 크기 (PKCS#7 패딩 단위, mysql_config_editor 호환)
 
 # Windows: %APPDATA%\MySQL\.mylogin.cnf
 # Unix:    ~/.mylogin.cnf
@@ -101,7 +102,7 @@ def _read_cnf(path: str = _MYLOGIN_CNF) -> Tuple[bytes, str]:
             padded_plain = dec.update(ciphertext) + dec.finalize()
             # PKCS#7 unpadding 시도, 실패 시 legacy NULL padding fallback
             try:
-                unpadder = PKCS7(128).unpadder()
+                unpadder = PKCS7(_AES_BLOCK_SIZE_BITS).unpadder()
                 plain = unpadder.update(padded_plain) + unpadder.finalize()
             except ValueError:
                 plain = padded_plain.rstrip(b'\x00')
@@ -145,7 +146,7 @@ def _write_cnf(login_key: bytes, ini_text: str, path: str = _MYLOGIN_CNF):
             # 줄 단위 개별 암호화 (PKCS#7 패딩: mysql_config_editor 호환)
             for line in text.splitlines(keepends=True):
                 plain = line.encode('utf-8')
-                padder = PKCS7(128).padder()
+                padder = PKCS7(_AES_BLOCK_SIZE_BITS).padder()
                 padded = padder.update(plain) + padder.finalize()
 
                 enc = Cipher(algorithms.AES(aes_key), modes.ECB()).encryptor()
@@ -220,12 +221,8 @@ class MysqlLoginPathManager:
         self._cnf_path = cnf_path or _MYLOGIN_CNF
 
     def is_available(self) -> bool:
-        """cryptography 라이브러리 사용 가능 여부 (의존성으로 항상 True)"""
-        try:
-            from cryptography.hazmat.primitives.ciphers import Cipher  # noqa
-            return True
-        except ImportError:
-            return False
+        """항상 True를 반환한다. cryptography는 필수 의존성으로 이미 설치되어 있다."""
+        return True
 
     @staticmethod
     def get_login_path_name(port: int) -> str:

--- a/src/core/oneclick_log.py
+++ b/src/core/oneclick_log.py
@@ -10,7 +10,6 @@ import logging
 import os
 import uuid
 from datetime import datetime
-from typing import Optional
 
 from src.core.platform_paths import log_dir
 

--- a/src/core/platform_integration.py
+++ b/src/core/platform_integration.py
@@ -137,23 +137,10 @@ def _show_windows_crash_recovery_message(error_message: str, app_dir: str) -> No
     ctypes.windll.user32.MessageBoxW(None, message, "TunnelForge - 오류", mb_iconerror)
 
 
-@dataclass
-class StartupRegistrar:
-    """OS-specific startup registration facade."""
-
-    platform_name: Optional[str] = None
-    home: Optional[Path] = None
-    executable: Optional[str] = None
-
-    @property
-    def is_supported(self) -> bool:
-        return is_windows(self.platform_name) or is_macos(self.platform_name)
+class WindowsStartupRegistrar:
+    """Windows 시작 프로그램(레지스트리 Run 키) 등록 전략."""
 
     def is_registered(self) -> bool:
-        if not self.is_supported:
-            return False
-        if is_macos(self.platform_name):
-            return self._macos_launch_agent_matches_current_app()
         try:
             import winreg
 
@@ -172,11 +159,6 @@ class StartupRegistrar:
             return False
 
     def set_registered(self, enable: bool) -> Tuple[bool, str]:
-        if not self.is_supported:
-            return False, "자동 시작은 아직 이 플랫폼에서 지원되지 않습니다."
-        if is_macos(self.platform_name):
-            return self._set_macos_launch_agent(enable)
-
         try:
             import winreg
 
@@ -212,37 +194,24 @@ class StartupRegistrar:
         main_script = os.path.abspath("main.py")
         return f'"{pythonw}" "{main_script}" --minimized'
 
-    def _home_path(self) -> Path:
-        return Path(self.home) if self.home is not None else Path.home()
 
-    def _macos_launch_agent_path(self) -> Path:
-        return self._home_path() / "Library" / "LaunchAgents" / "io.sanghyun.tunnelforge.plist"
+class MacOSStartupRegistrar:
+    """macOS LaunchAgent(plist) 등록 전략."""
 
-    def _macos_launch_agent_log_dir(self) -> Path:
-        return self._home_path() / "Library" / "Logs" / "TunnelForge"
+    def __init__(self, home: Optional[Path] = None, executable: Optional[str] = None):
+        self.home = home
+        self.executable = executable
 
-    def _macos_launch_agent_matches_current_app(self) -> bool:
-        path = self._macos_launch_agent_path()
-        if not path.exists():
-            return False
+    def is_registered(self) -> bool:
+        return self._launch_agent_matches_current_app()
 
-        try:
-            launch_agent = plistlib.loads(path.read_bytes())
-        except Exception:
-            return False
-
-        return (
-            launch_agent.get("ProgramArguments") == list(self._macos_startup_arguments())
-            and launch_agent.get("WorkingDirectory") == self._macos_working_directory()
-        )
-
-    def _set_macos_launch_agent(self, enable: bool) -> Tuple[bool, str]:
-        path = self._macos_launch_agent_path()
+    def set_registered(self, enable: bool) -> Tuple[bool, str]:
+        path = self._launch_agent_path()
         try:
             if enable:
                 path.parent.mkdir(parents=True, exist_ok=True)
-                self._macos_launch_agent_log_dir().mkdir(parents=True, exist_ok=True)
-                path.write_text(self._macos_launch_agent_plist(), encoding="utf-8")
+                self._launch_agent_log_dir().mkdir(parents=True, exist_ok=True)
+                path.write_text(self._launch_agent_plist(), encoding="utf-8")
             else:
                 try:
                     path.unlink()
@@ -252,28 +221,52 @@ class StartupRegistrar:
         except Exception as exc:
             return False, str(exc)
 
-    def _macos_startup_arguments(self) -> Tuple[str, ...]:
+    def _home_path(self) -> Path:
+        return Path(self.home) if self.home is not None else Path.home()
+
+    def _launch_agent_path(self) -> Path:
+        return self._home_path() / "Library" / "LaunchAgents" / "io.sanghyun.tunnelforge.plist"
+
+    def _launch_agent_log_dir(self) -> Path:
+        return self._home_path() / "Library" / "Logs" / "TunnelForge"
+
+    def _launch_agent_matches_current_app(self) -> bool:
+        path = self._launch_agent_path()
+        if not path.exists():
+            return False
+
+        try:
+            launch_agent = plistlib.loads(path.read_bytes())
+        except Exception:
+            return False
+
+        return (
+            launch_agent.get("ProgramArguments") == list(self._startup_arguments())
+            and launch_agent.get("WorkingDirectory") == self._working_directory()
+        )
+
+    def _startup_arguments(self) -> Tuple[str, ...]:
         executable = self.executable or sys.executable
         if getattr(sys, "frozen", False):
             return (executable, "--minimized")
         main_script = os.path.abspath("main.py")
         return (executable, main_script, "--minimized")
 
-    def _macos_working_directory(self) -> str:
+    def _working_directory(self) -> str:
         executable = str(self.executable or sys.executable)
         if getattr(sys, "frozen", False):
             return str(PurePosixPath(executable).parent)
         return str(Path(os.path.abspath("main.py")).parent)
 
-    def _macos_launch_agent_plist(self) -> str:
+    def _launch_agent_plist(self) -> str:
         args = "\n".join(
             f"        <string>{escape(str(arg))}</string>"
-            for arg in self._macos_startup_arguments()
+            for arg in self._startup_arguments()
         )
-        log_dir = self._macos_launch_agent_log_dir()
+        log_dir = self._launch_agent_log_dir()
         stdout_path = escape(str(log_dir / "launchagent.out.log"))
         stderr_path = escape(str(log_dir / "launchagent.err.log"))
-        working_directory = escape(self._macos_working_directory())
+        working_directory = escape(self._working_directory())
         return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -295,3 +288,35 @@ class StartupRegistrar:
 </dict>
 </plist>
 """
+
+
+@dataclass
+class StartupRegistrar:
+    """OS-specific startup registration facade.
+
+    실제 등록 로직은 플랫폼별 전략(WindowsStartupRegistrar/MacOSStartupRegistrar)에
+    위임하고, 이 클래스는 platform_name으로 전략을 고르는 얇은 facade 역할만 한다.
+    """
+
+    platform_name: Optional[str] = None
+    home: Optional[Path] = None
+    executable: Optional[str] = None
+
+    @property
+    def is_supported(self) -> bool:
+        return is_windows(self.platform_name) or is_macos(self.platform_name)
+
+    def _strategy(self):
+        if is_macos(self.platform_name):
+            return MacOSStartupRegistrar(home=self.home, executable=self.executable)
+        return WindowsStartupRegistrar()
+
+    def is_registered(self) -> bool:
+        if not self.is_supported:
+            return False
+        return self._strategy().is_registered()
+
+    def set_registered(self, enable: bool) -> Tuple[bool, str]:
+        if not self.is_supported:
+            return False, "자동 시작은 아직 이 플랫폼에서 지원되지 않습니다."
+        return self._strategy().set_registered(enable)

--- a/src/core/platform_paths.py
+++ b/src/core/platform_paths.py
@@ -21,6 +21,24 @@ def _environ(environ: Optional[Mapping[str, str]] = None) -> Mapping[str, str]:
     return environ if environ is not None else os.environ
 
 
+def _platform_base_dir(
+    system: str,
+    home_path: Path,
+    env: Mapping[str, str],
+    xdg_env_var: str,
+    xdg_default_subdir: str,
+) -> Path:
+    """Windows(LOCALAPPDATA fallback)와 Linux(XDG env fallback)의 공통 base 디렉토리.
+
+    macOS(Darwin)는 함수마다 서브패스가 다르므로(log_dir은 Library/Logs, 나머지는
+    Library/Application Support) 이 helper로 뭉개지 않고 각 호출부가 직접 처리한다.
+    """
+    if system == "Windows":
+        return Path(env.get("LOCALAPPDATA") or home_path / "AppData" / "Local")
+
+    return Path(env.get(xdg_env_var) or home_path / xdg_default_subdir)
+
+
 def app_support_dir(
     platform_name: Optional[str] = None,
     home: Optional[Path] = None,
@@ -31,14 +49,12 @@ def app_support_dir(
     home_path = _home_path(home)
     env = _environ(environ)
 
-    if system == "Windows":
-        base = Path(env.get("LOCALAPPDATA") or home_path / "AppData" / "Local")
-        return base / APP_NAME
     if system == "Darwin":
         return home_path / "Library" / "Application Support" / APP_NAME
+    if system == "Windows":
+        return _platform_base_dir(system, home_path, env, "XDG_CONFIG_HOME", ".config") / APP_NAME
 
-    base = Path(env.get("XDG_CONFIG_HOME") or home_path / ".config")
-    return base / APP_ID
+    return _platform_base_dir(system, home_path, env, "XDG_CONFIG_HOME", ".config") / APP_ID
 
 
 def data_dir(
@@ -51,14 +67,12 @@ def data_dir(
     home_path = _home_path(home)
     env = _environ(environ)
 
-    if system == "Windows":
-        base = Path(env.get("LOCALAPPDATA") or home_path / "AppData" / "Local")
-        return base / APP_NAME
     if system == "Darwin":
         return home_path / "Library" / "Application Support" / APP_NAME
+    if system == "Windows":
+        return _platform_base_dir(system, home_path, env, "XDG_DATA_HOME", ".local/share") / APP_NAME
 
-    base = Path(env.get("XDG_DATA_HOME") or home_path / ".local" / "share")
-    return base / APP_ID
+    return _platform_base_dir(system, home_path, env, "XDG_DATA_HOME", ".local/share") / APP_ID
 
 
 def log_dir(
@@ -71,14 +85,12 @@ def log_dir(
     home_path = _home_path(home)
     env = _environ(environ)
 
-    if system == "Windows":
-        base = Path(env.get("LOCALAPPDATA") or home_path / "AppData" / "Local")
-        return base / APP_NAME / "logs"
     if system == "Darwin":
         return home_path / "Library" / "Logs" / APP_NAME
+    if system == "Windows":
+        return _platform_base_dir(system, home_path, env, "XDG_STATE_HOME", ".local/state") / APP_NAME / "logs"
 
-    base = Path(env.get("XDG_STATE_HOME") or home_path / ".local" / "state")
-    return base / APP_ID / "logs"
+    return _platform_base_dir(system, home_path, env, "XDG_STATE_HOME", ".local/state") / APP_ID / "logs"
 
 
 def config_file(

--- a/src/core/production_guard.py
+++ b/src/core/production_guard.py
@@ -17,7 +17,6 @@ from PyQt6.QtWidgets import (
     QPushButton, QMessageBox, QFrame
 )
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QFont
 
 
 class Environment(Enum):
@@ -36,6 +35,13 @@ class Environment(Enum):
             if env.value == value:
                 return env
         return cls.UNKNOWN
+
+
+# SchemaConfirmDialog 스타일 상수 (ENV_COLORS와 별개로 중립적인 UI 색상)
+_NEUTRAL_BG = "#f8f9fa"
+_NEUTRAL_BORDER = "#dee2e6"
+_INPUT_BORDER = "#bdc3c7"
+_INPUT_FOCUS_BORDER = "#3498db"
 
 
 class SchemaConfirmDialog(QDialog):
@@ -74,7 +80,7 @@ class SchemaConfirmDialog(QDialog):
         self._init_ui(operation, details)
 
     def _init_ui(self, operation: str, details: str):
-        """UI 초기화"""
+        """UI 초기화 (조립만 담당 — 각 섹션은 포커스된 빌더에서 생성)"""
         self.setWindowTitle(f"⚠️ {self.ENV_LABELS.get(self.environment, 'UNKNOWN')} 환경")
         self.setMinimumWidth(450)
         self.setModal(True)
@@ -87,25 +93,7 @@ class SchemaConfirmDialog(QDialog):
             self.environment, ("#333", "#fff")
         )
 
-        # 헤더 프레임 (배경색 포함)
-        header_frame = QFrame()
-        header_frame.setStyleSheet(f"""
-            QFrame {{
-                background-color: {bg_color};
-                border: 2px solid {text_color};
-                border-radius: 8px;
-                padding: 10px;
-            }}
-        """)
-        header_layout = QVBoxLayout(header_frame)
-
-        # 환경 라벨
-        env_label = QLabel(self.ENV_LABELS.get(self.environment, "UNKNOWN"))
-        env_label.setStyleSheet(f"color: {text_color}; font-size: 18px; font-weight: bold;")
-        env_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        header_layout.addWidget(env_label)
-
-        layout.addWidget(header_frame)
+        layout.addWidget(self._build_header_frame(text_color, bg_color))
 
         # 작업 설명
         operation_label = QLabel(f"<b>{operation}</b> 작업을 실행하려 합니다.")
@@ -117,29 +105,62 @@ class SchemaConfirmDialog(QDialog):
         warning_label.setStyleSheet(f"color: {text_color}; font-weight: bold;")
         layout.addWidget(warning_label)
 
-        # 상세 정보 (있는 경우)
-        if details:
-            details_label = QLabel(details)
-            details_label.setWordWrap(True)
-            details_label.setStyleSheet("""
-                background-color: #f8f9fa;
-                border: 1px solid #dee2e6;
-                border-radius: 4px;
-                padding: 8px;
-            """)
+        details_label = self._build_details_section(details)
+        if details_label is not None:
             layout.addWidget(details_label)
 
-        # 구분선
+        for widget in self._build_schema_input_section(text_color, bg_color):
+            layout.addWidget(widget)
+
+        layout.addLayout(self._build_button_row(text_color))
+
+    def _build_header_frame(self, text_color: str, bg_color: str) -> QFrame:
+        """환경 라벨을 담은 헤더 프레임 (배경색 포함) 생성"""
+        header_frame = QFrame()
+        header_frame.setStyleSheet(f"""
+            QFrame {{
+                background-color: {bg_color};
+                border: 2px solid {text_color};
+                border-radius: 8px;
+                padding: 10px;
+            }}
+        """)
+        header_layout = QVBoxLayout(header_frame)
+
+        env_label = QLabel(self.ENV_LABELS.get(self.environment, "UNKNOWN"))
+        env_label.setStyleSheet(f"color: {text_color}; font-size: 18px; font-weight: bold;")
+        env_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        header_layout.addWidget(env_label)
+
+        return header_frame
+
+    def _build_details_section(self, details: str) -> Optional[QLabel]:
+        """상세 정보 라벨 생성 (details가 없으면 None)"""
+        if not details:
+            return None
+
+        details_label = QLabel(details)
+        details_label.setWordWrap(True)
+        details_label.setStyleSheet(f"""
+            background-color: {_NEUTRAL_BG};
+            border: 1px solid {_NEUTRAL_BORDER};
+            border-radius: 4px;
+            padding: 8px;
+        """)
+        return details_label
+
+    def _build_schema_input_section(self, text_color: str, bg_color: str):
+        """구분선 + 안내 문구 + 타겟 스키마 표시 + 입력 필드를 순서대로 생성
+
+        Returns:
+            layout에 순서대로 addWidget할 위젯 리스트
+        """
         line = QFrame()
         line.setFrameShape(QFrame.Shape.HLine)
         line.setFrameShadow(QFrame.Shadow.Sunken)
-        layout.addWidget(line)
 
-        # 스키마명 입력 안내
         instruction_label = QLabel("계속하려면 <b>스키마명을 정확히 입력</b>하세요:")
-        layout.addWidget(instruction_label)
 
-        # 타겟 스키마명 표시
         schema_display = QLabel(self.schema_name)
         schema_display.setStyleSheet(f"""
             background-color: {bg_color};
@@ -152,36 +173,34 @@ class SchemaConfirmDialog(QDialog):
             color: {text_color};
         """)
         schema_display.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(schema_display)
 
-        # 입력 필드
         self.input_schema = QLineEdit()
         self.input_schema.setPlaceholderText("스키마명 입력...")
-        self.input_schema.setStyleSheet("""
-            QLineEdit {
+        self.input_schema.setStyleSheet(f"""
+            QLineEdit {{
                 padding: 10px;
                 font-size: 14px;
-                border: 2px solid #bdc3c7;
+                border: 2px solid {_INPUT_BORDER};
                 border-radius: 4px;
-            }
-            QLineEdit:focus {
-                border-color: #3498db;
-            }
+            }}
+            QLineEdit:focus {{
+                border-color: {_INPUT_FOCUS_BORDER};
+            }}
         """)
         self.input_schema.textChanged.connect(self._on_text_changed)
-        layout.addWidget(self.input_schema)
 
-        # 버튼 레이아웃
+        return [line, instruction_label, schema_display, self.input_schema]
+
+    def _build_button_row(self, text_color: str) -> QHBoxLayout:
+        """취소/실행 버튼 레이아웃 생성 (초기에는 실행 버튼 비활성화)"""
         button_layout = QHBoxLayout()
         button_layout.addStretch()
 
-        # 취소 버튼
         self.btn_cancel = QPushButton("취소")
         self.btn_cancel.setMinimumWidth(100)
         self.btn_cancel.clicked.connect(self.reject)
         button_layout.addWidget(self.btn_cancel)
 
-        # 실행 버튼 (초기에는 비활성화)
         self.btn_execute = QPushButton("실행")
         self.btn_execute.setMinimumWidth(100)
         self.btn_execute.setEnabled(False)
@@ -204,7 +223,7 @@ class SchemaConfirmDialog(QDialog):
         self.btn_execute.clicked.connect(self.accept)
         button_layout.addWidget(self.btn_execute)
 
-        layout.addLayout(button_layout)
+        return button_layout
 
     def _on_text_changed(self, text: str):
         """입력 텍스트 변경 시 버튼 활성화 상태 업데이트"""

--- a/src/core/single_instance.py
+++ b/src/core/single_instance.py
@@ -11,6 +11,9 @@ from PyQt6.QtNetwork import QLocalServer, QLocalSocket
 DEFAULT_SERVER_NAME = "tunnelforge-single-instance-v1"
 DEFAULT_LOCK_FILE = os.path.join(tempfile.gettempdir(), "tunnelforge-single-instance.lock")
 
+_CONNECT_ATTEMPT_TIMEOUT_MS = 100
+_POLL_INTERVAL_SECONDS = 0.05
+
 
 class SingleInstanceGuard(QObject):
     """Own a local server so later launches can wake the first instance."""
@@ -88,15 +91,15 @@ class SingleInstanceGuard(QObject):
         while time.monotonic() < deadline:
             socket = QLocalSocket()
             socket.connectToServer(server_name)
-            if socket.waitForConnected(100):
+            if socket.waitForConnected(_CONNECT_ATTEMPT_TIMEOUT_MS):
                 message = f"activate:{sys.argv[0]}\n".encode("utf-8", errors="replace")
                 socket.write(message)
                 socket.flush()
-                socket.waitForBytesWritten(100)
+                socket.waitForBytesWritten(_CONNECT_ATTEMPT_TIMEOUT_MS)
                 socket.disconnectFromServer()
                 socket.deleteLater()
                 return True
             socket.deleteLater()
-            time.sleep(0.05)
+            time.sleep(_POLL_INTERVAL_SECONDS)
 
         return False

--- a/src/core/tunnel_engine.py
+++ b/src/core/tunnel_engine.py
@@ -74,6 +74,32 @@ class TunnelEngine:
             f"💡 OpenSSH 포맷인 경우 'pip install cryptography' 필요"
         )
 
+    def _build_forwarder(self, config, local_bind_address, pkey_obj, set_keepalive=None):
+        """SSHTunnelForwarder 공통 kwargs 조립 (모듈 전역 SSHTunnelForwarder 참조 필수)
+
+        Args:
+            config: 터널 설정 (bastion_host/bastion_port/bastion_user/remote_host/remote_port)
+            local_bind_address: 로컬 바인드 주소 튜플
+            pkey_obj: 이미 로드된 SSH 키 객체
+            set_keepalive: keepalive 간격(초). None이면 kwarg 자체를 생략(라이브러리 기본값 유지)
+
+        Returns:
+            생성된 (미시작) SSHTunnelForwarder 인스턴스
+        """
+        kwargs = dict(
+            ssh_username=config['bastion_user'],
+            ssh_pkey=pkey_obj,  # 경로 대신 키 객체 전달
+            remote_bind_address=(config['remote_host'], int(config['remote_port'])),
+            local_bind_address=local_bind_address,
+        )
+        if set_keepalive is not None:
+            kwargs['set_keepalive'] = set_keepalive
+
+        return SSHTunnelForwarder(
+            (config['bastion_host'], int(config['bastion_port'])),
+            **kwargs,
+        )
+
     def start_tunnel(self, config, check_port: bool = True):
         """SSH 터널 또는 직접 연결 시작
 
@@ -84,19 +110,19 @@ class TunnelEngine:
         Returns:
             (success, message) 튜플
         """
-        tid = config['id']
+        tunnel_id = config['id']
 
         # 이미 실행 중인지 확인
-        if tid in self.active_tunnels:
+        if tunnel_id in self.active_tunnels:
             if config.get('connection_mode') == 'direct':
                 return True, "이미 연결 중입니다."
-            elif self.active_tunnels[tid] and self.active_tunnels[tid].is_active:
+            elif self.active_tunnels[tunnel_id] and self.active_tunnels[tunnel_id].is_active:
                 return True, "이미 실행 중입니다."
 
         # 직접 연결 모드
         if config.get('connection_mode') == 'direct':
-            self.active_tunnels[tid] = None  # 터널 객체 없음 (직접 연결)
-            self.tunnel_configs[tid] = config
+            self.active_tunnels[tunnel_id] = None  # 터널 객체 없음 (직접 연결)
+            self.tunnel_configs[tunnel_id] = config
             logger.info(f"직접 연결 모드: {config['name']} -> {config['remote_host']}:{config['remote_port']}")
             return True, f"직접 연결: {config['remote_host']}:{config['remote_port']}"
 
@@ -111,7 +137,7 @@ class TunnelEngine:
 
     def _start_ssh_tunnel(self, config):
         """SSH 터널 시작 (내부 메서드)"""
-        tid = config['id']
+        tunnel_id = config['id']
         connection_logs = []
 
         try:
@@ -132,20 +158,18 @@ class TunnelEngine:
 
             connection_logs.append("SSH 터널 생성 중...")
             logger.debug("SSH 터널 생성 중...")
-            server = SSHTunnelForwarder(
-                (config['bastion_host'], int(config['bastion_port'])),
-                ssh_username=config['bastion_user'],
-                ssh_pkey=pkey_obj,  # 경로 대신 키 객체 전달
-                remote_bind_address=(config['remote_host'], int(config['remote_port'])),
+            server = self._build_forwarder(
+                config,
                 local_bind_address=('0.0.0.0', int(config['local_port'])),
-                set_keepalive=30.0
+                pkey_obj=pkey_obj,
+                set_keepalive=30.0,
             )
 
             connection_logs.append("터널 연결 시작...")
             logger.debug("터널 연결 시작...")
             server.start()
-            self.active_tunnels[tid] = server
-            self.tunnel_configs[tid] = config
+            self.active_tunnels[tunnel_id] = server
+            self.tunnel_configs[tunnel_id] = config
             logger.info(f"터널 연결 성공! (Local {config['local_port']} -> Remote {config['remote_host']})")
             return True, "연결 성공"
 
@@ -163,37 +187,37 @@ class TunnelEngine:
             logger.error(full_error)
             return False, full_error
 
-    def stop_tunnel(self, tid):
+    def stop_tunnel(self, tunnel_id):
         """터널 종료"""
-        if tid in self.active_tunnels:
+        if tunnel_id in self.active_tunnels:
             try:
-                server = self.active_tunnels[tid]
+                server = self.active_tunnels[tunnel_id]
                 if server is not None:  # SSH 터널인 경우만 stop 호출
                     server.stop()
-                del self.active_tunnels[tid]
-                if tid in self.tunnel_configs:
-                    del self.tunnel_configs[tid]
-                logger.info(f"터널 종료됨: {tid}")
+                del self.active_tunnels[tunnel_id]
+                if tunnel_id in self.tunnel_configs:
+                    del self.tunnel_configs[tunnel_id]
+                logger.info(f"터널 종료됨: {tunnel_id}")
                 return True
             except Exception as e:
                 logger.warning(f"터널 종료 중 오류: {e}")
         return False
 
-    def is_running(self, tid):
+    def is_running(self, tunnel_id):
         """터널/연결이 활성화 상태인지 확인"""
-        if tid in self.active_tunnels:
-            server = self.active_tunnels[tid]
+        if tunnel_id in self.active_tunnels:
+            server = self.active_tunnels[tunnel_id]
             if server is None:  # 직접 연결 모드
                 return True
             return server.is_active
         return False
 
-    def get_connection_info(self, tid):
+    def get_connection_info(self, tunnel_id):
         """실제 연결할 호스트/포트 반환"""
-        if tid not in self.tunnel_configs:
+        if tunnel_id not in self.tunnel_configs:
             return None, None
 
-        config = self.tunnel_configs[tid]
+        config = self.tunnel_configs[tunnel_id]
         if config.get('connection_mode') == 'direct':
             return config['remote_host'], int(config['remote_port'])
         else:
@@ -213,12 +237,10 @@ class TunnelEngine:
             pkey_obj = self._load_private_key(config['bastion_key'])
 
             # 임시 터널 생성 (포트 자동 할당)
-            temp_server = SSHTunnelForwarder(
-                (config['bastion_host'], int(config['bastion_port'])),
-                ssh_username=config['bastion_user'],
-                ssh_pkey=pkey_obj,
-                remote_bind_address=(config['remote_host'], int(config['remote_port'])),
-                local_bind_address=(DEFAULT_LOCAL_HOST, 0)  # 0 = 자동 할당
+            temp_server = self._build_forwarder(
+                config,
+                local_bind_address=(DEFAULT_LOCAL_HOST, 0),  # 0 = 자동 할당
+                pkey_obj=pkey_obj,
             )
 
             temp_server.start()
@@ -316,13 +338,13 @@ class TunnelEngine:
     def get_active_tunnels(self):
         """활성화된 터널/연결 목록 반환 (DB Export용)"""
         result = []
-        for tid, server in self.active_tunnels.items():
-            if tid in self.tunnel_configs:
-                config = self.tunnel_configs[tid]
-                host, port = self.get_connection_info(tid)
+        for tunnel_id, server in self.active_tunnels.items():
+            if tunnel_id in self.tunnel_configs:
+                config = self.tunnel_configs[tunnel_id]
+                host, port = self.get_connection_info(tunnel_id)
                 result.append({
-                    'id': tid,
-                    'tunnel_id': tid,  # DB 연결 다이얼로그에서 자격 증명 조회용
+                    'id': tunnel_id,
+                    'tunnel_id': tunnel_id,  # DB 연결 다이얼로그에서 자격 증명 조회용
                     'name': config.get('name', 'Unknown'),
                     'host': host,
                     'port': port,
@@ -332,8 +354,8 @@ class TunnelEngine:
 
     def stop_all(self):
         ids = list(self.active_tunnels.keys())
-        for tid in ids:
-            self.stop_tunnel(tid)
+        for tunnel_id in ids:
+            self.stop_tunnel(tunnel_id)
 
     def test_connection(self, config):
         """테스트 연결"""
@@ -375,12 +397,10 @@ class TunnelEngine:
             connection_logs.append("✅ SSH 키 로드 성공")
 
             connection_logs.append("🔗 임시 SSH 터널 생성 중...")
-            temp_server = SSHTunnelForwarder(
-                (config['bastion_host'], int(config['bastion_port'])),
-                ssh_username=config['bastion_user'],
-                ssh_pkey=pkey_obj,  # 경로 대신 키 객체 전달
-                remote_bind_address=(config['remote_host'], int(config['remote_port'])),
-                local_bind_address=(DEFAULT_LOCAL_HOST, 0)
+            temp_server = self._build_forwarder(
+                config,
+                local_bind_address=(DEFAULT_LOCAL_HOST, 0),
+                pkey_obj=pkey_obj,
             )
 
             connection_logs.append("🚀 Bastion Host 연결 시도...")

--- a/src/core/tunnel_health_checker.py
+++ b/src/core/tunnel_health_checker.py
@@ -1,0 +1,224 @@
+"""
+터널 Health Check 연결 관리
+
+TunnelMonitor에서 분리된 책임:
+- 터널별 Health check용 DB 연결 캐시
+- DB 자격 증명 조회 (config_manager 복호화 우선, 평문 fallback)
+- Rust DB Core 커넥터를 통한 latency 측정
+"""
+import time
+from typing import Any, Dict, Optional
+
+from src.core.db_core_service import create_rust_db_connector, normalize_db_engine
+from src.core.logger import get_logger
+from src.core.constants import DEFAULT_MYSQL_PORT, DEFAULT_LOCAL_HOST
+
+logger = get_logger(__name__)
+
+
+class TunnelHealthChecker:
+    """터널별 Health check DB 연결을 캐시하고 latency를 측정한다.
+
+    호출자(TunnelMonitor)와 동일한 lock을 공유한다 — 딕셔너리 접근만 락으로
+    보호하고, 실제 연결 생성/종료 같은 블로킹 I/O는 락 밖에서 수행한다.
+    """
+
+    def __init__(self, tunnel_engine, config_manager, lock):
+        """
+        Args:
+            tunnel_engine: TunnelEngine 인스턴스 (활성 터널 설정 조회용)
+            config_manager: ConfigManager 인스턴스 (자격 증명 복호화용, None 가능)
+            lock: 호출자(TunnelMonitor)와 공유하는 threading.RLock
+        """
+        self.tunnel_engine = tunnel_engine
+        self.config_manager = config_manager
+        self._lock = lock
+
+        # Health check용 Rust DB Core 연결 캐시 (터널별 1개씩 유지)
+        self._health_connections: Dict[str, Any] = {}
+
+    def _cleanup_health_connection(self, tunnel_id: str):
+        """특정 터널의 health check 연결 정리
+
+        딕셔너리 pop만 락으로 보호하고, 실제 연결 종료(I/O)는 락 밖에서 수행한다.
+        """
+        with self._lock:
+            conn = self._health_connections.pop(tunnel_id, None)
+        if conn:
+            try:
+                conn.close()
+                logger.debug(f"Health check 연결 정리: {tunnel_id}")
+            except Exception:
+                pass
+
+    def _cleanup_all_health_connections(self):
+        """모든 health check 연결 정리 (딕셔너리 정리만 락으로 보호)"""
+        with self._lock:
+            connections = dict(self._health_connections)
+            self._health_connections.clear()
+
+        for tunnel_id, conn in connections.items():
+            try:
+                conn.close()
+                logger.debug(f"Health check 연결 정리: {tunnel_id}")
+            except Exception:
+                pass
+
+    def _get_health_credentials(self, tunnel_id: str, config: Dict[str, Any]) -> tuple:
+        """Health check용 DB 자격 증명 조회
+
+        config_manager가 있으면 실제 저장 키(db_user)와 암호화된 비밀번호
+        (db_password_encrypted)를 복호화하여 사용한다. config_manager가 없으면
+        평문 비밀번호를 추측하지 않고, 암호화된 비밀번호가 존재할 경우
+        health check 자체를 스킵한다.
+
+        Args:
+            tunnel_id: 터널 ID
+            config: 터널 설정 dict
+
+        Returns:
+            (db_user, db_password) 튜플. 조회 불가 시 ("", "")
+        """
+        get_credentials = getattr(self.config_manager, 'get_tunnel_credentials', None)
+        if callable(get_credentials):
+            try:
+                db_user, db_password = get_credentials(tunnel_id)
+                return db_user or '', db_password or ''
+            except Exception as e:
+                logger.debug(f"자격 증명 조회 실패 ({tunnel_id}): {e}")
+                return '', ''
+
+        db_user = config.get('db_user', '')
+        if config.get('db_password_encrypted'):
+            # 복호화 가능한 config_manager가 없어 암호문을 그대로 쓸 수 없음
+            logger.debug(f"Latency 측정 스킵 (비밀번호 복호화 불가): {tunnel_id}")
+            return '', ''
+
+        return db_user, ''
+
+    def _measure_latency(self, tunnel_id: str) -> float:
+        """Latency 측정 (Rust DB Core 연결 사용)
+
+        MySQL/PostgreSQL 모두 실제 DB 프로토콜 연결을 통해 응답 시간을 측정합니다.
+
+        Args:
+            tunnel_id: 터널 ID
+
+        Returns:
+            지연 시간 (밀리초), 측정 실패 시 -1
+        """
+        try:
+            config = self.tunnel_engine.tunnel_configs.get(tunnel_id)
+            if not config:
+                return -1
+
+            # DB 인증 정보 확인 (실제 config 키: db_user + 암호화된 db_password_encrypted)
+            db_username, db_password = self._get_health_credentials(tunnel_id, config)
+            db_name = config.get('default_database') or config.get('db_name') or config.get('default_schema') or ''
+            db_engine = normalize_db_engine(config.get('db_engine'), config.get('remote_port'))
+
+            # 인증 정보가 없으면 측정 불가
+            if not db_username:
+                logger.debug(f"Latency 측정 스킵 (DB 인증 정보 없음): {tunnel_id}")
+                return -1
+
+            connection_mode = config.get('connection_mode', 'ssh')
+
+            if connection_mode == 'direct':
+                host = config.get('remote_host', '')
+                port = int(config.get('remote_port', DEFAULT_MYSQL_PORT))
+            else:
+                # SSH 터널 모드: 로컬 포트 사용
+                local_port = config.get('local_port')
+                if not local_port:
+                    return -1
+                host = DEFAULT_LOCAL_HOST
+                port = int(local_port)
+
+            # 캐시된 연결 조회 (딕셔너리 조회만 락으로 보호)
+            with self._lock:
+                conn = self._health_connections.get(tunnel_id)
+
+            # 연결이 없거나 끊어진 경우 재연결 (연결 생성은 락 밖에서 수행)
+            if conn is None:
+                conn = self._create_health_connection(
+                    tunnel_id, db_engine, host, port, db_username, db_password, db_name
+                )
+                if conn is None:
+                    return -1
+
+            # Rust Core connection ping으로 latency 측정
+            start = time.time()
+            try:
+                conn.ping(reconnect=False)
+                latency = (time.time() - start) * 1000
+                return latency
+            except Exception as e:
+                logger.debug(f"DB ping 실패 ({tunnel_id}): {e}")
+                # 연결 끊김 - 캐시에서 제거
+                self._cleanup_health_connection(tunnel_id)
+                return -1
+
+        except Exception as e:
+            logger.debug(f"Latency 측정 오류 ({tunnel_id}): {e}")
+            return -1
+
+    def _create_health_connection(
+        self, tunnel_id: str, engine: str, host: str, port: int,
+        username: str, password: str, database: str
+    ) -> Optional[Any]:
+        """Health check용 DB 연결 생성
+
+        Rust 커넥터 connect()/autocommit() 같은 블로킹 I/O는 락 밖에서 수행하고,
+        캐시 딕셔너리 갱신만 락으로 보호한다.
+
+        Args:
+            tunnel_id: 터널 ID
+            host: DB 호스트
+            port: DB 포트
+            username: DB 사용자명
+            password: DB 비밀번호
+            database: DB 이름
+
+        Returns:
+            DB connection 또는 None
+        """
+        try:
+            connector = create_rust_db_connector(
+                engine,
+                host,
+                port,
+                username,
+                password,
+                database if database else None,
+            )
+            success, message = connector.connect()
+            if not success or connector.connection is None:
+                logger.debug(f"Health check 연결 생성 실패 ({tunnel_id}): {message}")
+                return None
+            connector.connection.autocommit(True)
+            conn = connector.connection
+
+            # 다른 스레드가 동시에 같은 터널의 연결을 이미 캐시했다면
+            # 기존 것을 사용하고 방금 만든 연결은 락 밖에서 닫는다.
+            duplicate = None
+            with self._lock:
+                existing = self._health_connections.get(tunnel_id)
+                if existing is not None:
+                    duplicate = conn
+                    conn = existing
+                else:
+                    self._health_connections[tunnel_id] = conn
+
+            if duplicate is not None:
+                try:
+                    duplicate.close()
+                except Exception:
+                    pass
+            else:
+                logger.debug(f"Health check 연결 생성: {tunnel_id}")
+
+            return conn
+        except Exception as e:
+            logger.debug(f"Health check 연결 생성 실패 ({tunnel_id}): {e}")
+            return None

--- a/src/core/tunnel_monitor.py
+++ b/src/core/tunnel_monitor.py
@@ -9,14 +9,16 @@ import time
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Dict, List, Optional, Callable, Any
+from typing import Dict, List, Optional, Callable
 from enum import Enum
 
-from src.core.db_core_service import create_rust_db_connector, normalize_db_engine
 from src.core.logger import get_logger
-from src.core.constants import DEFAULT_MYSQL_PORT, DEFAULT_LOCAL_HOST
+from src.core.tunnel_health_checker import TunnelHealthChecker
 
 logger = get_logger(__name__)
+
+# 재연결 백오프 정책: 시도 횟수가 늘어날수록 대기 시간을 늘려 재시도 폭주를 방지한다.
+RECONNECT_BACKOFF_SECONDS = (1, 2, 5, 10, 30, 60)
 
 
 class TunnelState(Enum):
@@ -89,7 +91,6 @@ class TunnelMonitor:
             max_events: 저장할 최대 이벤트 수
         """
         self.tunnel_engine = tunnel_engine
-        self.config_manager = config_manager
         self._statuses: Dict[str, TunnelStatus] = {}
         self._events: List[TunnelEvent] = []
         self._max_events = max_events
@@ -101,8 +102,8 @@ class TunnelMonitor:
         self._stop_event = threading.Event()
         self._lock = threading.RLock()  # RLock: 재진입 가능 (on_tunnel_connected 등 내부 중첩 호출 대응)
 
-        # Health check용 Rust DB Core 연결 캐시 (터널별 1개씩 유지)
-        self._health_connections: Dict[str, Any] = {}
+        # Health check 책임은 TunnelHealthChecker로 위임 (터널별 연결 캐시 포함)
+        self._health_checker = TunnelHealthChecker(tunnel_engine, config_manager, self._lock)
 
         # 설정에서 자동 재연결 설정 로드
         if config_manager:
@@ -112,6 +113,20 @@ class TunnelMonitor:
             self._max_reconnect_attempts = config_manager.get_app_setting(
                 'max_reconnect_attempts', 5
             )
+
+    @property
+    def config_manager(self):
+        """자동 재연결 설정 로드에 쓰인 것과 동일한 config_manager (health checker와 공유)"""
+        return self._health_checker.config_manager
+
+    @config_manager.setter
+    def config_manager(self, value):
+        self._health_checker.config_manager = value
+
+    @property
+    def _health_connections(self):
+        """health checker가 소유한 동일 dict 객체 (item 대입이 그대로 반영됨)"""
+        return self._health_checker._health_connections
 
     def add_callback(self, callback: Callable[[str, TunnelStatus], None]):
         """상태 변경 콜백 등록
@@ -166,31 +181,12 @@ class TunnelMonitor:
         logger.info("터널 모니터링 중지")
 
     def _cleanup_health_connection(self, tunnel_id: str):
-        """특정 터널의 health check 연결 정리
-
-        딕셔너리 pop만 락으로 보호하고, 실제 연결 종료(I/O)는 락 밖에서 수행한다.
-        """
-        with self._lock:
-            conn = self._health_connections.pop(tunnel_id, None)
-        if conn:
-            try:
-                conn.close()
-                logger.debug(f"Health check 연결 정리: {tunnel_id}")
-            except Exception:
-                pass
+        """특정 터널의 health check 연결 정리 (TunnelHealthChecker로 위임)"""
+        self._health_checker._cleanup_health_connection(tunnel_id)
 
     def _cleanup_all_health_connections(self):
-        """모든 health check 연결 정리 (딕셔너리 정리만 락으로 보호)"""
-        with self._lock:
-            connections = dict(self._health_connections)
-            self._health_connections.clear()
-
-        for tunnel_id, conn in connections.items():
-            try:
-                conn.close()
-                logger.debug(f"Health check 연결 정리: {tunnel_id}")
-            except Exception:
-                pass
+        """모든 health check 연결 정리 (TunnelHealthChecker로 위임)"""
+        self._health_checker._cleanup_all_health_connections()
 
     def is_running(self) -> bool:
         """모니터링 실행 중 여부"""
@@ -350,164 +346,22 @@ class TunnelMonitor:
 
                 self._notify_callbacks(tunnel_id, status)
 
-    def _get_health_credentials(self, tunnel_id: str, config: Dict[str, Any]) -> tuple:
-        """Health check용 DB 자격 증명 조회
-
-        config_manager가 있으면 실제 저장 키(db_user)와 암호화된 비밀번호
-        (db_password_encrypted)를 복호화하여 사용한다. config_manager가 없으면
-        평문 비밀번호를 추측하지 않고, 암호화된 비밀번호가 존재할 경우
-        health check 자체를 스킵한다.
-
-        Args:
-            tunnel_id: 터널 ID
-            config: 터널 설정 dict
-
-        Returns:
-            (db_user, db_password) 튜플. 조회 불가 시 ("", "")
-        """
-        get_credentials = getattr(self.config_manager, 'get_tunnel_credentials', None)
-        if callable(get_credentials):
-            try:
-                db_user, db_password = get_credentials(tunnel_id)
-                return db_user or '', db_password or ''
-            except Exception as e:
-                logger.debug(f"자격 증명 조회 실패 ({tunnel_id}): {e}")
-                return '', ''
-
-        db_user = config.get('db_user', '')
-        if config.get('db_password_encrypted'):
-            # 복호화 가능한 config_manager가 없어 암호문을 그대로 쓸 수 없음
-            logger.debug(f"Latency 측정 스킵 (비밀번호 복호화 불가): {tunnel_id}")
-            return '', ''
-
-        return db_user, ''
+    def _get_health_credentials(self, tunnel_id: str, config: Dict[str, object]) -> tuple:
+        """Health check용 DB 자격 증명 조회 (TunnelHealthChecker로 위임)"""
+        return self._health_checker._get_health_credentials(tunnel_id, config)
 
     def _measure_latency(self, tunnel_id: str) -> float:
-        """Latency 측정 (Rust DB Core 연결 사용)
-
-        MySQL/PostgreSQL 모두 실제 DB 프로토콜 연결을 통해 응답 시간을 측정합니다.
-
-        Args:
-            tunnel_id: 터널 ID
-
-        Returns:
-            지연 시간 (밀리초), 측정 실패 시 -1
-        """
-        try:
-            config = self.tunnel_engine.tunnel_configs.get(tunnel_id)
-            if not config:
-                return -1
-
-            # DB 인증 정보 확인 (실제 config 키: db_user + 암호화된 db_password_encrypted)
-            db_username, db_password = self._get_health_credentials(tunnel_id, config)
-            db_name = config.get('default_database') or config.get('db_name') or config.get('default_schema') or ''
-            db_engine = normalize_db_engine(config.get('db_engine'), config.get('remote_port'))
-
-            # 인증 정보가 없으면 측정 불가
-            if not db_username:
-                logger.debug(f"Latency 측정 스킵 (DB 인증 정보 없음): {tunnel_id}")
-                return -1
-
-            connection_mode = config.get('connection_mode', 'ssh')
-
-            if connection_mode == 'direct':
-                host = config.get('remote_host', '')
-                port = int(config.get('remote_port', DEFAULT_MYSQL_PORT))
-            else:
-                # SSH 터널 모드: 로컬 포트 사용
-                local_port = config.get('local_port')
-                if not local_port:
-                    return -1
-                host = DEFAULT_LOCAL_HOST
-                port = int(local_port)
-
-            # 캐시된 연결 조회 (딕셔너리 조회만 락으로 보호)
-            with self._lock:
-                conn = self._health_connections.get(tunnel_id)
-
-            # 연결이 없거나 끊어진 경우 재연결 (연결 생성은 락 밖에서 수행)
-            if conn is None:
-                conn = self._create_health_connection(
-                    tunnel_id, db_engine, host, port, db_username, db_password, db_name
-                )
-                if conn is None:
-                    return -1
-
-            # Rust Core connection ping으로 latency 측정
-            start = time.time()
-            try:
-                conn.ping(reconnect=False)
-                latency = (time.time() - start) * 1000
-                return latency
-            except Exception as e:
-                logger.debug(f"DB ping 실패 ({tunnel_id}): {e}")
-                # 연결 끊김 - 캐시에서 제거
-                self._cleanup_health_connection(tunnel_id)
-                return -1
-
-        except Exception as e:
-            logger.debug(f"Latency 측정 오류 ({tunnel_id}): {e}")
-            return -1
+        """Latency 측정 (TunnelHealthChecker로 위임)"""
+        return self._health_checker._measure_latency(tunnel_id)
 
     def _create_health_connection(
         self, tunnel_id: str, engine: str, host: str, port: int,
         username: str, password: str, database: str
-    ) -> Optional[Any]:
-        """Health check용 DB 연결 생성
-
-        Rust 커넥터 connect()/autocommit() 같은 블로킹 I/O는 락 밖에서 수행하고,
-        캐시 딕셔너리 갱신만 락으로 보호한다.
-
-        Args:
-            tunnel_id: 터널 ID
-            host: DB 호스트
-            port: DB 포트
-            username: DB 사용자명
-            password: DB 비밀번호
-            database: DB 이름
-
-        Returns:
-            DB connection 또는 None
-        """
-        try:
-            connector = create_rust_db_connector(
-                engine,
-                host,
-                port,
-                username,
-                password,
-                database if database else None,
-            )
-            success, message = connector.connect()
-            if not success or connector.connection is None:
-                logger.debug(f"Health check 연결 생성 실패 ({tunnel_id}): {message}")
-                return None
-            connector.connection.autocommit(True)
-            conn = connector.connection
-
-            # 다른 스레드가 동시에 같은 터널의 연결을 이미 캐시했다면
-            # 기존 것을 사용하고 방금 만든 연결은 락 밖에서 닫는다.
-            duplicate = None
-            with self._lock:
-                existing = self._health_connections.get(tunnel_id)
-                if existing is not None:
-                    duplicate = conn
-                    conn = existing
-                else:
-                    self._health_connections[tunnel_id] = conn
-
-            if duplicate is not None:
-                try:
-                    duplicate.close()
-                except Exception:
-                    pass
-            else:
-                logger.debug(f"Health check 연결 생성: {tunnel_id}")
-
-            return conn
-        except Exception as e:
-            logger.debug(f"Health check 연결 생성 실패 ({tunnel_id}): {e}")
-            return None
+    ):
+        """Health check용 DB 연결 생성 (TunnelHealthChecker로 위임)"""
+        return self._health_checker._create_health_connection(
+            tunnel_id, engine, host, port, username, password, database
+        )
 
     def _attempt_reconnect(self, tunnel_id: str):
         """자동 재연결 시도
@@ -533,9 +387,8 @@ class TunnelMonitor:
                 )
                 return
 
-            # 백오프 딜레이: 1s, 2s, 5s, 10s, 30s, 60s
-            backoff = [1, 2, 5, 10, 30, 60]
-            delay = backoff[min(status.reconnect_count, len(backoff) - 1)]
+            # 백오프 딜레이: RECONNECT_BACKOFF_SECONDS 참조 (증가 정책은 모듈 상수 주석 참조)
+            delay = RECONNECT_BACKOFF_SECONDS[min(status.reconnect_count, len(RECONNECT_BACKOFF_SECONDS) - 1)]
 
             status.state = TunnelState.RECONNECTING
             status.reconnect_count += 1
@@ -546,62 +399,70 @@ class TunnelMonitor:
             )
 
         # 별도 스레드에서 재연결 시도 (락을 점유하지 않은 상태로 예약)
-        def reconnect():
-            time.sleep(delay)
+        threading.Thread(
+            target=self._reconnect_after_delay,
+            args=(tunnel_id, delay, status),
+            daemon=True
+        ).start()
 
-            if not self._running:
-                return
+    def _reconnect_after_delay(self, tunnel_id, delay, status):
+        """지연 시간 대기 후 재연결 시도 (별도 스레드에서 실행)
 
-            try:
-                # start_tunnel은 config dict를 요구함. stop_tunnel이 tunnel_configs를
-                # 삭제하므로, 반드시 stop 호출 전에 config를 조회/보관한다.
-                config = self.tunnel_engine.tunnel_configs.get(tunnel_id)
-                if not config:
-                    with self._lock:
-                        status.state = TunnelState.ERROR
-                        status.error_message = "재연결 실패: 터널 설정을 찾을 수 없음"
-                        self._add_event(
-                            tunnel_id, "error", status.error_message
-                        )
-                        self._notify_callbacks(tunnel_id, status)
-                    return
+        _attempt_reconnect가 예약한 백오프 지연을 소비한 뒤 실제 재연결을 수행한다.
+        """
+        time.sleep(delay)
 
-                # 끊긴 stale server 객체와 tunnel_configs 엔트리를 정리하여
-                # 포트 충돌 및 객체 누수를 방지한다.
-                self.tunnel_engine.stop_tunnel(tunnel_id)
+        if not self._running:
+            return
 
-                # 자동 재연결은 포트 재사용 상황이라 포트 충돌 체크를 건너뛴다.
-                success, msg = self.tunnel_engine.start_tunnel(
-                    config, check_port=False
-                )
-
-                should_retry = False
-                with self._lock:
-                    if success:
-                        status.state = TunnelState.CONNECTED
-                        status.connected_at = datetime.now()
-                        status.reconnect_count = 0
-                        status.error_message = None
-                        self._add_event(tunnel_id, "reconnected", "자동 재연결 성공")
-                    else:
-                        status.state = TunnelState.ERROR
-                        status.error_message = msg
-                        should_retry = self._auto_reconnect and self._running
-
-                    self._notify_callbacks(tunnel_id, status)
-
-                # 재귀 호출(및 그에 이은 sleep)은 락을 놓은 뒤 수행하여
-                # 대기 중에도 다른 스레드가 상태를 조회/갱신할 수 있게 한다.
-                if should_retry:
-                    self._attempt_reconnect(tunnel_id)
-
-            except Exception as e:
-                logger.error(f"재연결 오류 ({tunnel_id}): {e}")
+        try:
+            # start_tunnel은 config dict를 요구함. stop_tunnel이 tunnel_configs를
+            # 삭제하므로, 반드시 stop 호출 전에 config를 조회/보관한다.
+            config = self.tunnel_engine.tunnel_configs.get(tunnel_id)
+            if not config:
                 with self._lock:
                     status.state = TunnelState.ERROR
-                    status.error_message = str(e)
+                    status.error_message = "재연결 실패: 터널 설정을 찾을 수 없음"
+                    self._add_event(
+                        tunnel_id, "error", status.error_message
+                    )
+                    self._notify_callbacks(tunnel_id, status)
+                return
 
-        threading.Thread(target=reconnect, daemon=True).start()
+            # 끊긴 stale server 객체와 tunnel_configs 엔트리를 정리하여
+            # 포트 충돌 및 객체 누수를 방지한다.
+            self.tunnel_engine.stop_tunnel(tunnel_id)
+
+            # 자동 재연결은 포트 재사용 상황이라 포트 충돌 체크를 건너뛴다.
+            success, msg = self.tunnel_engine.start_tunnel(
+                config, check_port=False
+            )
+
+            should_retry = False
+            with self._lock:
+                if success:
+                    status.state = TunnelState.CONNECTED
+                    status.connected_at = datetime.now()
+                    status.reconnect_count = 0
+                    status.error_message = None
+                    self._add_event(tunnel_id, "reconnected", "자동 재연결 성공")
+                else:
+                    status.state = TunnelState.ERROR
+                    status.error_message = msg
+                    should_retry = self._auto_reconnect and self._running
+
+                self._notify_callbacks(tunnel_id, status)
+
+            # 재귀 호출(및 그에 이은 sleep)은 락을 놓은 뒤 수행하여
+            # 대기 중에도 다른 스레드가 상태를 조회/갱신할 수 있게 한다.
+            if should_retry:
+                self._attempt_reconnect(tunnel_id)
+
+        except Exception as e:
+            logger.error(f"재연결 오류 ({tunnel_id}): {e}")
+            with self._lock:
+                status.state = TunnelState.ERROR
+                status.error_message = str(e)
 
     def _add_event(self, tunnel_id: str, event_type: str, message: str):
         """이벤트 추가"""

--- a/tests/test_tunnel_monitor.py
+++ b/tests/test_tunnel_monitor.py
@@ -426,7 +426,9 @@ class TestTunnelMonitor:
             created["database"] = database
             return FakeConnector()
 
-        monkeypatch.setattr("src.core.tunnel_monitor.create_rust_db_connector", fake_create)
+        # CC-025: health check 로직이 tunnel_health_checker.py로 이관되어
+        # create_rust_db_connector 호출도 그 모듈 네임스페이스에서 일어난다.
+        monkeypatch.setattr("src.core.tunnel_health_checker.create_rust_db_connector", fake_create)
 
         conn = self.monitor._create_health_connection(
             "pg-tunnel", "postgresql", "127.0.0.1", 5432, "user", "pw", "analytics"
@@ -501,7 +503,8 @@ class TestTunnelMonitor:
         def fake_create(engine, host, port, user, password, database=None, schema=""):
             return FakeConnector(user, password)
 
-        monkeypatch.setattr("src.core.tunnel_monitor.create_rust_db_connector", fake_create)
+        # CC-025: create_rust_db_connector 호출은 이제 tunnel_health_checker.py 소속
+        monkeypatch.setattr("src.core.tunnel_health_checker.create_rust_db_connector", fake_create)
 
         result = self.monitor._measure_latency('tunnel1')
 
@@ -522,7 +525,8 @@ class TestTunnelMonitor:
         def fail_create(*args, **kwargs):
             raise AssertionError("db user 없이는 connector를 생성하면 안 됨")
 
-        monkeypatch.setattr("src.core.tunnel_monitor.create_rust_db_connector", fail_create)
+        # CC-025: create_rust_db_connector 호출은 이제 tunnel_health_checker.py 소속
+        monkeypatch.setattr("src.core.tunnel_health_checker.create_rust_db_connector", fail_create)
 
         result = self.monitor._measure_latency('tunnel1')
         assert result == -1


### PR DESCRIPTION
## 요약

Clean Code 리팩토링 Round 2, WP-2.8 (인프라 터널/플랫폼 소파일 정리). `_WP_SPEC.md`는 Round 1 머지 이전 코드베이스 기준으로 작성되어 라인번호가 대부분 무효화되어 있었으므로, 심볼명 기준으로 현재 코드에서 위치를 다시 찾아 작업했습니다. 스펙 대비 무의미해진 finding은 없었습니다(15건 모두 현재 코드에 그대로 남아 있었음).

## 처리한 Findings

- **CC-023/024** (`tunnel_engine.py`): `SSHTunnelForwarder` 생성 코드 3곳(`_start_ssh_tunnel`/`create_temp_tunnel`/`_test_ssh_tunnel_connection`)을 `_build_forwarder` 헬퍼로 통합. 모듈 전역 `SSHTunnelForwarder`를 그대로 참조하도록 하여 기존 테스트의 모듈 스코프 패치(`patch('src.core.tunnel_engine.SSHTunnelForwarder')`)가 계속 유효합니다. 파라미터/지역변수 `tid`는 전부 `tunnel_id`로 개명했고, `get_active_tunnels()`가 반환하는 dict의 `'id'`/`'tunnel_id'` 키 문자열은 그대로 유지했습니다.
- **CC-025** (`tunnel_monitor.py` → 신규 `tunnel_health_checker.py`): health-check 책임(연결 캐시, 자격증명 조회, latency 측정)을 `TunnelHealthChecker` 클래스로 추출했습니다. `TunnelMonitor`는 이를 조합하되, 기존 테스트 표면 보존을 위해 동일 이름의 위임(delegate) 메서드와 `_health_connections`/`config_manager` property(모두 checker의 동일 객체를 그대로 반환)를 유지했습니다. `create_rust_db_connector`를 monkeypatch하던 테스트 2곳은 실제 호출부가 이동한 `tunnel_health_checker` 모듈 경로로 patch 대상을 수정했습니다(동작은 동일, patch 위치만 보정).
- **CC-026/027** (`tunnel_monitor.py`): 재연결 백오프 리스트를 `RECONNECT_BACKOFF_SECONDS` 모듈 상수로 승격하고, `_attempt_reconnect` 내부의 중첩 `reconnect()` 클로저를 `_reconnect_after_delay(self, tunnel_id, delay, status)` 명명 메서드로 승격했습니다. `threading.Thread` 호출은 모듈 전역을 그대로 사용해 `patch('threading.Thread')` 기반 테스트가 그대로 통과합니다.
- **CC-028** (`single_instance.py`): `waitForConnected`/`waitForBytesWritten`/`time.sleep` 매직넘버를 `_CONNECT_ATTEMPT_TIMEOUT_MS`/`_POLL_INTERVAL_SECONDS` 모듈 상수로 승격.
- **CC-029** (`platform_paths.py`): Windows(LOCALAPPDATA fallback)/Linux(XDG fallback) 공통 로직을 `_platform_base_dir` 헬퍼로 캡슐화. macOS는 함수마다 서브패스가 달라(logs vs Application Support) helper로 뭉개지 않고 각 함수가 직접 처리하도록 유지했습니다.
- **CC-030** (`platform_integration.py`): `StartupRegistrar`를 `WindowsStartupRegistrar`/`MacOSStartupRegistrar` 전략 클래스 + 얇은 facade로 분리했습니다(같은 파일 내부, 새 import 경로 없음). 공개 생성자 kwargs(`platform_name`/`home`/`executable`)와 `is_registered`/`set_registered` 시그니처·반환 튜플은 그대로 유지했습니다.
- **CC-031/032/033** (`production_guard.py`): `SchemaConfirmDialog._init_ui`를 `_build_header_frame`/`_build_details_section`/`_build_schema_input_section`/`_build_button_row` 4개 빌더로 분해했습니다(위젯 트리를 그대로 보존하기 위해 컨테이너로 감싸지 않고 개별 위젯 리스트를 반환). 미사용 `QFont` import를 제거하고, 하드코딩 색상(`#f8f9fa`/`#dee2e6`/`#bdc3c7`/`#3498db`)을 `_NEUTRAL_BG`/`_NEUTRAL_BORDER`/`_INPUT_BORDER`/`_INPUT_FOCUS_BORDER` 모듈 상수로 승격했습니다. 최종 렌더링 QSS 문자열은 오프스크린 스모크 테스트로 시그널 연결·버튼 활성화 동작까지 확인했습니다.
- **CC-034/035** (`mysql_login_path.py`): `is_available()`은 `main_window.py:763,789`에서 호출되므로 삭제하지 않고 `return True`로 단순화, 오해 소지 있는 docstring/try-except를 제거했습니다. AES 블록 크기(128)를 `_AES_BLOCK_SIZE_BITS` 상수로 승격.
- **CC-047** (`logger.py`): `filter_log_by_level`에서 선행 `if`가 이미 ERROR를 처리하므로 도달 불가능했던 `elif level_upper == 'ERROR'` 분기를 제거.
- **CC-049** (`oneclick_log.py`): 미사용 `from typing import Optional` 제거.

## 검증

- `py_compile`: 신규 파일 포함 대상 10개 파일 전부 통과
- 타겟 pytest: `tests/test_tunnel_engine.py tests/test_tunnel_monitor.py tests/test_single_instance.py tests/test_platform_paths.py tests/test_platform_integration.py tests/test_production_guard.py tests/test_mysql_login_path.py tests/test_logger.py` → **96 passed**
- 전체 `pytest -q` 1회 → **1836 passed, 1 failed** (실패 1건은 `test_rust_core_packaging.py::test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`로 GitHub Actions 실행 이력에 의존하는 로컬 환경 상시 실패 테스트이며, 본 변경과 무관 — 기존에도 로컬에서 항상 실패하던 테스트)
- `SchemaConfirmDialog`는 `QT_QPA_PLATFORM=offscreen`으로 직접 인스턴스화하여 `input_schema`/`btn_execute` 시그널 연결과 활성화 로직이 그대로 동작하는지 별도 스모크 테스트로 확인

## 리스크

- CC-025 추출 과정에서 `test_tunnel_monitor.py`의 `create_rust_db_connector` monkeypatch 대상 3곳을 `src.core.tunnel_monitor` → `src.core.tunnel_health_checker`로 수정했습니다. 실제 호출 위치가 이동했기 때문에 필요한 최소 수정이며, 어서션 의도는 변경하지 않았습니다.
- `TunnelMonitor.config_manager`를 property로 바꿔 `TunnelHealthChecker.config_manager`에 위임하도록 했습니다 — `test_measure_latency_uses_config_manager_credentials`가 생성자 이후 `monitor.config_manager = mock_config`로 재할당하는 것을 검증하기 위한 설계 판단입니다(스펙에 명시되지 않았지만 기존 테스트 통과를 위해 필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)