### PR TITLE
refactor(rust): WP-2.11 query/schema/oneclick 클린코드 정리 (CC-229/231/232/233/234/235/242)

### DIFF
--- a/migration_core/src/oneclick.rs
+++ b/migration_core/src/oneclick.rs
@@ -127,70 +127,12 @@ pub(crate) fn oneclick_run_streaming<F: FnMut(Value)>(request: &Request, mut emi
         "steps": recommendations
     });
     let apply_plan = oneclick_apply_actions(&plan_payload);
-    let (
-        success_count,
-        fail_count,
-        skip_count,
-        disallowed_fix_attempts,
-        applied_fixes,
-        execution_log,
-    ) = if dry_run {
-        (
-            0usize,
-            0usize,
-            apply_plan.actions.len() + apply_plan.skipped,
-            apply_plan.disallowed,
-            Vec::new(),
-            vec!["DRY-RUN: no database changes were executed.".to_string()],
-        )
-    } else if !apply_plan.disallowed.is_empty() {
-        (
-            0,
-            apply_plan.disallowed.len(),
-            apply_plan.skipped,
-            apply_plan.disallowed,
-            Vec::new(),
-            vec!["Disallowed One-Click automatic fix attempt blocked.".to_string()],
-        )
-    } else if apply_plan.actions.is_empty() {
-        (
-            0,
-            0,
-            apply_plan.skipped,
-            Vec::new(),
-            Vec::new(),
-            vec!["No automatic Rust Core fixes are currently required.".to_string()],
-        )
-    } else {
-        match LiveAdapter::connect(&state.endpoint) {
-            Ok(mut adapter) => {
-                let outcome = oneclick_execute_apply_plan(&apply_plan, &mut adapter);
-                (
-                    outcome.success_count,
-                    outcome.fail_count,
-                    apply_plan.skipped,
-                    Vec::new(),
-                    outcome.applied_fixes,
-                    outcome.log,
-                )
-            }
-            Err(err) => (
-                0,
-                apply_plan.actions.len(),
-                apply_plan.skipped,
-                Vec::new(),
-                Vec::new(),
-                vec![format!(
-                    "FAILED: unable to connect for One-Click fixes: {err}"
-                )],
-            ),
-        }
-    };
-    let execution_success = fail_count == 0 && disallowed_fix_attempts.is_empty();
-    let report_execution_log = execution_log.clone();
-    let report_fail_count = fail_count;
-    let report_disallowed_count = disallowed_fix_attempts.len();
-    let report_applied_count = applied_fixes.len();
+    let outcome = oneclick_execute_stage(&state, &apply_plan, dry_run);
+    let execution_success = outcome.fail_count == 0 && outcome.disallowed_fix_attempts.is_empty();
+    let report_execution_log = outcome.log.clone();
+    let report_fail_count = outcome.fail_count;
+    let report_disallowed_count = outcome.disallowed_fix_attempts.len();
+    let report_applied_count = outcome.applied_fixes.len();
     let execution_message = if dry_run {
         "Execution completed"
     } else if execution_success {
@@ -202,12 +144,12 @@ pub(crate) fn oneclick_run_streaming<F: FnMut(Value)>(request: &Request, mut emi
         "event": "execution",
         "request_id": request.request_id,
         "dry_run": dry_run,
-        "success_count": success_count,
-        "fail_count": fail_count,
-        "skip_count": skip_count,
-        "disallowed_fix_attempts": disallowed_fix_attempts,
-        "applied_fixes": applied_fixes,
-        "log": execution_log
+        "success_count": outcome.success_count,
+        "fail_count": outcome.fail_count,
+        "skip_count": outcome.skip_count,
+        "disallowed_fix_attempts": outcome.disallowed_fix_attempts,
+        "applied_fixes": outcome.applied_fixes,
+        "log": outcome.log
     }));
     emit(oneclick_progress_event(request, 80, execution_message));
 
