### PR TITLE
refactor(migration-core): migrate/ddl/dump_format 중복·매직값·갓함수 정리 (WP-2.12)

### DIFF
--- a/migration_core/src/ddl.rs
+++ b/migration_core/src/ddl.rs
@@ -4,6 +4,14 @@ use std::io::Write;
 
 use crate::*;
 
+/// MySQL collation/식별자 이름의 최대 길이. MySQL 식별자는 64자를 넘지 못하므로,
+/// 그보다 긴 collation 문자열은 변조된 값으로 보고 fail-closed로 거부한다.
+const MYSQL_IDENTIFIER_MAX_LEN: usize = 64;
+
+/// 검증 대상 컬럼 타입 문자열의 최대 길이. 정상 타입 선언은 이보다 훨씬 짧으므로,
+/// 초과하는 값은 주입 시도로 보고 파싱 전에 fail-closed로 거부한다.
+const MAX_COLUMN_TYPE_LEN: usize = 512;
+
 pub(crate) fn read_engine(payload: &Value, key: &str) -> String {
     payload
         .get(key)
@@ -241,13 +249,11 @@ pub fn select_chunk_sql(
     )
 }
 
-pub fn select_chunk_text_sql(
-    engine: &str,
-    table: &NormalizedTable,
-    key_columns: &[String],
-) -> String {
-    let columns = column_names(table);
-    let projected_columns = table
+/// 청크 SELECT의 텍스트 컬럼 프로젝션 절을 생성한다. 바이너리 컬럼은 hex로 인코딩하고
+/// (postgresql=encode, 그 외=HEX), 나머지는 엔진별로 text/CAST로 정규화하여 JSONL 직렬화가
+/// 안전한 문자열이 되도록 한다. 세 select_chunk_text_* 함수가 동일 프로젝션을 공유한다.
+fn projected_text_columns_sql(engine: &str, table: &NormalizedTable) -> String {
+    table
         .columns
         .iter()
         .map(|column| {
@@ -280,7 +286,16 @@ pub fn select_chunk_text_sql(
             }
         })
         .collect::<Vec<_>>()
-        .join(", ");
+        .join(", ")
+}
+
+pub fn select_chunk_text_sql(
+    engine: &str,
+    table: &NormalizedTable,
+    key_columns: &[String],
+) -> String {
+    let columns = column_names(table);
+    let projected_columns = projected_text_columns_sql(engine, table);
     let order_columns: Vec<String> = if key_columns.is_empty() {
         columns
     } else {
@@ -312,40 +327,7 @@ pub fn select_chunk_text_after_key_sql(
     limit: usize,
 ) -> String {
     let columns = column_names(table);
-    let projected_columns = table
-        .columns
-        .iter()
-        .map(|column| {
-            if is_binary_type(&column.type_name) && engine == "postgresql" {
-                format!(
-                    "encode({}, 'hex') AS {}",
-                    quote_ident(engine, &column.name),
-                    quote_ident(engine, &column.name)
-                )
-            } else if is_binary_type(&column.type_name) {
-                format!(
-                    "HEX({}) AS {}",
-                    quote_ident(engine, &column.name),
-                    quote_ident(engine, &column.name)
-                )
-            } else if engine == "postgresql" {
-                format!(
-                    "{}::text AS {}",
-                    quote_ident(engine, &column.name),
-                    quote_ident(engine, &column.name)
-                )
-            } else if engine == "mysql" {
-                quote_ident(engine, &column.name)
-            } else {
-                format!(
-                    "CAST({} AS CHAR) AS {}",
-                    quote_ident(engine, &column.name),
-                    quote_ident(engine, &column.name)
-                )
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(", ");
+    let projected_columns = projected_text_columns_sql(engine, table);
     let order_by = key_columns
         .iter()
         .map(|column| quote_column_ref(engine, &table.name, column))
@@ -387,40 +369,7 @@ pub fn select_chunk_text_range_sql(
     start: i128,
     end: i128,
 ) -> String {
-    let projected_columns = table
-        .columns
-        .iter()
-        .map(|column| {
-            if is_binary_type(&column.type_name) && engine == "postgresql" {
-                format!(
-                    "encode({}, 'hex') AS {}",
-                    quote_ident(engine, &column.name),
-                    quote_ident(engine, &column.name)
-                )
-            } else if is_binary_type(&column.type_name) {
-                format!(
-                    "HEX({}) AS {}",
-                    quote_ident(engine, &column.name),
-                    quote_ident(engine, &column.name)
-                )
-            } else if engine == "postgresql" {
-                format!(
-                    "{}::text AS {}",
-                    quote_ident(engine, &column.name),
-                    quote_ident(engine, &column.name)
-                )
-            } else if engine == "mysql" {
-                quote_ident(engine, &column.name)
-            } else {
-                format!(
-                    "CAST({} AS CHAR) AS {}",
-                    quote_ident(engine, &column.name),
-                    quote_ident(engine, &column.name)
-                )
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(", ");
+    let projected_columns = projected_text_columns_sql(engine, table);
     let key_ref = quote_column_ref(engine, &table.name, key_column);
     format!(
         "SELECT {} FROM {} WHERE {} >= {} AND {} <= {} ORDER BY {}",
@@ -485,13 +434,17 @@ pub fn insert_sql(engine: &str, table: &str, columns: &[String]) -> String {
     )
 }
 
-pub fn insert_rows_literal_sql(
+/// `INSERT INTO t (cols) VALUES (...), (...)`를 조립하는 공통 헬퍼.
+/// row가 Object가 아니면 모든 컬럼을 NULL로, Object면 컬럼명으로 값을 조회해
+/// `literal_for(컬럼명, 값)`으로 SQL 리터럴을 만든다. 값이 없으면 Value::Null로 대체한다.
+fn insert_values_sql(
     engine: &str,
     table: &str,
-    columns: &[String],
+    column_names: &[&str],
     rows: &[Value],
+    literal_for: impl Fn(&str, &Value) -> String,
 ) -> String {
-    let column_sql = columns
+    let column_sql = column_names
         .iter()
         .map(|column| quote_ident(engine, column))
         .collect::<Vec<_>>()
@@ -499,11 +452,11 @@ pub fn insert_rows_literal_sql(
     let values_sql = rows
         .iter()
         .map(|row| {
-            let values = columns
+            let values = column_names
                 .iter()
                 .map(|column| match row {
                     Value::Object(object) => {
-                        sql_literal(object.get(column).unwrap_or(&Value::Null))
+                        literal_for(column, object.get(*column).unwrap_or(&Value::Null))
                     }
                     _ => "NULL".to_string(),
                 })
@@ -521,43 +474,33 @@ pub fn insert_rows_literal_sql(
     )
 }
 
+pub fn insert_rows_literal_sql(
+    engine: &str,
+    table: &str,
+    columns: &[String],
+    rows: &[Value],
+) -> String {
+    let column_names: Vec<&str> = columns.iter().map(String::as_str).collect();
+    insert_values_sql(engine, table, &column_names, rows, |_column, value| {
+        sql_literal(value)
+    })
+}
+
 pub fn insert_rows_literal_sql_for_table(
     target_engine: &str,
     table: &NormalizedTable,
     rows: &[Value],
 ) -> String {
-    let columns = column_names(table);
-    let column_sql = columns
+    let column_names: Vec<&str> = table.columns.iter().map(|column| column.name.as_str()).collect();
+    let column_types: BTreeMap<&str, &str> = table
+        .columns
         .iter()
-        .map(|column| quote_ident(target_engine, column))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let values_sql = rows
-        .iter()
-        .map(|row| {
-            let values = table
-                .columns
-                .iter()
-                .map(|column| match row {
-                    Value::Object(object) => sql_literal_for_column(
-                        target_engine,
-                        &column.type_name,
-                        object.get(&column.name).unwrap_or(&Value::Null),
-                    ),
-                    _ => "NULL".to_string(),
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("({values})")
-        })
-        .collect::<Vec<_>>()
-        .join(", ");
-    format!(
-        "INSERT INTO {} ({}) VALUES {}",
-        quote_ident(target_engine, &table.name),
-        column_sql,
-        values_sql
-    )
+        .map(|column| (column.name.as_str(), column.type_name.as_str()))
+        .collect();
+    insert_values_sql(target_engine, &table.name, &column_names, rows, |column, value| {
+        let source_type = column_types.get(column).copied().unwrap_or("");
+        sql_literal_for_column(target_engine, source_type, value)
+    })
 }
 
 pub(crate) fn copy_rows_to_postgres(
@@ -709,13 +652,15 @@ pub fn sql_literal_for_column(target_engine: &str, source_type: &str, value: &Va
         if target_engine == "postgresql" {
             return sql_literal(&Value::String(sanitize_postgresql_text(text)));
         }
-        if target_engine == "mysql" && is_json_type(&source_type) {
-            return mysql_json_literal(value);
-        }
-        if target_engine == "mysql" {
-            return mysql_sql_literal(value);
-        }
+        return mysql_or_generic_literal(target_engine, &source_type, value);
     }
+    mysql_or_generic_literal(target_engine, source_type, value)
+}
+
+/// mysql 타겟이면 JSON 타입은 `_utf8mb4'...'` 도입자를 붙이고, 그 외 mysql 값은 mysql
+/// 이스케이프 규칙으로, mysql이 아니면 범용 SQL 리터럴로 변환한다.
+/// sql_literal_for_column의 String/비-String 경로가 공유하던 3분기 로직을 통합한 헬퍼다.
+fn mysql_or_generic_literal(target_engine: &str, source_type: &str, value: &Value) -> String {
     if target_engine == "mysql" && is_json_type(source_type) {
         return mysql_json_literal(value);
     }
@@ -764,7 +709,10 @@ pub fn is_timestamp_type(type_name: &str) -> bool {
     type_name.starts_with("datetime") || type_name.starts_with("timestamp")
 }
 
-pub fn sql_literal(value: &Value) -> String {
+/// Null/Bool/Number의 공통 SQL 리터럴화를 담당하고, 문자열/배열/객체는 주어진 `escape`
+/// 클로저로 이스케이프한다. sql_literal(작은따옴표 doubling)과 mysql_sql_literal(mysql
+/// 이스케이프)이 동일한 Null/Bool/Number arm을 공유하도록 통합한 헬퍼다.
+fn generic_sql_literal(value: &Value, escape: impl Fn(&str) -> String) -> String {
     match value {
         Value::Null => "NULL".to_string(),
         Value::Bool(value) => {
@@ -775,27 +723,17 @@ pub fn sql_literal(value: &Value) -> String {
             }
         }
         Value::Number(value) => value.to_string(),
-        Value::String(value) => format!("'{}'", value.replace('\'', "''")),
-        Value::Array(_) | Value::Object(_) => {
-            format!("'{}'", value.to_string().replace('\'', "''"))
-        }
+        Value::String(value) => escape(value),
+        Value::Array(_) | Value::Object(_) => escape(&value.to_string()),
     }
 }
 
+pub fn sql_literal(value: &Value) -> String {
+    generic_sql_literal(value, |text| format!("'{}'", text.replace('\'', "''")))
+}
+
 fn mysql_sql_literal(value: &Value) -> String {
-    match value {
-        Value::Null => "NULL".to_string(),
-        Value::Bool(value) => {
-            if *value {
-                "TRUE".to_string()
-            } else {
-                "FALSE".to_string()
-            }
-        }
-        Value::Number(value) => value.to_string(),
-        Value::String(value) => mysql_string_literal(value),
-        Value::Array(_) | Value::Object(_) => mysql_string_literal(&value.to_string()),
-    }
+    generic_sql_literal(value, mysql_string_literal)
 }
 
 fn mysql_json_literal(value: &Value) -> String {
@@ -929,6 +867,27 @@ pub(crate) fn group_foreign_keys(rows: Vec<(String, String, String, String)>) ->
 }
 
 pub(crate) fn generate_table_ddl(table: &NormalizedTable, source: &str, target: &str) -> Option<String> {
+    let (mut lines, primary_keys) = column_ddl_lines(table, source, target)?;
+    if !primary_keys.is_empty() {
+        lines.push(format!("  PRIMARY KEY ({})", primary_keys.join(", ")));
+    }
+    let table_suffix = mysql_table_collation_suffix(source, target, table)?;
+    Some(format!(
+        "CREATE TABLE {} (\n{}\n){};",
+        quote_ident(target, &table.name),
+        lines.join(",\n"),
+        table_suffix
+    ))
+}
+
+/// 각 컬럼의 DDL 라인과 primary key 컬럼 목록을 만든다. 최종 DDL에 들어갈 타입 문자열
+/// (mapped_type)을 is_safe_column_type로 검증하고, 위반 시 fail-closed로 None을 반환해
+/// 컬럼 정의 탈출(CTAS/추가 컬럼 주입)을 차단한다.
+fn column_ddl_lines(
+    table: &NormalizedTable,
+    source: &str,
+    target: &str,
+) -> Option<(Vec<String>, Vec<String>)> {
     let mut lines = Vec::new();
     let mut primary_keys = Vec::new();
 
@@ -969,41 +928,40 @@ pub(crate) fn generate_table_ddl(table: &NormalizedTable, source: &str, target: 
         }
     }
 
-    if !primary_keys.is_empty() {
-        lines.push(format!("  PRIMARY KEY ({})", primary_keys.join(", ")));
-    }
+    Some((lines, primary_keys))
+}
 
+/// same-engine(MySQL→MySQL) 일 때만 테이블 레벨 `COLLATE=...` 접미사를 만든다.
+/// cross-engine이나 PostgreSQL 타겟은 빈 문자열을 반환하고, 변조된 collation 값은
+/// fail-closed로 None을 반환한다.
+fn mysql_table_collation_suffix(
+    source: &str,
+    target: &str,
+    table: &NormalizedTable,
+) -> Option<String> {
     // 테이블 레벨 기본 collation 재현은 같은 엔진(MySQL→MySQL)에서만 한다.
     // cross-engine이나 PostgreSQL 타겟에는 테이블 레벨 DEFAULT COLLATE 개념이 없어 붙이면 오류가 난다.
     // COLLATE만 지정해도 MySQL이 해당 collation의 charset을 자동 결정하므로 charset은 별도로 방출하지 않는다.
-    let table_suffix =
-        if source.eq_ignore_ascii_case(target) && target.eq_ignore_ascii_case("mysql") {
-            match table
-                .table_collation
-                .as_deref()
-                .map(str::trim)
-                .filter(|collation| !collation.is_empty())
-            {
-                // dump 매니페스트는 변조 가능한 파일이므로, collation 값을 그대로 DDL에 끼우면
-                // `utf8mb4_bin AS SELECT ...`(CTAS) 나 `utf8mb4_bin ENGINE=MyISAM` 같은
-                // 테이블 옵션/구문 주입이 가능하다(SQL injection). MySQL collation 식별자 형태만
-                // 허용하고, 위반 시 fail-closed로 DDL 생성을 거부한다(import 중단).
-                Some(collation) if is_valid_mysql_collation_ident(collation) => {
-                    format!(" COLLATE={collation}")
-                }
-                Some(_) => return None,
-                None => String::new(),
+    if source.eq_ignore_ascii_case(target) && target.eq_ignore_ascii_case("mysql") {
+        match table
+            .table_collation
+            .as_deref()
+            .map(str::trim)
+            .filter(|collation| !collation.is_empty())
+        {
+            // dump 매니페스트는 변조 가능한 파일이므로, collation 값을 그대로 DDL에 끼우면
+            // `utf8mb4_bin AS SELECT ...`(CTAS) 나 `utf8mb4_bin ENGINE=MyISAM` 같은
+            // 테이블 옵션/구문 주입이 가능하다(SQL injection). MySQL collation 식별자 형태만
+            // 허용하고, 위반 시 fail-closed로 DDL 생성을 거부한다(import 중단).
+            Some(collation) if is_valid_mysql_collation_ident(collation) => {
+                Some(format!(" COLLATE={collation}"))
             }
-        } else {
-            String::new()
-        };
-
-    Some(format!(
-        "CREATE TABLE {} (\n{}\n){};",
-        quote_ident(target, &table.name),
-        lines.join(",\n"),
-        table_suffix
-    ))
+            Some(_) => None,
+            None => Some(String::new()),
+        }
+    } else {
+        Some(String::new())
+    }
 }
 
 /// dump 매니페스트에서 온 collation 문자열이 MySQL collation 식별자로 안전한지 검사한다.
@@ -1011,10 +969,212 @@ pub(crate) fn generate_table_ddl(table: &NormalizedTable, source: &str, target: 
 /// CTAS·table_options SQL 주입을 fail-closed로 차단한다.
 fn is_valid_mysql_collation_ident(value: &str) -> bool {
     !value.is_empty()
-        && value.len() <= 64
+        && value.len() <= MYSQL_IDENTIFIER_MAX_LEN
         && value
             .bytes()
             .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
+/// base 식별자를 파싱한다: ascii 알파벳으로 시작해 이후 영숫자/밑줄. 성공 시 진행된 index를,
+/// 첫 글자가 알파벳이 아니면 None을 반환한다.
+fn parse_base_ident(bytes: &[u8], mut i: usize) -> Option<usize> {
+    if i >= bytes.len() || !bytes[i].is_ascii_alphabetic() {
+        return None;
+    }
+    i += 1;
+    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+        i += 1;
+    }
+    Some(i)
+}
+
+/// enum/set의 따옴표 문자열 리스트를 파싱한다: qstr (',' qstr)*. `i`는 첫 여는 따옴표를 가리켜야 한다.
+/// 백슬래시를 포함한 값과 닫히지 않은 문자열은 fail-closed로 거부한다(어느 MySQL 이스케이프
+/// 모드에서도 validator와 서버의 따옴표 경계가 어긋나지 않도록).
+fn parse_quoted_string_list(bytes: &[u8], mut i: usize) -> Option<usize> {
+    loop {
+        if i >= bytes.len() || bytes[i] != b'\'' {
+            return None;
+        }
+        i += 1;
+        loop {
+            if i >= bytes.len() {
+                return None; // 닫히지 않은 문자열
+            }
+            match bytes[i] {
+                b'\\' => return None,
+                b'\'' => {
+                    if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+                        i += 2; // '' 이스케이프된 따옴표
+                    } else {
+                        i += 1; // 닫는 따옴표
+                        break;
+                    }
+                }
+                _ => i += 1,
+            }
+        }
+        while i < bytes.len() && bytes[i] == b' ' {
+            i += 1;
+        }
+        if i < bytes.len() && bytes[i] == b',' {
+            i += 1;
+            while i < bytes.len() && bytes[i] == b' ' {
+                i += 1;
+            }
+            continue;
+        }
+        break;
+    }
+    Some(i)
+}
+
+/// 숫자 리스트를 파싱한다: digits (',' digits)*. 숫자가 하나도 없으면 None을 반환한다.
+fn parse_numeric_list(bytes: &[u8], mut i: usize) -> Option<usize> {
+    loop {
+        let numeric_list_start = i;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i == numeric_list_start {
+            return None;
+        }
+        while i < bytes.len() && bytes[i] == b' ' {
+            i += 1;
+        }
+        if i < bytes.len() && bytes[i] == b',' {
+            i += 1;
+            while i < bytes.len() && bytes[i] == b' ' {
+                i += 1;
+            }
+            continue;
+        }
+        break;
+    }
+    Some(i)
+}
+
+/// 선택적 인자 그룹 '(' ... ')'를 파싱한다. `i`는 여는 괄호를 가리켜야 한다.
+/// 내부는 따옴표 문자열 리스트(enum/set) 또는 숫자 리스트다.
+fn parse_arg_group(bytes: &[u8], i: usize) -> Option<usize> {
+    let mut i = i + 1;
+    while i < bytes.len() && bytes[i] == b' ' {
+        i += 1;
+    }
+    i = if i < bytes.len() && bytes[i] == b'\'' {
+        parse_quoted_string_list(bytes, i)?
+    } else {
+        parse_numeric_list(bytes, i)?
+    };
+    while i < bytes.len() && bytes[i] == b' ' {
+        i += 1;
+    }
+    if i >= bytes.len() || bytes[i] != b')' {
+        return None;
+    }
+    Some(i + 1)
+}
+
+/// 하나의 후행 modifier 단어와 그 인자를 파싱한다. `i`는 단어 첫 글자(비공백)를 가리켜야 한다.
+///   modifier = unsigned | zerofill | precision | varying [ '(' digits ')' ]
+///            | (with|without) time zone | (charset|collate) <ident>
+///            | character set <ident>
+/// 허용되지 않는 단어나 비단어 문자는 None으로 거부한다.
+fn parse_modifier_word(s: &str, bytes: &[u8], i: usize) -> Option<usize> {
+    let modifier_word_start = i;
+    let mut i = i;
+    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+        i += 1;
+    }
+    if i == modifier_word_start {
+        return None; // 비단어 문자(괄호/세미콜론/등호 등) → 거부
+    }
+    let word = s[modifier_word_start..i].to_ascii_lowercase();
+    match word.as_str() {
+        // PostgreSQL 원형 다단어 타입 꼬리 허용: `double precision`, `bit/character varying`,
+        // `timestamp/time with|without time zone`. same-engine PostgreSQL에서는 map_type이
+        // 원문 type_name을 그대로 반환하므로, 이 타입들을 거부하면 정상 import가 깨진다(fidelity).
+        "unsigned" | "zerofill" | "precision" => Some(i),
+        "varying" => {
+            // character varying(255) / bit varying(8) — 선택적 길이 인자를 허용한다.
+            while i < bytes.len() && bytes[i] == b' ' {
+                i += 1;
+            }
+            if i < bytes.len() && bytes[i] == b'(' {
+                i += 1;
+                while i < bytes.len() && bytes[i] == b' ' {
+                    i += 1;
+                }
+                let varying_length_start = i;
+                while i < bytes.len() && bytes[i].is_ascii_digit() {
+                    i += 1;
+                }
+                if i == varying_length_start {
+                    return None;
+                }
+                while i < bytes.len() && bytes[i] == b' ' {
+                    i += 1;
+                }
+                if i >= bytes.len() || bytes[i] != b')' {
+                    return None;
+                }
+                i += 1;
+            }
+            Some(i)
+        }
+        "with" | "without" => {
+            for expected in ["time", "zone"] {
+                while i < bytes.len() && bytes[i] == b' ' {
+                    i += 1;
+                }
+                let time_zone_word_start = i;
+                while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
+                    i += 1;
+                }
+                if !s[time_zone_word_start..i].eq_ignore_ascii_case(expected) {
+                    return None;
+                }
+            }
+            Some(i)
+        }
+        "charset" | "collate" => {
+            while i < bytes.len() && bytes[i] == b' ' {
+                i += 1;
+            }
+            let charset_or_collate_value_start = i;
+            while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                i += 1;
+            }
+            if i == charset_or_collate_value_start {
+                return None;
+            }
+            Some(i)
+        }
+        "character" => {
+            while i < bytes.len() && bytes[i] == b' ' {
+                i += 1;
+            }
+            let set_keyword_start = i;
+            while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
+                i += 1;
+            }
+            if !s[set_keyword_start..i].eq_ignore_ascii_case("set") {
+                return None;
+            }
+            while i < bytes.len() && bytes[i] == b' ' {
+                i += 1;
+            }
+            let character_set_name_start = i;
+            while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                i += 1;
+            }
+            if i == character_set_name_start {
+                return None;
+            }
+            Some(i)
+        }
+        _ => None,
+    }
 }
 
 /// dump 매니페스트에서 온 MySQL 컬럼 타입 문자열이 안전한 문법인지 검사한다.
@@ -1026,98 +1186,22 @@ fn is_valid_mysql_collation_ident(value: &str) -> bool {
 /// enum/set 값 리스트는 따옴표 문자열이라 단순 식별자 allowlist로는 걸러낼 수 없어 구조적으로 파싱한다.
 fn is_safe_column_type(type_name: &str) -> bool {
     let s = type_name.trim();
-    if s.is_empty() || s.len() > 512 {
+    if s.is_empty() || s.len() > MAX_COLUMN_TYPE_LEN {
         return false;
     }
     let bytes = s.as_bytes();
-    let mut i = 0usize;
 
-    // 1) base 식별자: ascii 알파벳으로 시작, 이후 영숫자/밑줄
-    if !bytes[i].is_ascii_alphabetic() {
+    // 1) base 식별자
+    let Some(mut i) = parse_base_ident(bytes, 0) else {
         return false;
-    }
-    i += 1;
-    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
-        i += 1;
-    }
+    };
 
     // 2) 선택적 인자 그룹 '(' ... ')'
     if i < bytes.len() && bytes[i] == b'(' {
-        i += 1;
-        while i < bytes.len() && bytes[i] == b' ' {
-            i += 1;
+        match parse_arg_group(bytes, i) {
+            Some(next) => i = next,
+            None => return false,
         }
-        if i < bytes.len() && bytes[i] == b'\'' {
-            // 따옴표 문자열 리스트 (enum/set): qstr (',' qstr)*
-            loop {
-                if i >= bytes.len() || bytes[i] != b'\'' {
-                    return false;
-                }
-                i += 1;
-                loop {
-                    if i >= bytes.len() {
-                        return false; // 닫히지 않은 문자열
-                    }
-                    // enum/set 문자열 값에 백슬래시가 있으면 fail-closed로 거부한다.
-                    // 백슬래시를 일반 문자로 취급하면 기본 MySQL 모드(백슬래시=이스케이프)에서 validator와
-                    // 서버의 따옴표 경계가 어긋나 우회되고(예: enum('a\', ') , evil int -- ')), 반대로
-                    // 이스케이프로 취급하면 NO_BACKSLASH_ESCAPES 모드에서 어긋난다. 어느 모드에서도 안전하도록
-                    // 백슬래시를 포함한 값 자체를 거부한다(정상 enum/set 값에 백슬래시는 실사용상 드묾).
-                    match bytes[i] {
-                        b'\\' => return false,
-                        b'\'' => {
-                            if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
-                                i += 2; // '' 이스케이프된 따옴표
-                            } else {
-                                i += 1; // 닫는 따옴표
-                                break;
-                            }
-                        }
-                        _ => i += 1,
-                    }
-                }
-                while i < bytes.len() && bytes[i] == b' ' {
-                    i += 1;
-                }
-                if i < bytes.len() && bytes[i] == b',' {
-                    i += 1;
-                    while i < bytes.len() && bytes[i] == b' ' {
-                        i += 1;
-                    }
-                    continue;
-                }
-                break;
-            }
-        } else {
-            // 숫자 리스트: digits (',' digits)*
-            loop {
-                let ds = i;
-                while i < bytes.len() && bytes[i].is_ascii_digit() {
-                    i += 1;
-                }
-                if i == ds {
-                    return false;
-                }
-                while i < bytes.len() && bytes[i] == b' ' {
-                    i += 1;
-                }
-                if i < bytes.len() && bytes[i] == b',' {
-                    i += 1;
-                    while i < bytes.len() && bytes[i] == b' ' {
-                        i += 1;
-                    }
-                    continue;
-                }
-                break;
-            }
-        }
-        while i < bytes.len() && bytes[i] == b' ' {
-            i += 1;
-        }
-        if i >= bytes.len() || bytes[i] != b')' {
-            return false;
-        }
-        i += 1;
     }
 
     // 3) 후행 modifier들 (공백 구분)
@@ -1128,95 +1212,9 @@ fn is_safe_column_type(type_name: &str) -> bool {
         if i >= bytes.len() {
             break;
         }
-        let ws = i;
-        while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
-            i += 1;
-        }
-        if i == ws {
-            return false; // 비단어 문자(괄호/세미콜론/등호 등) → 거부
-        }
-        let word = s[ws..i].to_ascii_lowercase();
-        match word.as_str() {
-            "unsigned" | "zerofill" => {}
-            // PostgreSQL 원형 다단어 타입 꼬리 허용: `double precision`, `bit/character varying`,
-            // `timestamp/time with|without time zone`. same-engine PostgreSQL에서는 map_type이
-            // 원문 type_name을 그대로 반환하므로, 이 타입들을 거부하면 정상 import가 깨진다(fidelity).
-            "precision" => {}
-            "varying" => {
-                // character varying(255) / bit varying(8) — 선택적 길이 인자를 허용한다.
-                while i < bytes.len() && bytes[i] == b' ' {
-                    i += 1;
-                }
-                if i < bytes.len() && bytes[i] == b'(' {
-                    i += 1;
-                    while i < bytes.len() && bytes[i] == b' ' {
-                        i += 1;
-                    }
-                    let ds = i;
-                    while i < bytes.len() && bytes[i].is_ascii_digit() {
-                        i += 1;
-                    }
-                    if i == ds {
-                        return false;
-                    }
-                    while i < bytes.len() && bytes[i] == b' ' {
-                        i += 1;
-                    }
-                    if i >= bytes.len() || bytes[i] != b')' {
-                        return false;
-                    }
-                    i += 1;
-                }
-            }
-            "with" | "without" => {
-                for expected in ["time", "zone"] {
-                    while i < bytes.len() && bytes[i] == b' ' {
-                        i += 1;
-                    }
-                    let ws2 = i;
-                    while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
-                        i += 1;
-                    }
-                    if !s[ws2..i].eq_ignore_ascii_case(expected) {
-                        return false;
-                    }
-                }
-            }
-            "charset" | "collate" => {
-                while i < bytes.len() && bytes[i] == b' ' {
-                    i += 1;
-                }
-                let is2 = i;
-                while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
-                    i += 1;
-                }
-                if i == is2 {
-                    return false;
-                }
-            }
-            "character" => {
-                while i < bytes.len() && bytes[i] == b' ' {
-                    i += 1;
-                }
-                let ss = i;
-                while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
-                    i += 1;
-                }
-                if !s[ss..i].eq_ignore_ascii_case("set") {
-                    return false;
-                }
-                while i < bytes.len() && bytes[i] == b' ' {
-                    i += 1;
-                }
-                let is2 = i;
-                while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
-                    i += 1;
-                }
-                if i == is2 {
-                    return false;
-                }
-            }
-            _ => return false,
+        match parse_modifier_word(s, bytes, i) {
+            Some(next) => i = next,
+            None => return false,
         }
     }
 
@@ -1535,6 +1533,30 @@ mod tests {
     
     
     use crate::adapters::test_support::{RecordingAdapter, schema, single_pk_table_with_collation};
+
+    /// mysql JSON 컬럼 리터럴 테스트가 공유하는 fixture. `ai_phase1_cache.result_json`에
+    /// 유니코드 + 백슬래시 이스케이프가 섞인 JSON을 insert하는 SQL을 만든다.
+    fn ai_phase1_cache_json_insert_sql() -> String {
+        let table = NormalizedTable {
+            name: "ai_phase1_cache".to_string(),
+            columns: vec![NormalizedColumn {
+                name: "result_json".to_string(),
+                type_name: "json".to_string(),
+                default_value: None,
+                nullable: false,
+                primary_key: false,
+                unique: false,
+            }],
+            indexes: Vec::new(),
+            foreign_keys: Vec::new(),
+            table_collation: None,
+        };
+        let json_text = r#"{"facts":[{"content":"문서 제목은 \"工伤管理表\"로 표기되어 있다."}]}"#;
+        insert_rows_literal_sql_for_table("mysql", &table, &[json!({"result_json": json_text})])
+    }
+
+    const AI_PHASE1_CACHE_JSON_INSERT_SQL: &str =
+        r#"INSERT INTO `ai_phase1_cache` (`result_json`) VALUES (_utf8mb4'{"facts":[{"content":"문서 제목은 \\"工伤管理表\\"로 표기되어 있다."}]}')"#;
 
     #[test]
     fn post_load_ddl_policy_applies_for_recreated_targets_only() {
@@ -2263,61 +2285,19 @@ mod tests {
 
     #[test]
     fn mysql_json_literal_insert_preserves_json_escape_backslashes() {
-        let table = NormalizedTable {
-            name: "ai_phase1_cache".to_string(),
-            columns: vec![NormalizedColumn {
-                name: "result_json".to_string(),
-                type_name: "json".to_string(),
-                default_value: None,
-                nullable: false,
-                primary_key: false,
-                unique: false,
-            }],
-            indexes: Vec::new(),
-            foreign_keys: Vec::new(),
-            table_collation: None,
-        };
-        let json_text = r#"{"facts":[{"content":"문서 제목은 \"工伤管理表\"로 표기되어 있다."}]}"#;
-
-        let sql = insert_rows_literal_sql_for_table(
-            "mysql",
-            &table,
-            &[json!({"result_json": json_text})],
-        );
-
+        // JSON 내부 백슬래시 이스케이프가 mysql 리터럴에서 이중 백슬래시로 보존되는지 검증.
         assert_eq!(
-            sql,
-            r#"INSERT INTO `ai_phase1_cache` (`result_json`) VALUES (_utf8mb4'{"facts":[{"content":"문서 제목은 \\"工伤管理表\\"로 표기되어 있다."}]}')"#
+            ai_phase1_cache_json_insert_sql(),
+            AI_PHASE1_CACHE_JSON_INSERT_SQL
         );
     }
 
     #[test]
     fn mysql_json_literal_uses_utf8mb4_introducer_for_unicode_json_text() {
-        let table = NormalizedTable {
-            name: "ai_phase1_cache".to_string(),
-            columns: vec![NormalizedColumn {
-                name: "result_json".to_string(),
-                type_name: "json".to_string(),
-                default_value: None,
-                nullable: false,
-                primary_key: false,
-                unique: false,
-            }],
-            indexes: Vec::new(),
-            foreign_keys: Vec::new(),
-            table_collation: None,
-        };
-        let json_text = r#"{"facts":[{"content":"문서 제목은 \"工伤管理表\"로 표기되어 있다."}]}"#;
-
-        let sql = insert_rows_literal_sql_for_table(
-            "mysql",
-            &table,
-            &[json!({"result_json": json_text})],
-        );
-
+        // 유니코드 JSON 텍스트에 _utf8mb4 도입자가 붙는지 검증.
         assert_eq!(
-            sql,
-            r#"INSERT INTO `ai_phase1_cache` (`result_json`) VALUES (_utf8mb4'{"facts":[{"content":"문서 제목은 \\"工伤管理表\\"로 표기되어 있다."}]}')"#
+            ai_phase1_cache_json_insert_sql(),
+            AI_PHASE1_CACHE_JSON_INSERT_SQL
         );
     }
 

--- a/migration_core/src/dump_format.rs
+++ b/migration_core/src/dump_format.rs
@@ -9,6 +9,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use mysql::prelude::Queryable;
 use crate::*;
 
+/// 이 평균 행 크기(바이트) 이상인 넓은 테이블에서는, 직전 실행에서 학습된 chunk_rows 프로파일이
+/// 바이트 목표 기반 추정보다 실측에 가깝다고 보고 학습값을 신뢰한다.
+const LEARNED_PROFILE_LARGE_ROW_BYTES: u64 = 4_096;
+
 pub fn table_dependency_order(schema: &NormalizedSchema) -> Vec<String> {
     let (ordered, _) = table_dependency_order_indices(schema);
     ordered
@@ -244,7 +248,7 @@ pub(crate) fn learned_mysql_range_chunk_size(
     let Some(profile) = profile else {
         return byte_target_size;
     };
-    if avg_row_bytes >= 4_096 && profile.chunk_rows >= byte_target_size {
+    if avg_row_bytes >= LEARNED_PROFILE_LARGE_ROW_BYTES && profile.chunk_rows >= byte_target_size {
         return profile.chunk_rows.max(1).min(fallback_chunk_size.max(1));
     }
     byte_target_size

--- a/migration_core/src/migrate.rs
+++ b/migration_core/src/migrate.rs
@@ -453,6 +453,17 @@ fn plan_table_summaries(request: &Request, schema: &NormalizedSchema) -> Vec<Val
         .collect()
 }
 
+/// payload에서 필수 endpoint(`source`/`target`)를 해석한다. 키가 없으면 패닉 대신 Err를
+/// 반환하고, endpoint_from_value의 파싱 오류도 그대로 Err로 전달한다. 호출부(migrate/verify)는
+/// 반환된 Err를 각자의 error 이벤트 방식(emit vs events.push)으로 처리한다.
+fn required_endpoint(payload: &Value, key: &str) -> Result<Endpoint, String> {
+    match payload.get(key).map(endpoint_from_value).transpose() {
+        Ok(Some(endpoint)) => Ok(endpoint),
+        Ok(None) => Err(format!("{key} endpoint is missing")),
+        Err(err) => Err(err),
+    }
+}
+
 pub(crate) fn migrate_streaming<F: FnMut(Value)>(request: &Request, mut emit: F) {
     emit(phase_event(request, "migrate", "migration started"));
     if request.payload.get("source").is_some() && request.payload.get("target").is_some() {
@@ -464,27 +475,15 @@ pub(crate) fn migrate_streaming<F: FnMut(Value)>(request: &Request, mut emit: F)
             .payload
             .get("state")
             .and_then(|value| serde_json::from_value::<ResumeState>(value.clone()).ok());
-        let source_endpoint = match request
-            .payload
-            .get("source")
-            .map(endpoint_from_value)
-            .transpose()
-        {
-            Ok(Some(endpoint)) => endpoint,
-            Ok(None) => unreachable!(),
+        let source_endpoint = match required_endpoint(&request.payload, "source") {
+            Ok(endpoint) => endpoint,
             Err(err) => {
                 emit(json!({"event": "error", "request_id": request.request_id, "message": err}));
                 return;
             }
         };
-        let target_endpoint = match request
-            .payload
-            .get("target")
-            .map(endpoint_from_value)
-            .transpose()
-        {
-            Ok(Some(endpoint)) => endpoint,
-            Ok(None) => unreachable!(),
+        let target_endpoint = match required_endpoint(&request.payload, "target") {
+            Ok(endpoint) => endpoint,
             Err(err) => {
                 emit(json!({"event": "error", "request_id": request.request_id, "message": err}));
                 return;
@@ -618,14 +617,8 @@ pub(crate) fn verify(request: &Request) -> Vec<Value> {
     let mut events = vec![phase_event(request, "verify", "verification started")];
     if request.payload.get("source").is_some() && request.payload.get("target").is_some() {
         let schema = parse_schema(&request.payload["schema"]).unwrap_or_default();
-        let source_endpoint = match request
-            .payload
-            .get("source")
-            .map(endpoint_from_value)
-            .transpose()
-        {
-            Ok(Some(endpoint)) => endpoint,
-            Ok(None) => unreachable!(),
+        let source_endpoint = match required_endpoint(&request.payload, "source") {
+            Ok(endpoint) => endpoint,
             Err(err) => {
                 events.push(
                     json!({"event": "error", "request_id": request.request_id, "message": err}),
@@ -633,14 +626,8 @@ pub(crate) fn verify(request: &Request) -> Vec<Value> {
                 return events;
             }
         };
-        let target_endpoint = match request
-            .payload
-            .get("target")
-            .map(endpoint_from_value)
-            .transpose()
-        {
-            Ok(Some(endpoint)) => endpoint,
-            Ok(None) => unreachable!(),
+        let target_endpoint = match required_endpoint(&request.payload, "target") {
+            Ok(endpoint) => endpoint,
             Err(err) => {
                 events.push(
                     json!({"event": "error", "request_id": request.request_id, "message": err}),
@@ -1066,18 +1053,12 @@ fn migrate_with_adapters_reporting<S: MigrationAdapter, T: MigrationAdapter, F: 
         match generate_schema_ddl(&ordered_schema, source_engine, target_engine) {
             Ok(ddl) => ddl,
             Err(err) => {
-                let table = ordered_schema
+                let location = ordered_schema
                     .tables
                     .first()
-                    .cloned()
-                    .unwrap_or(NormalizedTable {
-                        name: "schema_ddl".to_string(),
-                        columns: Vec::new(),
-                        indexes: Vec::new(),
-                        foreign_keys: Vec::new(),
-                        table_collation: None,
-                    });
-                return migration_error_result(state, rows_copied, chunks_copied, &table, err);
+                    .map(|table| table.name.as_str())
+                    .unwrap_or("schema_ddl");
+                return migration_error_result(state, rows_copied, chunks_copied, location, err);
             }
         }
     };
@@ -1095,77 +1076,30 @@ fn migrate_with_adapters_reporting<S: MigrationAdapter, T: MigrationAdapter, F: 
         }
 
         let table_ddl = ddl.get(table_index).map(String::as_str).unwrap_or("");
-        if let Err(err) = target.create_table(table, table_ddl) {
-            return migration_error_result(state, rows_copied, chunks_copied, table, err);
-        }
-        let total_rows = source.row_count(&table.name).ok();
-        let key_columns = key_columns(table);
-        let use_keyset = !key_columns.is_empty();
-        let mut offset = if use_keyset {
-            0
-        } else {
-            state.tables[state_index].rows_copied as usize
-        };
-        let mut last_key = if use_keyset {
-            state.tables[state_index].last_key.clone()
-        } else {
-            None
-        };
-        loop {
-            let rows = match if use_keyset {
-                source.read_rows_after_key(table, &key_columns, last_key.as_deref(), chunk_size)
-            } else {
-                source.read_rows(table, offset, chunk_size)
-            } {
-                Ok(rows) => rows,
-                Err(err) => {
-                    return migration_error_result(state, rows_copied, chunks_copied, table, err)
-                }
-            };
-            if rows.is_empty() {
-                state.tables[state_index].completed = true;
-                state.tables[state_index].last_key = None;
-                on_event(json!({
-                    "event": "table_progress",
-                    "table": table.name,
-                    "status": "completed",
-                    "state": &state
-                }));
-                break;
+        match copy_table_rows(
+            table,
+            table_ddl,
+            &mut state,
+            state_index,
+            source,
+            target,
+            options,
+            chunk_size,
+            &mut rows_copied,
+            &mut chunks_copied,
+            on_event,
+        ) {
+            Ok(()) => {}
+            Err(TableCopyControl::Error(err)) => {
+                return migration_error_result(
+                    state,
+                    rows_copied,
+                    chunks_copied,
+                    &table.name,
+                    err,
+                );
             }
-
-            let copied_now = rows.len();
-            let next_key = if use_keyset {
-                rows.last().and_then(|row| row_key_token(row, &key_columns))
-            } else {
-                None
-            };
-            if let Err(err) = target.insert_rows(table, rows) {
-                return migration_error_result(state, rows_copied, chunks_copied, table, err);
-            }
-            if use_keyset {
-                state.tables[state_index].rows_copied += copied_now as u64;
-                state.tables[state_index].last_key = next_key.clone();
-                last_key = next_key;
-            } else {
-                offset += copied_now;
-                state.tables[state_index].rows_copied = offset as u64;
-                state.tables[state_index].last_key = Some(offset.to_string());
-            }
-            rows_copied += copied_now as u64;
-            chunks_copied += 1;
-            on_event(json!({
-                "event": "row_progress",
-                "table": table.name,
-                "rows": state.tables[state_index].rows_copied,
-                "total": total_rows,
-                "state": &state
-            }));
-
-            if options
-                .cancel_after_chunks
-                .is_some_and(|limit| chunks_copied >= limit)
-            {
+            Err(TableCopyControl::Cancelled) => {
                 return MigrationResult {
                     success: false,
                     rows_copied,
@@ -1179,18 +1113,12 @@ fn migrate_with_adapters_reporting<S: MigrationAdapter, T: MigrationAdapter, F: 
 
     state.current_phase = "completed".to_string();
     if let Err(err) = apply_post_load_ddl(target, &ordered_schema, target_engine) {
-        let table = ordered_schema
+        let location = ordered_schema
             .tables
             .first()
-            .cloned()
-            .unwrap_or(NormalizedTable {
-                name: "post_data_ddl".to_string(),
-                columns: Vec::new(),
-                indexes: Vec::new(),
-                foreign_keys: Vec::new(),
-                table_collation: None,
-            });
-        return migration_error_result(state, rows_copied, chunks_copied, &table, err);
+            .map(|table| table.name.as_str())
+            .unwrap_or("post_data_ddl");
+        return migration_error_result(state, rows_copied, chunks_copied, location, err);
     }
     MigrationResult {
         success: true,
@@ -1201,11 +1129,111 @@ fn migrate_with_adapters_reporting<S: MigrationAdapter, T: MigrationAdapter, F: 
     }
 }
 
+/// 한 테이블의 복사 흐름을 나타내는 내부 제어 신호. create/read/insert 오류(Error)나
+/// cancel_after_chunks 도달(Cancelled) 시 상위 함수가 최종 MigrationResult를 조립하도록 위임한다.
+/// (state를 소유한 상위에서 결과를 만들어야 하므로 여기서는 MigrationResult를 직접 반환하지 않는다.)
+enum TableCopyControl {
+    Error(String),
+    Cancelled,
+}
+
+/// create_table 후 keyset/offset 페이지네이션으로 한 테이블의 행을 청크 단위로 복사하고
+/// state와 rows_copied/chunks_copied를 갱신하며 progress 이벤트를 emit한다. 정상 완료 시 Ok(()),
+/// 오류/취소 시 상위가 처리하도록 Err(TableCopyControl)을 반환한다.
+#[allow(clippy::too_many_arguments)]
+fn copy_table_rows<S: MigrationAdapter, T: MigrationAdapter, F: FnMut(Value)>(
+    table: &NormalizedTable,
+    table_ddl: &str,
+    state: &mut ResumeState,
+    state_index: usize,
+    source: &mut S,
+    target: &mut T,
+    options: &MigrationOptions,
+    chunk_size: usize,
+    rows_copied: &mut u64,
+    chunks_copied: &mut usize,
+    on_event: &mut F,
+) -> Result<(), TableCopyControl> {
+    if let Err(err) = target.create_table(table, table_ddl) {
+        return Err(TableCopyControl::Error(err));
+    }
+    let total_rows = source.row_count(&table.name).ok();
+    let key_columns = key_columns(table);
+    let use_keyset = !key_columns.is_empty();
+    let mut offset = if use_keyset {
+        0
+    } else {
+        state.tables[state_index].rows_copied as usize
+    };
+    let mut last_key = if use_keyset {
+        state.tables[state_index].last_key.clone()
+    } else {
+        None
+    };
+    loop {
+        let rows = match if use_keyset {
+            source.read_rows_after_key(table, &key_columns, last_key.as_deref(), chunk_size)
+        } else {
+            source.read_rows(table, offset, chunk_size)
+        } {
+            Ok(rows) => rows,
+            Err(err) => return Err(TableCopyControl::Error(err)),
+        };
+        if rows.is_empty() {
+            state.tables[state_index].completed = true;
+            state.tables[state_index].last_key = None;
+            on_event(json!({
+                "event": "table_progress",
+                "table": table.name,
+                "status": "completed",
+                "state": &state
+            }));
+            break;
+        }
+
+        let copied_now = rows.len();
+        let next_key = if use_keyset {
+            rows.last().and_then(|row| row_key_token(row, &key_columns))
+        } else {
+            None
+        };
+        if let Err(err) = target.insert_rows(table, rows) {
+            return Err(TableCopyControl::Error(err));
+        }
+        if use_keyset {
+            state.tables[state_index].rows_copied += copied_now as u64;
+            state.tables[state_index].last_key = next_key.clone();
+            last_key = next_key;
+        } else {
+            offset += copied_now;
+            state.tables[state_index].rows_copied = offset as u64;
+            state.tables[state_index].last_key = Some(offset.to_string());
+        }
+        *rows_copied += copied_now as u64;
+        *chunks_copied += 1;
+        on_event(json!({
+            "event": "row_progress",
+            "table": table.name,
+            "rows": state.tables[state_index].rows_copied,
+            "total": total_rows,
+            "state": &state
+        }));
+
+        if options
+            .cancel_after_chunks
+            .is_some_and(|limit| *chunks_copied >= limit)
+        {
+            return Err(TableCopyControl::Cancelled);
+        }
+    }
+    Ok(())
+}
+
 fn migration_error_result(
     state: ResumeState,
     rows_copied: u64,
     chunks_copied: usize,
-    table: &NormalizedTable,
+    location: &str,
     err: String,
 ) -> MigrationResult {
     MigrationResult {
@@ -1216,7 +1244,7 @@ fn migration_error_result(
         issues: vec![MigrationIssue {
             issue_type: None,
             severity: "error".to_string(),
-            location: table.name.clone(),
+            location: location.to_string(),
             message: err,
             suggestion: "Resolve the database error and resume the migration.".to_string(),
             blocking: true,
@@ -1340,11 +1368,10 @@ fn verify_with_adapters_reporting<S: MigrationAdapter, T: MigrationAdapter, F: F
             }
         };
         let total_rows = source_count.max(target_count);
-        let mut verified_rows = 0usize;
         emit(json!({
             "event": "row_progress",
             "table": table.name,
-            "rows": verified_rows,
+            "rows": 0,
             "total": total_rows
         }));
         if source_count != target_count {
@@ -1357,116 +1384,157 @@ fn verify_with_adapters_reporting<S: MigrationAdapter, T: MigrationAdapter, F: F
         }
 
         let key_columns = key_columns(table);
-        if key_columns.is_empty() {
-            let source_counts = match digest_counts_for_adapter(source, table, chunk_size) {
-                Ok(counts) => counts,
-                Err(err) => {
-                    mismatches.push(json!({
-                        "table": table.name,
-                        "kind": "error",
-                        "side": "source",
-                        "message": err
-                    }));
-                    continue;
-                }
-            };
-            let target_counts = match digest_counts_for_adapter(target, table, chunk_size) {
-                Ok(counts) => counts,
-                Err(err) => {
-                    mismatches.push(json!({
-                        "table": table.name,
-                        "kind": "error",
-                        "side": "target",
-                        "message": err
-                    }));
-                    continue;
-                }
-            };
-            for mismatch in compare_digest_counts(&source_counts, &target_counts) {
-                mismatches.push(with_table(&table.name, mismatch));
-            }
-            verified_rows = total_rows;
-            emit(json!({
-                "event": "row_progress",
-                "table": table.name,
-                "rows": verified_rows,
-                "total": total_rows
-            }));
-            emit(json!({
-                "event": "table_progress",
-                "table": table.name,
-                "status": "completed"
-            }));
-            continue;
-        }
-
-        let mut last_key: Option<String> = None;
-        loop {
-            let source_rows = match source.read_rows_after_key(
+        let table_mismatches = if key_columns.is_empty() {
+            verify_table_by_digest(source, target, table, chunk_size, total_rows, emit)
+        } else {
+            verify_table_by_keyset(
+                source,
+                target,
                 table,
                 &key_columns,
-                last_key.as_deref(),
                 chunk_size,
-            ) {
-                Ok(rows) => rows,
-                Err(err) => {
-                    mismatches.push(json!({
-                        "table": table.name,
-                        "kind": "error",
-                        "side": "source",
-                        "message": err
-                    }));
-                    break;
-                }
-            };
-            let target_rows = match target.read_rows_after_key(
-                table,
-                &key_columns,
-                last_key.as_deref(),
-                chunk_size,
-            ) {
-                Ok(rows) => rows,
-                Err(err) => {
-                    mismatches.push(json!({
-                        "table": table.name,
-                        "kind": "error",
-                        "side": "target",
-                        "message": err
-                    }));
-                    break;
-                }
-            };
-            if source_rows.is_empty() && target_rows.is_empty() {
-                break;
-            }
-            mismatches.extend(compare_typed_keyed_rows(
-                table,
-                &key_columns,
-                &source_rows,
-                &target_rows,
-            ));
-            verified_rows += source_rows.len().max(target_rows.len());
-            emit(json!({
-                "event": "row_progress",
-                "table": table.name,
-                "rows": verified_rows.min(total_rows),
-                "total": total_rows
-            }));
-            let next_key = source_rows
-                .last()
-                .or_else(|| target_rows.last())
-                .and_then(|row| row_key_token(row, &key_columns));
-            if next_key.is_none() || next_key == last_key {
-                break;
-            }
-            last_key = next_key;
-        }
-        emit(json!({
-            "event": "table_progress",
-            "table": table.name,
-            "status": "completed"
-        }));
+                total_rows,
+                emit,
+            )
+        };
+        mismatches.extend(table_mismatches);
     }
+    mismatches
+}
+
+/// key column이 없는 테이블을 digest 카운트 비교로 검증한다. source/target의 행 다이제스트
+/// 빈도를 비교해 불일치를 만들고, 완료 시 row_progress(total) + table_progress(completed)를 emit한다.
+/// 카운트 수집 오류가 나면 그 오류만 담아 반환하고 완료 이벤트는 emit하지 않는다.
+fn verify_table_by_digest<S: MigrationAdapter, T: MigrationAdapter, F: FnMut(Value)>(
+    source: &mut S,
+    target: &mut T,
+    table: &NormalizedTable,
+    chunk_size: usize,
+    total_rows: usize,
+    emit: &mut F,
+) -> Vec<Value> {
+    let mut mismatches = Vec::new();
+    let source_counts = match digest_counts_for_adapter(source, table, chunk_size) {
+        Ok(counts) => counts,
+        Err(err) => {
+            mismatches.push(json!({
+                "table": table.name,
+                "kind": "error",
+                "side": "source",
+                "message": err
+            }));
+            return mismatches;
+        }
+    };
+    let target_counts = match digest_counts_for_adapter(target, table, chunk_size) {
+        Ok(counts) => counts,
+        Err(err) => {
+            mismatches.push(json!({
+                "table": table.name,
+                "kind": "error",
+                "side": "target",
+                "message": err
+            }));
+            return mismatches;
+        }
+    };
+    for mismatch in compare_digest_counts(&source_counts, &target_counts) {
+        mismatches.push(with_table(&table.name, mismatch));
+    }
+    emit(json!({
+        "event": "row_progress",
+        "table": table.name,
+        "rows": total_rows,
+        "total": total_rows
+    }));
+    emit(json!({
+        "event": "table_progress",
+        "table": table.name,
+        "status": "completed"
+    }));
+    mismatches
+}
+
+/// key column이 있는 테이블을 keyset 페이지네이션으로 행 단위 비교한다. 청크마다 양측을
+/// 읽어 typed 비교하고 row_progress를 emit하며, 마지막에 table_progress(completed)를 emit한다.
+/// 읽기 오류가 나면 그 오류를 담고 루프를 종료한다(완료 이벤트는 그대로 emit).
+fn verify_table_by_keyset<S: MigrationAdapter, T: MigrationAdapter, F: FnMut(Value)>(
+    source: &mut S,
+    target: &mut T,
+    table: &NormalizedTable,
+    key_columns: &[String],
+    chunk_size: usize,
+    total_rows: usize,
+    emit: &mut F,
+) -> Vec<Value> {
+    let mut mismatches = Vec::new();
+    let mut verified_rows = 0usize;
+    let mut last_key: Option<String> = None;
+    loop {
+        let source_rows = match source.read_rows_after_key(
+            table,
+            key_columns,
+            last_key.as_deref(),
+            chunk_size,
+        ) {
+            Ok(rows) => rows,
+            Err(err) => {
+                mismatches.push(json!({
+                    "table": table.name,
+                    "kind": "error",
+                    "side": "source",
+                    "message": err
+                }));
+                break;
+            }
+        };
+        let target_rows = match target.read_rows_after_key(
+            table,
+            key_columns,
+            last_key.as_deref(),
+            chunk_size,
+        ) {
+            Ok(rows) => rows,
+            Err(err) => {
+                mismatches.push(json!({
+                    "table": table.name,
+                    "kind": "error",
+                    "side": "target",
+                    "message": err
+                }));
+                break;
+            }
+        };
+        if source_rows.is_empty() && target_rows.is_empty() {
+            break;
+        }
+        mismatches.extend(compare_typed_keyed_rows(
+            table,
+            key_columns,
+            &source_rows,
+            &target_rows,
+        ));
+        verified_rows += source_rows.len().max(target_rows.len());
+        emit(json!({
+            "event": "row_progress",
+            "table": table.name,
+            "rows": verified_rows.min(total_rows),
+            "total": total_rows
+        }));
+        let next_key = source_rows
+            .last()
+            .or_else(|| target_rows.last())
+            .and_then(|row| row_key_token(row, key_columns));
+        if next_key.is_none() || next_key == last_key {
+            break;
+        }
+        last_key = next_key;
+    }
+    emit(json!({
+        "event": "table_progress",
+        "table": table.name,
+        "status": "completed"
+    }));
     mismatches
 }
 


### PR DESCRIPTION
## 개요

Clean Code Round 2 **WP-2.12** — Rust `migration_core`의 `migrate.rs` / `ddl.rs` / `dump_format.rs` 세 모듈 내부 정리. **순수 동작 보존 리팩터**만 수행했으며, 모든 `pub` 함수의 시그니처/공개성은 불변, 추출한 헬퍼는 전부 module-private입니다. 버전 bump 없음.

## Findings 처리 (16건)

| Finding | 모듈 | 내용 | 상태 |
|---|---|---|---|
| CC-237 | ddl | select_chunk_text_* 3함수의 28줄 프로젝션 클로저 → `projected_text_columns_sql` | 완료 |
| CC-246 | ddl | insert_rows_literal_sql / _for_table INSERT 조립 → `insert_values_sql` | 완료 |
| CC-247 | ddl | sql_literal_for_column의 mysql-json/mysql/fallback 3분기 → `mysql_or_generic_literal` | 완료 |
| CC-250 | ddl | sql_literal / mysql_sql_literal의 Null/Bool/Number arm → `generic_sql_literal` | 완료 |
| CC-244/245 | ddl | is_safe_column_type(198줄 파서) → parse_base_ident / parse_quoted_string_list / parse_numeric_list / parse_arg_group / parse_modifier_word 분해 + 지역변수 의미 이름화 | 완료 |
| CC-249 | ddl | generate_table_ddl → `column_ddl_lines` + `mysql_table_collation_suffix` | 완료 |
| CC-251 | ddl | 매직값 64/512 → `MYSQL_IDENTIFIER_MAX_LEN` / `MAX_COLUMN_TYPE_LEN` 상수 | 완료 |
| CC-243 | dump_format | 매직값 4096 → `LEARNED_PROFILE_LARGE_ROW_BYTES` 상수 | 완료 |
| CC-240 | migrate | endpoint 해석 보일러플레이트 4회 중복 → `required_endpoint` (unreachable!() 패닉 제거) | 완료 |
| CC-238 | migrate | migrate_with_adapters_reporting 테이블별 복사 본문 → `copy_table_rows` + `TableCopyControl` | 완료 |
| CC-239 | migrate | verify_with_adapters_reporting → `verify_table_by_digest` / `verify_table_by_keyset` | 완료 |
| CC-241 | migrate | migration_error_result `table: &NormalizedTable` → `location: &str`, 가짜 NormalizedTable 2곳 제거 | 완료 |
| CC-248 | ddl | 엔진 dispatch 정리는 CC-247 헬퍼 재사용으로 처리, SqlDialect trait은 캐스팅 동작 변경 위험 때문에 **미도입**(스펙 지침) | 완료(축소) |
| CC-252 | ddl | 완전 중복이던 mysql json 리터럴 테스트 2개 fixture → 공유 헬퍼 | 완료 |
| CC-253 | — | 라인번호 무효화로 대상 특정 불가 → **skip**(아래 참고) | skip |

## 주요 판단 (동작 보존 관련)

- **CC-241**: 스펙은 가짜 NormalizedTable 자리에 리터럴 `"schema_ddl"`/`"post_data_ddl"`을 넣으라고 안내하지만, 원본 코드는 `.first().cloned().unwrap_or(fake)` 구조라 **스키마에 테이블이 있으면 location이 첫 테이블명**(fake는 빈 스키마일 때만)입니다. 동작 보존(절대원칙 #1)을 위해 리터럴 대신 `ordered_schema.tables.first().map(|t| t.name.as_str()).unwrap_or("schema_ddl")`로 시맨틱을 그대로 유지했습니다.
- **CC-238**: 스펙의 `Result<TableCopyOutcome, MigrationResult>` 시그니처는 helper가 `&mut state`를 빌린 상태에서 MigrationResult로 state를 move해야 해 borrow 충돌이 발생합니다. state를 소유한 상위가 최종 결과를 조립하도록 `Result<(), TableCopyControl>` 형태(내부 enum)로 구현했습니다. emit 순서·payload·카운트·에러 경로 모두 원본과 동일.
- **CC-253**: "bigint-PK range-dump 리터럴 / auto_increment·기본값 리터럴"이 Round 1 이후 라인번호 무효화로 ~10개 dump/ddl 테스트 중 단일 대상을 명확히 특정할 수 없고, 명백히 안전한 중복이 없어 skip 처리했습니다. 대상이 확정되면 후속 반영 가능합니다.

## 검증

- `cargo build --manifest-path migration_core/Cargo.toml --release` — 성공, 경고 0
- `cargo test --manifest-path migration_core/Cargo.toml` — **216 lib + jsonl_cli 2 + live_roundtrip 9 + stress_rss 2(+1 manual ignored) 전부 pass** (보안 주입 테스트 8건 포함)
- `python -m pytest -q` — **1836 passed**, 1 failed(`test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge` = GitHub CI 의존 로컬 상시 실패 테스트, Rust 변경과 무관)

## 위험

- files_touched(migrate/dump_format/ddl.rs) 밖 파일 변경 없음, lib.rs 미수정, 공유테스트 live_roundtrip.rs 실행만.
- 보안 fail-closed 가드(is_safe_column_type / generate_table_ddl / is_valid_mysql_collation_ident) 분해는 주입 테스트가 그대로 green이라 accept/reject 의미 보존 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)