@@ -1316,6 +1258,8 @@ struct OneClickApplyPlan {
 struct OneClickApplyOutcome {
     success_count: usize,
     fail_count: usize,
+    skip_count: usize,
+    disallowed_fix_attempts: Vec<String>,
     log: Vec<String>,
     applied_fixes: Vec<Value>,
 }
@@ -1544,8 +1488,61 @@ fn oneclick_execute_apply_plan<A: MigrationAdapter>(
     OneClickApplyOutcome {
         success_count,
         fail_count,
+        skip_count: plan.skipped,
+        disallowed_fix_attempts: Vec::new(),
         log,
         applied_fixes,
+    }
+}
+
+/// One-Click 실행 단계: dry-run / disallowed / no-action / live-apply 4분기를 처리해
+/// 타입드 OneClickApplyOutcome 로 반환한다. 기존 익명 6-tuple 을 대체한다(동작 보존).
+fn oneclick_execute_stage(
+    state: &OneClickState,
+    apply_plan: &OneClickApplyPlan,
+    dry_run: bool,
+) -> OneClickApplyOutcome {
+    if dry_run {
+        OneClickApplyOutcome {
+            success_count: 0,
+            fail_count: 0,
+            skip_count: apply_plan.actions.len() + apply_plan.skipped,
+            disallowed_fix_attempts: apply_plan.disallowed.clone(),
+            log: vec!["DRY-RUN: no database changes were executed.".to_string()],
+            applied_fixes: Vec::new(),
+        }
+    } else if !apply_plan.disallowed.is_empty() {
+        OneClickApplyOutcome {
+            success_count: 0,
+            fail_count: apply_plan.disallowed.len(),
+            skip_count: apply_plan.skipped,
+            disallowed_fix_attempts: apply_plan.disallowed.clone(),
+            log: vec!["Disallowed One-Click automatic fix attempt blocked.".to_string()],
+            applied_fixes: Vec::new(),
+        }
+    } else if apply_plan.actions.is_empty() {
+        OneClickApplyOutcome {
+            success_count: 0,
+            fail_count: 0,
+            skip_count: apply_plan.skipped,
+            disallowed_fix_attempts: Vec::new(),
+            log: vec!["No automatic Rust Core fixes are currently required.".to_string()],
+            applied_fixes: Vec::new(),
+        }
+    } else {
+        match LiveAdapter::connect(&state.endpoint) {
+            Ok(mut adapter) => oneclick_execute_apply_plan(apply_plan, &mut adapter),
+            Err(err) => OneClickApplyOutcome {
+                success_count: 0,
+                fail_count: apply_plan.actions.len(),
+                skip_count: apply_plan.skipped,
+                disallowed_fix_attempts: Vec::new(),
+                log: vec![format!(
+                    "FAILED: unable to connect for One-Click fixes: {err}"
+                )],
+                applied_fixes: Vec::new(),
+            },
+        }
     }
 }
 

--- a/migration_core/src/oneclick.rs
+++ b/migration_core/src/oneclick.rs
@@ -1327,6 +1327,51 @@ struct OneClickDryRunPreview {
     disallowed: Vec<String>,
 }
 
+/// One-Click step 의 공통 분류 결과.
+/// apply(real) 와 dry-run preview 가 공유하는 per-step 판정만 담는다.
+/// real-apply 전용인 sql_template 불일치 검사는 여기 포함하지 않고
+/// oneclick_apply_actions 후처리에 남긴다(preview 출력 불변 보존).
+enum OneClickStepClassification {
+    Skip,
+    Disallowed(String),
+    Charset(Value),
+    Engine { table: String, sql: String },
+}
+
+fn classify_oneclick_step(step: &Value, schema: &str) -> OneClickStepClassification {
+    let issue_type = step
+        .get("issue_type")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let selected = step.get("selected_option").unwrap_or(&Value::Null);
+    let strategy = selected
+        .get("strategy")
+        .and_then(Value::as_str)
+        .unwrap_or("manual");
+
+    if strategy == "manual" || strategy == "skip" {
+        return OneClickStepClassification::Skip;
+    }
+    if issue_type == "charset_issue" && strategy == "charset_collation_fk_safe" {
+        return match oneclick_charset_fk_safe_option_from_payload(selected, schema) {
+            Ok(option) => OneClickStepClassification::Charset(option),
+            Err(_) => OneClickStepClassification::Disallowed(format!("{issue_type}:{strategy}")),
+        };
+    }
+    if issue_type == "deprecated_engine" && strategy == "engine_innodb" {
+        let Some(table) = oneclick_apply_step_table(step, schema) else {
+            return OneClickStepClassification::Skip;
+        };
+        let sql = format!(
+            "ALTER TABLE {}.{} ENGINE=InnoDB;",
+            quote_ident("mysql", schema),
+            quote_ident("mysql", &table),
+        );
+        return OneClickStepClassification::Engine { table, sql };
+    }
+    OneClickStepClassification::Disallowed(format!("{issue_type}:{strategy}"))
+}
+
 fn oneclick_apply_actions(payload: &Value) -> OneClickApplyPlan {
     let schema = payload
         .get("schema")
@@ -1343,94 +1388,68 @@ fn oneclick_apply_actions(payload: &Value) -> OneClickApplyPlan {
         .into_iter()
         .flatten()
     {
-        let issue_type = step
-            .get("issue_type")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown");
-        let selected = step.get("selected_option").unwrap_or(&Value::Null);
-        let strategy = selected
-            .get("strategy")
-            .and_then(Value::as_str)
-            .unwrap_or("manual");
-
-        if strategy == "manual" || strategy == "skip" {
-            skipped += 1;
-            continue;
-        }
-        if issue_type == "charset_issue" && strategy == "charset_collation_fk_safe" {
-            match oneclick_charset_fk_safe_option_from_payload(selected, schema) {
-                Ok(option) => {
-                    let tables = oneclick_required_string_list(option.get("tables"), "tables")
+        match classify_oneclick_step(step, schema) {
+            OneClickStepClassification::Skip => skipped += 1,
+            OneClickStepClassification::Disallowed(reason) => disallowed.push(reason),
+            OneClickStepClassification::Charset(option) => {
+                let tables = oneclick_required_string_list(option.get("tables"), "tables")
+                    .unwrap_or_default();
+                let fk_order = oneclick_required_string_list(option.get("fk_order"), "fk_order")
+                    .unwrap_or_default();
+                let sql_statements =
+                    oneclick_required_string_list(option.get("sql"), "sql").unwrap_or_default();
+                let rollback_sql =
+                    oneclick_required_string_list(option.get("rollback_sql"), "rollback_sql")
                         .unwrap_or_default();
-                    let fk_order =
-                        oneclick_required_string_list(option.get("fk_order"), "fk_order")
-                            .unwrap_or_default();
-                    let sql_statements =
-                        oneclick_required_string_list(option.get("sql"), "sql").unwrap_or_default();
-                    let rollback_sql =
-                        oneclick_required_string_list(option.get("rollback_sql"), "rollback_sql")
-                            .unwrap_or_default();
-                    actions.push(OneClickApplyAction {
-                        issue_type: issue_type.to_string(),
-                        strategy: strategy.to_string(),
-                        schema: schema.to_string(),
-                        table: tables.first().cloned().unwrap_or_default(),
-                        sql: sql_statements.first().cloned().unwrap_or_default(),
-                        tables,
-                        fk_order,
-                        sql_statements,
-                        rollback_sql,
-                        target_charset: option
-                            .get("target_charset")
-                            .and_then(Value::as_str)
-                            .map(ToString::to_string),
-                        target_collation: option
-                            .get("target_collation")
-                            .and_then(Value::as_str)
-                            .map(ToString::to_string),
-                    });
-                }
-                Err(_) => disallowed.push(format!("{issue_type}:{strategy}")),
+                actions.push(OneClickApplyAction {
+                    issue_type: "charset_issue".to_string(),
+                    strategy: "charset_collation_fk_safe".to_string(),
+                    schema: schema.to_string(),
+                    table: tables.first().cloned().unwrap_or_default(),
+                    sql: sql_statements.first().cloned().unwrap_or_default(),
+                    tables,
+                    fk_order,
+                    sql_statements,
+                    rollback_sql,
+                    target_charset: option
+                        .get("target_charset")
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string),
+                    target_collation: option
+                        .get("target_collation")
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string),
+                });
             }
-            continue;
+            OneClickStepClassification::Engine { table, sql } => {
+                // real-apply 전용: 클라이언트가 보낸 sql_template 이 서버 산출 SQL 과
+                // 불일치하면 disallowed 로 거부한다(preview 경로에는 적용하지 않음).
+                let selected = step.get("selected_option").unwrap_or(&Value::Null);
+                if selected
+                    .get("sql_template")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|template| !template.is_empty() && *template != sql)
+                    .is_some()
+                {
+                    disallowed.push("deprecated_engine:engine_innodb:sql_mismatch".to_string());
+                    continue;
+                }
+                actions.push(OneClickApplyAction {
+                    issue_type: "deprecated_engine".to_string(),
+                    strategy: "engine_innodb".to_string(),
+                    schema: schema.to_string(),
+                    table: table.clone(),
+                    sql: sql.clone(),
+                    tables: vec![table],
+                    fk_order: Vec::new(),
+                    sql_statements: vec![sql],
+                    rollback_sql: Vec::new(),
+                    target_charset: None,
+                    target_collation: None,
+                });
+            }
         }
-        if issue_type != "deprecated_engine" || strategy != "engine_innodb" {
-            disallowed.push(format!("{issue_type}:{strategy}"));
-            continue;
-        }
-
-        let Some(table) = oneclick_apply_step_table(step, schema) else {
-            skipped += 1;
-            continue;
-        };
-        let sql = format!(
-            "ALTER TABLE {}.{} ENGINE=InnoDB;",
-            quote_ident("mysql", schema),
-            quote_ident("mysql", &table),
-        );
-        if selected
-            .get("sql_template")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|template| !template.is_empty() && *template != sql)
-            .is_some()
-        {
-            disallowed.push(format!("{issue_type}:{strategy}:sql_mismatch"));
-            continue;
-        }
-        actions.push(OneClickApplyAction {
-            issue_type: issue_type.to_string(),
-            strategy: strategy.to_string(),
-            schema: schema.to_string(),
-            table: table.clone(),
-            sql: sql.clone(),
-            tables: vec![table],
-            fk_order: Vec::new(),
-            sql_statements: vec![sql],
-            rollback_sql: Vec::new(),
-            target_charset: None,
-            target_collation: None,
-        });
     }
 
     OneClickApplyPlan {
@@ -1456,56 +1475,30 @@ fn oneclick_dry_run_preview_fixes(payload: &Value) -> OneClickDryRunPreview {
         .into_iter()
         .flatten()
     {
-        let issue_type = step
-            .get("issue_type")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown");
-        let selected = step.get("selected_option").unwrap_or(&Value::Null);
-        let strategy = selected
-            .get("strategy")
-            .and_then(Value::as_str)
-            .unwrap_or("manual");
-
-        if strategy == "manual" || strategy == "skip" {
-            skipped += 1;
-            continue;
-        }
-        if issue_type == "charset_issue" && strategy == "charset_collation_fk_safe" {
-            match oneclick_charset_fk_safe_option_from_payload(selected, schema) {
-                Ok(mut plan) => {
-                    if let Some(object) = plan.as_object_mut() {
-                        object.insert("issue_type".to_string(), json!("charset_issue"));
-                        object.insert("schema".to_string(), json!(schema));
-                        object.insert("dry_run".to_string(), json!(true));
-                        object.insert("success".to_string(), json!(false));
-                    }
-                    planned_fixes.push(plan);
+        match classify_oneclick_step(step, schema) {
+            OneClickStepClassification::Skip => skipped += 1,
+            OneClickStepClassification::Disallowed(reason) => disallowed.push(reason),
+            OneClickStepClassification::Charset(mut plan) => {
+                if let Some(object) = plan.as_object_mut() {
+                    object.insert("issue_type".to_string(), json!("charset_issue"));
+                    object.insert("schema".to_string(), json!(schema));
+                    object.insert("dry_run".to_string(), json!(true));
+                    object.insert("success".to_string(), json!(false));
                 }
-                Err(_) => disallowed.push(format!("{issue_type}:{strategy}")),
+                planned_fixes.push(plan);
             }
-            continue;
+            OneClickStepClassification::Engine { table, sql } => {
+                planned_fixes.push(json!({
+                    "issue_type": "deprecated_engine",
+                    "strategy": "engine_innodb",
+                    "schema": schema,
+                    "table": table,
+                    "sql": sql,
+                    "dry_run": true,
+                    "success": false
+                }));
+            }
         }
-        if issue_type == "deprecated_engine" && strategy == "engine_innodb" {
-            let Some(table) = oneclick_apply_step_table(step, schema) else {
-                skipped += 1;
-                continue;
-            };
-            planned_fixes.push(json!({
-                "issue_type": "deprecated_engine",
-                "strategy": "engine_innodb",
-                "schema": schema,
-                "table": table,
-                "sql": format!(
-                    "ALTER TABLE {}.{} ENGINE=InnoDB;",
-                    quote_ident("mysql", schema),
-                    quote_ident("mysql", &table),
-                ),
-                "dry_run": true,
-                "success": false
-            }));
-            continue;
-        }
-        disallowed.push(format!("{issue_type}:{strategy}"));
     }
 
     OneClickDryRunPreview {

--- a/migration_core/src/oneclick.rs
+++ b/migration_core/src/oneclick.rs
@@ -216,19 +216,7 @@ pub(crate) fn oneclick_run_streaming<F: FnMut(Value)>(request: &Request, mut emi
         "validation",
         "one-click validation started",
     ));
-    let validation_issues = match inspect_live(&state.endpoint) {
-        Ok(inspection) => oneclick_issues_from_inspection(&inspection),
-        Err(err) => vec![MigrationIssue {
-            issue_type: None,
-            severity: "error".to_string(),
-            location: "validation".to_string(),
-            message: err,
-            suggestion: "Check the database connection and rerun validation.".to_string(),
-            blocking: true,
-            table_name: None,
-            column_name: None,
-        }],
-    };
+    let validation_issues = issues_from_inspect_result(inspect_live(&state.endpoint));
     let validation_success = validation_issues.is_empty()
         && execution_success
         && report_fail_count == 0
@@ -515,19 +503,7 @@ pub(crate) fn oneclick_validate(request: &Request) -> Vec<Value> {
     )];
     match oneclick_endpoint(request) {
         Ok((endpoint, schema_name)) => {
-            let issues = match inspect_live(&endpoint) {
-                Ok(inspection) => oneclick_issues_from_inspection(&inspection),
-                Err(err) => vec![MigrationIssue {
-                    issue_type: None,
-                    severity: "error".to_string(),
-                    location: "validation".to_string(),
-                    message: err,
-                    suggestion: "Check the database connection and rerun validation.".to_string(),
-                    blocking: true,
-                    table_name: None,
-                    column_name: None,
-                }],
-            };
+            let issues = issues_from_inspect_result(inspect_live(&endpoint));
             events.push(json!({
                 "event": "result",
                 "request_id": request.request_id,
@@ -740,6 +716,25 @@ fn oneclick_issues_from_inspection(inspection: &InspectionResult) -> Vec<Migrati
             column_name: None,
         })
         .collect()
+}
+
+/// inspect 결과(성공/실패)를 검증용 MigrationIssue 목록으로 변환한다.
+/// Ok → oneclick_issues_from_inspection, Err → 단일 validation-error MigrationIssue.
+/// oneclick_run_streaming 과 oneclick_validate 에 중복돼 있던 fallback 블록을 하나로 통합한다.
+fn issues_from_inspect_result(result: Result<InspectionResult, String>) -> Vec<MigrationIssue> {
+    match result {
+        Ok(inspection) => oneclick_issues_from_inspection(&inspection),
+        Err(err) => vec![MigrationIssue {
+            issue_type: None,
+            severity: "error".to_string(),
+            location: "validation".to_string(),
+            message: err,
+            suggestion: "Check the database connection and rerun validation.".to_string(),
+            blocking: true,
+            table_name: None,
+            column_name: None,
+        }],
+    }
 }
 
 fn oneclick_deprecated_engine_marker(object: &str) -> Option<(String, String)> {

--- a/migration_core/src/oneclick.rs
+++ b/migration_core/src/oneclick.rs
@@ -1556,13 +1556,27 @@ fn oneclick_execute_apply_plan<A: MigrationAdapter>(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OneClickPayloadShape {
+    CharsetCollationFkSafe,
+    SingleTable,
+}
+
+fn classify_oneclick_payload_shape(action: &OneClickApplyAction) -> OneClickPayloadShape {
+    if action.issue_type == "charset_issue" && action.strategy == "charset_collation_fk_safe" {
+        OneClickPayloadShape::CharsetCollationFkSafe
+    } else {
+        OneClickPayloadShape::SingleTable
+    }
+}
+
 fn oneclick_applied_fix_payload(
     action: &OneClickApplyAction,
     success: bool,
     error: Option<&str>,
 ) -> Value {
-    if action.issue_type == "charset_issue" && action.strategy == "charset_collation_fk_safe" {
-        let mut payload = json!({
+    let mut payload = match classify_oneclick_payload_shape(action) {
+        OneClickPayloadShape::CharsetCollationFkSafe => json!({
             "issue_type": action.issue_type,
             "strategy": action.strategy,
             "schema": action.schema,
@@ -1573,22 +1587,17 @@ fn oneclick_applied_fix_payload(
             "rollback_sql": action.rollback_sql,
             "fk_order": action.fk_order,
             "success": success
-        });
-        if let Some(error) = error {
-            payload["error"] = json!(error);
-        }
-        return payload;
-    }
-
-    let mut payload = json!({
-        "issue_type": action.issue_type,
-        "strategy": action.strategy,
-        "schema": action.schema,
-        "table": action.table,
-        "sql": action.sql,
-        "success": success,
-        "rows_affected": 0
-    });
+        }),
+        OneClickPayloadShape::SingleTable => json!({
+            "issue_type": action.issue_type,
+            "strategy": action.strategy,
+            "schema": action.schema,
+            "table": action.table,
+            "sql": action.sql,
+            "success": success,
+            "rows_affected": 0
+        }),
+    };
     if let Some(error) = error {
         payload["error"] = json!(error);
     }

--- a/migration_core/src/oneclick.rs
+++ b/migration_core/src/oneclick.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use mysql::prelude::Queryable;
 use crate::*;
+use crate::schema::error_event;
 
 pub(crate) fn preflight_streaming<F: FnMut(Value)>(request: &Request, mut emit: F) {
     emit(phase_event(
@@ -53,11 +54,7 @@ pub(crate) fn oneclick_run_streaming<F: FnMut(Value)>(request: &Request, mut emi
     let state = match oneclick_preflight_state(request) {
         Ok(state) => state,
         Err(err) => {
-            emit(json!({
-                "event": "error",
-                "request_id": request.request_id,
-                "message": err
-            }));
+            emit(error_event(request, err));
             return;
         }
     };
@@ -277,11 +274,7 @@ pub(crate) fn oneclick_preflight(request: &Request) -> Vec<Value> {
                 "issues": state.issues
             }));
         }
-        Err(err) => events.push(json!({
-            "event": "error",
-            "request_id": request.request_id,
-            "message": err
-        })),
+        Err(err) => events.push(error_event(request, err)),
     }
     events
 }
@@ -305,11 +298,7 @@ pub(crate) fn oneclick_analyze(request: &Request) -> Vec<Value> {
                 "issues": state.issues
             }));
         }
-        Err(err) => events.push(json!({
-            "event": "error",
-            "request_id": request.request_id,
-            "message": err
-        })),
+        Err(err) => events.push(error_event(request, err)),
     }
     events
 }
@@ -385,11 +374,7 @@ pub(crate) fn oneclick_derive_charset_contracts(request: &Request) -> Vec<Value>
                 }
             }
             Err(err) => {
-                events.push(json!({
-                    "event": "error",
-                    "request_id": request.request_id,
-                    "message": err
-                }));
+                events.push(error_event(request, err));
                 return events;
             }
         }
@@ -487,30 +472,21 @@ pub(crate) fn oneclick_apply_fixes(request: &Request) -> Vec<Value> {
     let (endpoint, _) = match oneclick_endpoint(request) {
         Ok(endpoint) => endpoint,
         Err(err) => {
-            events.push(json!({
-                "event": "error",
-                "request_id": request.request_id,
-                "message": err
-            }));
+            events.push(error_event(request, err));
             return events;
         }
     };
     if endpoint.engine != "mysql" {
-        events.push(json!({
-            "event": "error",
-            "request_id": request.request_id,
-            "message": "oneclick.apply_fixes currently supports MySQL engine fixes only"
-        }));
+        events.push(error_event(
+            request,
+            "oneclick.apply_fixes currently supports MySQL engine fixes only",
+        ));
         return events;
     }
     let mut adapter = match LiveAdapter::connect(&endpoint) {
         Ok(adapter) => adapter,
         Err(err) => {
-            events.push(json!({
-                "event": "error",
-                "request_id": request.request_id,
-                "message": err
-            }));
+            events.push(error_event(request, err));
             return events;
         }
     };
@@ -562,11 +538,7 @@ pub(crate) fn oneclick_validate(request: &Request) -> Vec<Value> {
                 "all_fixed": issues.is_empty()
             }));
         }
-        Err(err) => events.push(json!({
-            "event": "error",
-            "request_id": request.request_id,
-            "message": err
-        })),
+        Err(err) => events.push(error_event(request, err)),
     }
     events
 }

--- a/migration_core/src/query.rs
+++ b/migration_core/src/query.rs
@@ -162,28 +162,53 @@ pub(crate) fn execute_query_adapter(
     }
 }
 
+/// SQL 주석 스캐너: `bytes[i]` 에서 시작하는 주석을 감지하면 그 주석 토큰 바로 다음
+/// 인덱스를 반환하고, 주석 시작이 아니면 `None` 을 반환한다.
+///
+/// - 라인 주석(`--`, `allow_hash` 시 `#`): 종료 개행 `'\n'` 의 인덱스(개행 미소비).
+///   개행이 없으면 `len`.
+/// - 블록 주석(`/* */`): 닫는 `*/` 바로 다음 인덱스. 닫힘이 없으면 기존 산술상 `len+1`.
+///
+/// 반환 인덱스와 스캔 산술은 세 호출부(query::strip_leading_comments_and_parens,
+/// schema::mysql_definition_has_residual_definer, schema::validate_single_view_statement)의
+/// 기존 수제 스캐너와 바이트 단위로 일치한다. `#` 인식은 `allow_hash` 로만 켜지므로,
+/// `allow_hash=false` 호출부(View 정의 검증기)는 지금처럼 `#` 을 리터럴로 취급한다.
+pub(crate) fn skip_sql_comment(bytes: &[u8], i: usize, allow_hash: bool) -> Option<usize> {
+    let len = bytes.len();
+    if i >= len {
+        return None;
+    }
+    if bytes[i] == b'-' && i + 1 < len && bytes[i + 1] == b'-' {
+        let mut j = i + 2;
+        while j < len && bytes[j] != b'\n' {
+            j += 1;
+        }
+        return Some(j);
+    }
+    if allow_hash && bytes[i] == b'#' {
+        let mut j = i + 1;
+        while j < len && bytes[j] != b'\n' {
+            j += 1;
+        }
+        return Some(j);
+    }
+    if bytes[i] == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
+        let mut j = i + 2;
+        while j + 1 < len && !(bytes[j] == b'*' && bytes[j + 1] == b'/') {
+            j += 1;
+        }
+        return Some(j + 2);
+    }
+    None
+}
+
 fn strip_leading_comments_and_parens(sql: &str) -> &str {
     let mut text = sql.trim_start();
     loop {
-        if let Some(rest) = text.strip_prefix("--") {
-            text = match rest.find('\n') {
-                Some(idx) => rest[idx + 1..].trim_start(),
-                None => "",
-            };
-            continue;
-        }
-        if let Some(rest) = text.strip_prefix('#') {
-            text = match rest.find('\n') {
-                Some(idx) => rest[idx + 1..].trim_start(),
-                None => "",
-            };
-            continue;
-        }
-        if let Some(rest) = text.strip_prefix("/*") {
-            text = match rest.find("*/") {
-                Some(idx) => rest[idx + 2..].trim_start(),
-                None => "",
-            };
+        if let Some(end) = skip_sql_comment(text.as_bytes(), 0, true) {
+            // 기존 &str 의미 보존: 주석 끝부터 다시 잘라내고 선행 공백을 trim_start 한다.
+            // 닫히지 않은 주석(end == len 또는 len+1)은 get 으로 안전하게 "" 로 수렴한다.
+            text = text.get(end..).unwrap_or("").trim_start();
             continue;
         }
         if let Some(rest) = text.strip_prefix('(') {

--- a/migration_core/src/schema.rs
+++ b/migration_core/src/schema.rs
@@ -183,84 +183,36 @@ pub fn inspect_live(endpoint: &Endpoint) -> Result<InspectionResult, String> {
     }
 }
 
-fn inspect_mysql(endpoint: &Endpoint) -> Result<InspectionResult, String> {
-    let schema_name = endpoint_schema(endpoint);
-    let opts = mysql_opts(endpoint);
-    let pool = mysql::Pool::new(opts).map_err(|err| format!("mysql pool error: {err}"))?;
-    let mut conn = pool
-        .get_conn()
-        .map_err(|err| format!("mysql connection error: {err}"))?;
-    let table_names: Vec<(String, Option<String>)> = conn
-        .exec_map(
-            inspect_tables_sql("mysql"),
-            (&schema_name,),
-            |(table_name, table_collation): (String, Option<String>)| (table_name, table_collation),
-        )
-        .map_err(|err| format!("mysql table inspect error: {err}"))?;
+/// per-table 스키마 inspect 를 엔진 독립적으로 수행하기 위한 어댑터.
+/// 드라이버 API 차이(mysql exec_map 클로저 vs postgres client.query + row.get 인덱스)는
+/// 각 impl 안에 캡슐화하고, inspect_generic 은 table_names → columns/keys/foreign_keys/indexes
+/// → apply_key_flags/group_indexes/group_foreign_keys → NormalizedTable push 의 5단계 시퀀스만
+/// 담당한다. DB 연결/쿼리는 tunnelforge-core 소유 그대로 유지한다.
+trait InspectAdapter {
+    fn table_names(&mut self, schema: &str) -> Result<Vec<(String, Option<String>)>, String>;
+    fn columns(&mut self, schema: &str, table: &str) -> Result<Vec<NormalizedColumn>, String>;
+    fn keys(&mut self, schema: &str, table: &str) -> Result<Vec<(String, String)>, String>;
+    fn foreign_keys(
+        &mut self,
+        schema: &str,
+        table: &str,
+    ) -> Result<Vec<(String, String, String, String)>, String>;
+    fn indexes(&mut self, schema: &str, table: &str) -> Result<Vec<(String, String, bool)>, String>;
+    fn unsupported_objects(&mut self, schema: &str) -> Result<Vec<String>, String>;
+}
+
+fn inspect_generic<A: InspectAdapter>(
+    adapter: &mut A,
+    schema_name: &str,
+) -> Result<InspectionResult, String> {
+    let table_names = adapter.table_names(schema_name)?;
     let mut tables = Vec::new();
 
     for (table_name, table_collation) in table_names {
-        let columns: Vec<NormalizedColumn> =
-            conn
-                .exec_map(
-                    inspect_columns_sql("mysql"),
-                    (&schema_name, &table_name),
-                    |(
-                        name,
-                        type_name,
-                        character_set,
-                        collation,
-                        is_nullable,
-                        default_value,
-                        extra,
-                    ): (
-                        String,
-                        String,
-                        Option<String>,
-                        Option<String>,
-                        String,
-                        Option<String>,
-                        String,
-                    )| {
-                        let type_name =
-                            mysql_type_with_character_options(&type_name, character_set, collation);
-                        NormalizedColumn {
-                            name,
-                            type_name: with_auto_increment_marker(&type_name, &extra),
-                            default_value,
-                            nullable: is_nullable.eq_ignore_ascii_case("YES"),
-                            primary_key: false,
-                            unique: false,
-                        }
-                    },
-                )
-                .map_err(|err| format!("mysql column inspect error: {err}"))?;
-        let keys: Vec<(String, String)> = conn
-            .exec_map(
-                inspect_keys_sql("mysql"),
-                (&schema_name, &table_name),
-                |(name, constraint_type): (String, String)| (name, constraint_type),
-            )
-            .map_err(|err| format!("mysql key inspect error: {err}"))?;
-        let foreign_key_rows: Vec<(String, String, String, String)> = conn
-            .exec_map(
-                inspect_foreign_keys_sql("mysql"),
-                (&schema_name, &table_name),
-                |(name, column, referenced_table, referenced_column): (
-                    String,
-                    String,
-                    String,
-                    String,
-                )| (name, column, referenced_table, referenced_column),
-            )
-            .map_err(|err| format!("mysql FK inspect error: {err}"))?;
-        let index_rows: Vec<(String, String, bool)> = conn
-            .exec_map(
-                inspect_indexes_sql("mysql"),
-                (&schema_name, &table_name),
-                |(name, column, is_unique): (String, String, u8)| (name, column, is_unique == 1),
-            )
-            .map_err(|err| format!("mysql index inspect error: {err}"))?;
+        let columns = adapter.columns(schema_name, &table_name)?;
+        let keys = adapter.keys(schema_name, &table_name)?;
+        let foreign_key_rows = adapter.foreign_keys(schema_name, &table_name)?;
+        let index_rows = adapter.indexes(schema_name, &table_name)?;
         tables.push(NormalizedTable {
             name: table_name,
             columns: apply_key_flags(columns, &keys),
@@ -270,12 +222,125 @@ fn inspect_mysql(endpoint: &Endpoint) -> Result<InspectionResult, String> {
         });
     }
 
-    let unsupported_objects = inspect_mysql_unsupported_objects(&mut conn, &schema_name)?;
+    let unsupported_objects = adapter.unsupported_objects(schema_name)?;
 
     Ok(InspectionResult {
         schema: NormalizedSchema { tables },
         unsupported_objects,
     })
+}
+
+struct MysqlInspectAdapter {
+    conn: mysql::PooledConn,
+}
+
+impl InspectAdapter for MysqlInspectAdapter {
+    fn table_names(&mut self, schema: &str) -> Result<Vec<(String, Option<String>)>, String> {
+        self.conn
+            .exec_map(
+                inspect_tables_sql("mysql"),
+                (schema,),
+                |(table_name, table_collation): (String, Option<String>)| {
+                    (table_name, table_collation)
+                },
+            )
+            .map_err(|err| format!("mysql table inspect error: {err}"))
+    }
+
+    fn columns(&mut self, schema: &str, table: &str) -> Result<Vec<NormalizedColumn>, String> {
+        self.conn
+            .exec_map(
+                inspect_columns_sql("mysql"),
+                (schema, table),
+                |(
+                    name,
+                    type_name,
+                    character_set,
+                    collation,
+                    is_nullable,
+                    default_value,
+                    extra,
+                ): (
+                    String,
+                    String,
+                    Option<String>,
+                    Option<String>,
+                    String,
+                    Option<String>,
+                    String,
+                )| {
+                    let type_name =
+                        mysql_type_with_character_options(&type_name, character_set, collation);
+                    NormalizedColumn {
+                        name,
+                        type_name: with_auto_increment_marker(&type_name, &extra),
+                        default_value,
+                        nullable: is_nullable.eq_ignore_ascii_case("YES"),
+                        primary_key: false,
+                        unique: false,
+                    }
+                },
+            )
+            .map_err(|err| format!("mysql column inspect error: {err}"))
+    }
+
+    fn keys(&mut self, schema: &str, table: &str) -> Result<Vec<(String, String)>, String> {
+        self.conn
+            .exec_map(
+                inspect_keys_sql("mysql"),
+                (schema, table),
+                |(name, constraint_type): (String, String)| (name, constraint_type),
+            )
+            .map_err(|err| format!("mysql key inspect error: {err}"))
+    }
+
+    fn foreign_keys(
+        &mut self,
+        schema: &str,
+        table: &str,
+    ) -> Result<Vec<(String, String, String, String)>, String> {
+        self.conn
+            .exec_map(
+                inspect_foreign_keys_sql("mysql"),
+                (schema, table),
+                |(name, column, referenced_table, referenced_column): (
+                    String,
+                    String,
+                    String,
+                    String,
+                )| { (name, column, referenced_table, referenced_column) },
+            )
+            .map_err(|err| format!("mysql FK inspect error: {err}"))
+    }
+
+    fn indexes(
+        &mut self,
+        schema: &str,
+        table: &str,
+    ) -> Result<Vec<(String, String, bool)>, String> {
+        self.conn
+            .exec_map(
+                inspect_indexes_sql("mysql"),
+                (schema, table),
+                |(name, column, is_unique): (String, String, u8)| (name, column, is_unique == 1),
+            )
+            .map_err(|err| format!("mysql index inspect error: {err}"))
+    }
+
+    fn unsupported_objects(&mut self, schema: &str) -> Result<Vec<String>, String> {
+        inspect_mysql_unsupported_objects(&mut self.conn, schema)
+    }
+}
+
+fn inspect_mysql(endpoint: &Endpoint) -> Result<InspectionResult, String> {
+    let schema_name = endpoint_schema(endpoint);
+    let opts = mysql_opts(endpoint);
+    let pool = mysql::Pool::new(opts).map_err(|err| format!("mysql pool error: {err}"))?;
+    let conn = pool
+        .get_conn()
+        .map_err(|err| format!("mysql connection error: {err}"))?;
+    let mut adapter = MysqlInspectAdapter { conn };
+    inspect_generic(&mut adapter, &schema_name)
 }
 
 fn inspect_mysql_unsupported_objects(
@@ -322,25 +387,32 @@ fn inspect_mysql_deprecated_engines_sql() -> &'static str {
     "SELECT TABLE_NAME, ENGINE FROM information_schema.tables WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = 'BASE TABLE' AND ENGINE IN ('MyISAM') ORDER BY TABLE_NAME"
 }
 
-fn inspect_postgresql(endpoint: &Endpoint) -> Result<InspectionResult, String> {
-    let schema_name = endpoint_schema(endpoint);
-    let mut client = postgres_config(endpoint)
-        .connect(NoTls)
-        .map_err(|err| format!("postgresql connection error: {err}"))?;
-    let table_rows = client
-        .query(inspect_tables_sql("postgresql"), &[&schema_name])
-        .map_err(|err| format!("postgresql table inspect error: {err}"))?;
-    let mut tables = Vec::new();
+struct PostgresInspectAdapter {
+    client: postgres::Client,
+}
 
-    for row in table_rows {
-        let table_name: String = row.get(0);
-        let column_rows = client
-            .query(
-                inspect_columns_sql("postgresql"),
-                &[&schema_name, &table_name],
-            )
+impl InspectAdapter for PostgresInspectAdapter {
+    fn table_names(&mut self, schema: &str) -> Result<Vec<(String, Option<String>)>, String> {
+        let rows = self
+            .client
+            .query(inspect_tables_sql("postgresql"), &[&schema])
+            .map_err(|err| format!("postgresql table inspect error: {err}"))?;
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                let table_name: String = row.get(0);
+                // PostgreSQL 은 table-level collation 을 노출하지 않으므로 항상 None.
+                (table_name, None)
+            })
+            .collect())
+    }
+
+    fn columns(&mut self, schema: &str, table: &str) -> Result<Vec<NormalizedColumn>, String> {
+        let column_rows = self
+            .client
+            .query(inspect_columns_sql("postgresql"), &[&schema, &table])
             .map_err(|err| format!("postgresql column inspect error: {err}"))?;
-        let columns = column_rows
+        Ok(column_rows
             .into_iter()
             .map(|column| {
                 let name: String = column.get(0);
@@ -373,68 +445,77 @@ fn inspect_postgresql(endpoint: &Endpoint) -> Result<InspectionResult, String> {
                     unique: false,
                 }
             })
-            .collect();
-        let key_rows = client
-            .query(inspect_keys_sql("postgresql"), &[&schema_name, &table_name])
+            .collect())
+    }
+
+    fn keys(&mut self, schema: &str, table: &str) -> Result<Vec<(String, String)>, String> {
+        let key_rows = self
+            .client
+            .query(inspect_keys_sql("postgresql"), &[&schema, &table])
             .map_err(|err| format!("postgresql key inspect error: {err}"))?;
-        let keys = key_rows
+        Ok(key_rows
             .into_iter()
             .map(|row| {
                 let name: String = row.get(0);
                 let constraint_type: String = row.get(1);
                 (name, constraint_type)
             })
-            .collect::<Vec<_>>();
-        let foreign_key_rows = client
-            .query(
-                inspect_foreign_keys_sql("postgresql"),
-                &[&schema_name, &table_name],
-            )
-            .map_err(|err| format!("postgresql FK inspect error: {err}"))?;
-        let foreign_keys = group_foreign_keys(
-            foreign_key_rows
-                .into_iter()
-                .map(|row| {
-                    let name: String = row.get(0);
-                    let column: String = row.get(1);
-                    let referenced_table: String = row.get(2);
-                    let referenced_column: String = row.get(3);
-                    (name, column, referenced_table, referenced_column)
-                })
-                .collect(),
-        );
-        let index_rows = client
-            .query(
-                inspect_indexes_sql("postgresql"),
-                &[&schema_name, &table_name],
-            )
-            .map_err(|err| format!("postgresql index inspect error: {err}"))?;
-        let indexes = group_indexes(
-            index_rows
-                .into_iter()
-                .map(|row| {
-                    let name: String = row.get(0);
-                    let column: String = row.get(1);
-                    let is_unique: bool = row.get(2);
-                    (name, column, is_unique)
-                })
-                .collect(),
-        );
-        tables.push(NormalizedTable {
-            name: table_name,
-            columns: apply_key_flags(columns, &keys),
-            indexes,
-            foreign_keys,
-            table_collation: None,
-        });
+            .collect())
     }
 
-    let unsupported_objects = inspect_postgresql_unsupported_objects(&mut client, &schema_name)?;
+    fn foreign_keys(
+        &mut self,
+        schema: &str,
+        table: &str,
+    ) -> Result<Vec<(String, String, String, String)>, String> {
+        let foreign_key_rows = self
+            .client
+            .query(inspect_foreign_keys_sql("postgresql"), &[&schema, &table])
+            .map_err(|err| format!("postgresql FK inspect error: {err}"))?;
+        Ok(foreign_key_rows
+            .into_iter()
+            .map(|row| {
+                let name: String = row.get(0);
+                let column: String = row.get(1);
+                let referenced_table: String = row.get(2);
+                let referenced_column: String = row.get(3);
+                (name, column, referenced_table, referenced_column)
+            })
+            .collect())
+    }
 
-    Ok(InspectionResult {
-        schema: NormalizedSchema { tables },
-        unsupported_objects,
-    })
+    fn indexes(
+        &mut self,
+        schema: &str,
+        table: &str,
+    ) -> Result<Vec<(String, String, bool)>, String> {
+        let index_rows = self
+            .client
+            .query(inspect_indexes_sql("postgresql"), &[&schema, &table])
+            .map_err(|err| format!("postgresql index inspect error: {err}"))?;
+        Ok(index_rows
+            .into_iter()
+            .map(|row| {
+                let name: String = row.get(0);
+                let column: String = row.get(1);
+                let is_unique: bool = row.get(2);
+                (name, column, is_unique)
+            })
+            .collect())
+    }
+
+    fn unsupported_objects(&mut self, schema: &str) -> Result<Vec<String>, String> {
+        inspect_postgresql_unsupported_objects(&mut self.client, schema)
+    }
+}
+
+fn inspect_postgresql(endpoint: &Endpoint) -> Result<InspectionResult, String> {
+    let schema_name = endpoint_schema(endpoint);
+    let client = postgres_config(endpoint)
+        .connect(NoTls)
+        .map_err(|err| format!("postgresql connection error: {err}"))?;
+    let mut adapter = PostgresInspectAdapter { client };
+    inspect_generic(&mut adapter, &schema_name)
 }
 
 fn inspect_postgresql_unsupported_objects(

--- a/migration_core/src/schema.rs
+++ b/migration_core/src/schema.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use mysql::prelude::Queryable;
 use postgres::NoTls;
 use crate::*;
+use crate::query::skip_sql_comment;
 
 pub(crate) fn normalized_schema_diff(source: &NormalizedSchema, target: &NormalizedSchema) -> Vec<Value> {
     let source_tables: BTreeMap<String, &NormalizedTable> = source
@@ -632,18 +633,9 @@ pub(crate) fn mysql_definition_has_residual_definer(sql: &str) -> bool {
     let len = bytes.len();
     let mut i = 0;
     while i < len {
-        if bytes[i] == b'-' && i + 1 < len && bytes[i + 1] == b'-' {
-            i += 2;
-            while i < len && bytes[i] != b'\n' {
-                i += 1;
-            }
-            cleaned.push(' ');
-        } else if bytes[i] == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
-            i += 2;
-            while i + 1 < len && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                i += 1;
-            }
-            i += 2;
+        // allow_hash=false: '#' 은 주석이 아니라 리터럴로 취급(더 보수적, fail-closed 보존).
+        if let Some(end) = skip_sql_comment(bytes, i, false) {
+            i = end;
             cleaned.push(' ');
         } else {
             cleaned.push(bytes[i] as char);
@@ -680,6 +672,12 @@ pub(crate) fn validate_single_view_statement(sql: &str) -> Result<(), String> {
     let mut i = 0;
     let len = bytes.len();
     while i < len {
+        // 주석(-- , /* */) 은 공유 스캐너로 스킵한다. allow_hash=false 로 '#' 은 리터럴 취급.
+        // 기존 루프의 trailing `i += 1` 을 보존하기 위해 end + 1 로 재개한다.
+        if let Some(end) = skip_sql_comment(bytes, i, false) {
+            i = end + 1;
+            continue;
+        }
         let ch = bytes[i];
         match ch {
             b'\'' => {
@@ -714,21 +712,6 @@ pub(crate) fn validate_single_view_statement(sql: &str) -> Result<(), String> {
                 while i < len && bytes[i] != b'`' {
                     i += 1;
                 }
-            }
-            b'-' if i + 1 < len && bytes[i + 1] == b'-' => {
-                // 라인 주석
-                i += 2;
-                while i < len && bytes[i] != b'\n' {
-                    i += 1;
-                }
-            }
-            b'/' if i + 1 < len && bytes[i + 1] == b'*' => {
-                // 블록 주석
-                i += 2;
-                while i + 1 < len && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                    i += 1;
-                }
-                i += 2;
             }
             b';' => {
                 // 끝에 오는 세미콜론(뒤에 공백만 남음)은 허용, 그 외는 추가 statement로 간주.

--- a/migration_core/src/schema.rs
+++ b/migration_core/src/schema.rs
@@ -114,6 +114,17 @@ pub(crate) fn normalized_schema_diff(source: &NormalizedSchema, target: &Normali
     differences
 }
 
+/// 스트리밍/배치 응답에서 공통으로 쓰이는 `error` 이벤트 리터럴을 생성한다.
+/// `json!({"event":"error","request_id":request.request_id,"message":message})` 와
+/// 바이트 단위로 동일한 payload 를 반환한다.
+pub(crate) fn error_event(request: &Request, message: impl Into<String>) -> Value {
+    json!({
+        "event": "error",
+        "request_id": request.request_id,
+        "message": message.into()
+    })
+}
+
 pub(crate) fn inspect(request: &Request) -> Vec<Value> {
     if let Some(endpoint) = request
         .payload
@@ -130,11 +141,7 @@ pub(crate) fn inspect(request: &Request) -> Vec<Value> {
                 "schema": result.schema,
                 "unsupported_objects": result.unsupported_objects
             })),
-            Err(err) => events.push(json!({
-                "event": "error",
-                "request_id": request.request_id,
-                "message": err
-            })),
+            Err(err) => events.push(error_event(request, err)),
         }
         return events;
     }


### PR DESCRIPTION
## 개요

Clean Code Round 2 WP-2.11. Rust `tunnelforge-core` 의 `query.rs` / `schema.rs` / `oneclick.rs` 세 모듈에 대한 **동작 보존 리팩터링**. 7개 finding을 finding별 개별 커밋으로 처리했다. 공개 시그니처 불변(내부 헬퍼/구조체만 추가), 버전 bump 없음, 세 모듈 파일 밖은 일절 수정하지 않았다.

## Findings

| # | 심각도 | 내용 | 파일 |
|---|--------|------|------|
| CC-233 | LOW | `error` 이벤트 리터럴을 `error_event(request, message)` 헬퍼로 통합 | schema.rs, oneclick.rs |
| CC-229 | MEDIUM | 중복 fallback issue 블록을 `issues_from_inspect_result` 로 추출 | oneclick.rs |
| CC-242 | LOW | payload shape 문자열 dispatch → `OneClickPayloadShape` enum + `classify_oneclick_payload_shape` | oneclick.rs |
| CC-232 | MEDIUM | apply/preview 공유 step 분류기 `classify_oneclick_step` 추출 | oneclick.rs |
| CC-231 | HIGH | execution 익명 6-tuple → 타입드 `OneClickApplyOutcome` + `oneclick_execute_stage` 단계 함수 | oneclick.rs |
| CC-234 | MEDIUM | 수제 SQL 주석 스캐너 3개 → `skip_sql_comment(bytes, i, allow_hash)` 통합 | query.rs, schema.rs |
| CC-235 | MEDIUM | inspect_mysql/inspect_postgresql → `InspectAdapter` trait + `inspect_generic` | schema.rs |

## 동작 보존 핵심 포인트

- **CC-231**: emit 이벤트의 순서/개수/필드를 바이트 단위로 동일하게 유지. `OneClickApplyOutcome` 에 `skip_count`/`disallowed_fix_attempts` 필드 추가(테스트 리터럴 없음 → 컴파일 영향 없음). `oneclick_apply_fixes` 호출부는 기존 필드만 읽어 무영향.
- **CC-232**: real-apply 전용 `sql_template` 불일치 검사는 분류기에 넣지 않고 `oneclick_apply_actions` 후처리에만 남겨 **dry-run preview 출력 불변** 보존(스펙이 좁힌 divergence 유지).
- **CC-234**: 세 스캐너의 사이트별 산술을 그대로 보존 — mysql(`i=end`), validate(`i=end+1`로 기존 trailing increment 보존), strip_leading(`text.get(end..).trim_start()`로 &str/Unicode 의미 보존). 두 View 검증기는 `allow_hash=false`로 `#`을 리터럴로 취급(fail-closed 보안 동작 유지).
- **CC-235**: postgres adapter는 fk/index를 raw row로 반환하고 그룹핑은 `inspect_generic`에서 수행(mysql과 동일 경로). SQL 텍스트/에러 메시지/정규화 로직 그대로. **실 DB 왕복은 `live_roundtrip.rs`(env-gated)로만 커버되므로 머지 전 라이브 DB 실행 권장.**

## 검증

- `cargo test --manifest-path migration_core/Cargo.toml`: **216 유닛 + 통합 테스트 전부 통과** (live_roundtrip는 env 미설정으로 스킵)
- `cargo build --manifest-path migration_core/Cargo.toml --release`: **성공**
- 전체 `pytest`: **1836 passed, 1 failed**
  - 유일한 실패 `test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge` 는 GitHub CI 상태 의존 테스트로 로컬에서 항상 실패하는 알려진 flaky 테스트(Rust 변경과 무관). 스펙의 "macOS 패키징 실패 무시" 대상.

## Skip / 노후화 대응

- 스펙의 라인번호(L###)는 Round 1 머지 전 기준이라 무효 → 전부 심볼명(함수/구조체명)으로 재매핑해 작업.
- CC-233은 스펙 열거 6개 사이트 외에 `oneclick_run_streaming`의 동일 shape error emit 1개도 함께 통합(같은 모듈 내, 바이트 동일 → DRY 강화). 그 외 dump.rs/import.rs/migrate.rs/protocol.rs의 동일 리터럴은 각 WP 소유이므로 건드리지 않음.
- Round 1에서 이미 해결돼 무의미해진 finding은 없었음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)