### PR TITLE
refactor(rust-dump-import): dump/import 정리 — 갓함수 분해 + 컨텍스트 구조체 + worker-pool 통합 (WP-2.10)

### DIFF
--- a/migration_core/src/dump.rs
+++ b/migration_core/src/dump.rs
@@ -287,14 +287,25 @@ pub(crate) fn dump_import_row_progress_event(
     event
 }
 
-fn dump_run<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value, String> {
-    let endpoint = request_endpoint(request)?;
+/// dump.run 요청 payload에서 파싱·검증한 옵션 묶음.
+struct DumpRunOptions {
+    output_dir: String,
+    chunk_size: usize,
+    threads: usize,
+    overwrite: bool,
+    selected_tables: Vec<String>,
+    data_format: String,
+    compression: String,
+}
+
+fn parse_dump_run_options(request: &Request) -> Result<DumpRunOptions, String> {
     let output_dir = request
         .payload
         .get("output_dir")
         .and_then(Value::as_str)
         .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| "dump.run requires output_dir".to_string())?;
+        .ok_or_else(|| "dump.run requires output_dir".to_string())?
+        .to_string();
     let chunk_size = request
         .payload
         .get("chunk_size")
@@ -333,16 +344,111 @@ fn dump_run<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value, St
     if !matches!(compression.as_str(), "none" | "zstd") {
         return Err(format!("unsupported dump compression: {compression}"));
     }
+    Ok(DumpRunOptions {
+        output_dir,
+        chunk_size,
+        threads,
+        overwrite,
+        selected_tables,
+        data_format,
+        compression,
+    })
+}
 
-    let output_path = Path::new(output_dir);
-    prepare_dump_output_dir(output_path, overwrite)?;
+/// engine/threads/table_total로 결정되는 덤프 실행 전략.
+enum DumpStrategy {
+    SingleMysqlParallel,
+    GlobalMysql,
+    TableParallel,
+    Sequential,
+}
+
+impl DumpStrategy {
+    fn scheduler_label(&self) -> &'static str {
+        match self {
+            DumpStrategy::GlobalMysql => "global_chunk",
+            _ => "table_parallel",
+        }
+    }
+}
+
+fn select_dump_strategy(engine: &str, threads: usize, table_total: usize) -> DumpStrategy {
+    if engine == "mysql" && threads > 1 && table_total == 1 {
+        DumpStrategy::SingleMysqlParallel
+    } else if engine == "mysql" && threads > 1 && table_total > 1 {
+        DumpStrategy::GlobalMysql
+    } else if threads > 1 && table_total > 1 {
+        DumpStrategy::TableParallel
+    } else {
+        DumpStrategy::Sequential
+    }
+}
+
+/// View 정의 수집(전체 export 시) + DumpManifest 조립 및 파일 기록. (manifest, view 개수)를 반환한다.
+fn finalize_dump_manifest<F: FnMut(Value)>(
+    endpoint: &Endpoint,
+    schema: NormalizedSchema,
+    table_manifests: Vec<DumpTableManifest>,
+    options: &DumpRunOptions,
+    output_path: &Path,
+    full_export: bool,
+    request_id: Option<String>,
+    mut emit: F,
+) -> Result<(DumpManifest, usize), String> {
+    // View 정의 수집 (전체 export 시에만). 실패해도 테이블 덤프는 유효하므로 fatal로 보지 않는다.
+    let views = if full_export {
+        match collect_views(endpoint) {
+            Ok(views) => views,
+            Err(err) => {
+                emit(json!({
+                    "event": "phase",
+                    "request_id": request_id,
+                    "phase": "dump",
+                    "message": format!("View 정의 수집 실패 (테이블 덤프는 정상): {err}"),
+                }));
+                Vec::new()
+            }
+        }
+    } else {
+        Vec::new()
+    };
+    let views_count = views.len();
+    let (snapshot_policy, strict_export, manifest_warnings) =
+        dump_manifest_consistency_metadata(options.threads);
+
+    let manifest = DumpManifest {
+        format: "tunnelforge-dump".to_string(),
+        format_version: if options.data_format == "jsonl" { 1 } else { 2 },
+        data_format: options.data_format.clone(),
+        compression: options.compression.clone(),
+        source_engine: endpoint.engine.clone(),
+        database: endpoint.database.clone(),
+        schema,
+        snapshot_policy,
+        strict_export,
+        manifest_warnings,
+        chunk_size: options.chunk_size,
+        created_unix_seconds: current_unix_seconds(),
+        tables: table_manifests,
+        views,
+    };
+    write_dump_manifest(output_path, &manifest)?;
+    Ok((manifest, views_count))
+}
+
+fn dump_run<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value, String> {
+    let endpoint = request_endpoint(request)?;
+    let options = parse_dump_run_options(request)?;
+
+    let output_path = Path::new(&options.output_dir);
+    prepare_dump_output_dir(output_path, options.overwrite)?;
 
     // 부분 export(tables 지정) 시에는 View가 참조하는 base table이 빠질 수 있으므로 View를 수집하지 않는다.
-    let full_export = selected_tables.is_empty();
+    let full_export = options.selected_tables.is_empty();
     let inspection = inspect_live(&endpoint)?;
     let mut schema = inspection.schema;
-    if !selected_tables.is_empty() {
-        let selected: BTreeSet<String> = selected_tables.into_iter().collect();
+    if !options.selected_tables.is_empty() {
+        let selected: BTreeSet<String> = options.selected_tables.iter().cloned().collect();
         schema.tables.retain(|table| selected.contains(&table.name));
     }
     schema = dependency_ordered_schema(&schema);
@@ -358,8 +464,9 @@ fn dump_run<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value, St
     ));
 
     let table_total = schema.tables.len();
-    let parallel_limits = dump_parallel_limits(threads, table_total);
-    let export_tables = if threads > 1 && table_total > 1 {
+    let parallel_limits = dump_parallel_limits(options.threads, table_total);
+    let strategy = select_dump_strategy(&endpoint.engine, options.threads, table_total);
+    let export_tables = if options.threads > 1 && table_total > 1 {
         dump_schedule_order(&schema.tables, &row_counts)
     } else {
         schema.tables.clone()
@@ -369,26 +476,22 @@ fn dump_run<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value, St
         &export_tables,
         &row_counts,
         parallel_limits,
-        threads,
-        chunk_size,
-        &data_format,
-        &compression,
-        if endpoint.engine == "mysql" && threads > 1 && table_total > 1 {
-            "global_chunk"
-        } else {
-            "table_parallel"
-        },
+        options.threads,
+        options.chunk_size,
+        &options.data_format,
+        &options.compression,
+        strategy.scheduler_label(),
     ));
     let ctx = DumpJobContext {
         endpoint: endpoint.clone(),
         output_path: output_path.to_path_buf(),
-        chunk_size,
-        data_format: data_format.clone(),
-        compression: compression.clone(),
+        chunk_size: options.chunk_size,
+        data_format: options.data_format.clone(),
+        compression: options.compression.clone(),
         request_id: request.request_id.clone(),
     };
-    let (table_manifests, total_rows, total_chunks) =
-        if endpoint.engine == "mysql" && threads > 1 && table_total == 1 {
+    let (table_manifests, total_rows, total_chunks) = match strategy {
+        DumpStrategy::SingleMysqlParallel => {
             match dump_single_mysql_table_parallel(
                 &ctx,
                 &export_tables[0],
@@ -401,66 +504,40 @@ fn dump_run<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value, St
                     dump_tables_sequential(&mut adapter, &ctx, &export_tables, |event| emit(event))?
                 }
             }
-        } else if endpoint.engine == "mysql" && threads > 1 && table_total > 1 {
-            dump_tables_global_mysql(&ctx, &export_tables, threads, |event| emit(event))?
-        } else if threads > 1 && table_total > 1 {
-            dump_tables_parallel(
-                &ctx,
-                &export_tables,
-                parallel_limits.table_workers,
-                parallel_limits.range_workers_per_table,
-                |event| emit(event),
-            )?
-        } else {
+        }
+        DumpStrategy::GlobalMysql => {
+            dump_tables_global_mysql(&ctx, &export_tables, options.threads, |event| emit(event))?
+        }
+        DumpStrategy::TableParallel => dump_tables_parallel(
+            &ctx,
+            &export_tables,
+            parallel_limits.table_workers,
+            parallel_limits.range_workers_per_table,
+            |event| emit(event),
+        )?,
+        DumpStrategy::Sequential => {
             let mut adapter = LiveAdapter::connect(&endpoint)?;
             dump_tables_sequential(&mut adapter, &ctx, &export_tables, |event| emit(event))?
-        };
-
-    // View 정의 수집 (전체 export 시에만). 실패해도 테이블 덤프는 유효하므로 fatal로 보지 않는다.
-    let views = if full_export {
-        match collect_views(&endpoint) {
-            Ok(views) => views,
-            Err(err) => {
-                emit(json!({
-                    "event": "phase",
-                    "request_id": request.request_id,
-                    "phase": "dump",
-                    "message": format!("View 정의 수집 실패 (테이블 덤프는 정상): {err}"),
-                }));
-                Vec::new()
-            }
         }
-    } else {
-        Vec::new()
     };
-    let views_count = views.len();
-    let (snapshot_policy, strict_export, manifest_warnings) =
-        dump_manifest_consistency_metadata(threads);
 
-    let manifest = DumpManifest {
-        format: "tunnelforge-dump".to_string(),
-        format_version: if data_format == "jsonl" { 1 } else { 2 },
-        data_format,
-        compression,
-        source_engine: endpoint.engine.clone(),
-        database: endpoint.database.clone(),
+    let (manifest, views_count) = finalize_dump_manifest(
+        &endpoint,
         schema,
-        snapshot_policy,
-        strict_export,
-        manifest_warnings,
-        chunk_size,
-        created_unix_seconds: current_unix_seconds(),
-        tables: table_manifests,
-        views,
-    };
-    write_dump_manifest(output_path, &manifest)?;
+        table_manifests,
+        &options,
+        output_path,
+        full_export,
+        request.request_id.clone(),
+        |event| emit(event),
+    )?;
 
     Ok(json!({
         "event": "result",
         "request_id": request.request_id,
         "command": "dump.run",
         "success": true,
-        "output_dir": output_dir,
+        "output_dir": options.output_dir,
         "format": manifest.format,
         "format_version": manifest.format_version,
         "compression": manifest.compression,

--- a/migration_core/src/dump.rs
+++ b/migration_core/src/dump.rs
@@ -10,6 +10,9 @@ use std::time::Instant;
 use mysql::prelude::Queryable;
 use crate::*;
 
+/// dump.run / dump.import 요청에 threads가 명시되지 않았을 때 사용하는 기본 워커 수.
+pub(crate) const DEFAULT_DUMP_THREADS: usize = 8;
+
 pub(crate) fn dump_run_streaming<F: FnMut(Value)>(request: &Request, mut emit: F) {
     emit(json!({
         "event": "phase",
@@ -26,12 +29,6 @@ pub(crate) fn dump_run_streaming<F: FnMut(Value)>(request: &Request, mut emit: F
             "message": err
         })),
     }
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-struct DumpTableStats {
-    rows: u64,
-    avg_row_bytes: u64,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -98,10 +95,10 @@ fn global_dump_work_plan_for_ranges(
     global_dump_work_plan(tables, &range_counts)
 }
 
-fn dump_table_stats(
+fn dump_table_row_counts(
     endpoint: &Endpoint,
     tables: &[NormalizedTable],
-) -> BTreeMap<String, DumpTableStats> {
+) -> BTreeMap<String, u64> {
     let mut counts = BTreeMap::new();
     if endpoint.engine != "mysql" || tables.is_empty() {
         return counts;
@@ -117,21 +114,15 @@ fn dump_table_stats(
         .collect::<Vec<_>>()
         .join(", ");
     let sql = format!(
-        "SELECT TABLE_NAME, COALESCE(TABLE_ROWS, 0), COALESCE(AVG_ROW_LENGTH, 0) FROM information_schema.tables WHERE TABLE_SCHEMA = {} AND TABLE_NAME IN ({})",
+        "SELECT TABLE_NAME, COALESCE(TABLE_ROWS, 0) FROM information_schema.tables WHERE TABLE_SCHEMA = {} AND TABLE_NAME IN ({})",
         sql_literal(&Value::String(schema_name)),
         table_names
     );
-    let Ok(rows) = conn.query::<(String, u64, u64), _>(sql) else {
+    let Ok(rows) = conn.query::<(String, u64), _>(sql) else {
         return counts;
     };
-    for (table, rows, avg_row_bytes) in rows {
-        counts.insert(
-            table,
-            DumpTableStats {
-                rows,
-                avg_row_bytes,
-            },
-        );
+    for (table, rows) in rows {
+        counts.insert(table, rows);
     }
     counts
 }
@@ -234,6 +225,19 @@ fn dump_schedule_event(
     })
 }
 
+/// dump.import 진행률 이벤트의 청크 관련 필드 묶음.
+///
+/// 이전에는 네 개의 위치 인자 `Option<u64>`가 나란히 전달돼 호출부에서
+/// `chunks_done`과 `chunk_index`가 같은 값을 두 번 넘기는 등 의미가 불명확했다.
+/// named field 로 묶어 각 값의 역할을 호출부에서 자기문서화한다.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ChunkProgress {
+    pub(crate) chunks_done: Option<u64>,
+    pub(crate) chunks_total: Option<u64>,
+    pub(crate) chunk_index: Option<u64>,
+    pub(crate) load_ms: Option<u64>,
+}
+
 pub(crate) fn dump_import_row_progress_event(
     request_id: Option<String>,
     table: &str,
@@ -242,10 +246,7 @@ pub(crate) fn dump_import_row_progress_event(
     overall_rows_before: u64,
     overall_rows_total: u64,
     chunk_rows: u64,
-    chunks_done: Option<u64>,
-    chunks_total: Option<u64>,
-    chunk_index: Option<u64>,
-    load_ms: Option<u64>,
+    chunk_progress: ChunkProgress,
     strategy: &str,
 ) -> Value {
     let raw_overall_rows_done = overall_rows_before.saturating_add(table_rows_done);
@@ -269,16 +270,16 @@ pub(crate) fn dump_import_row_progress_event(
     });
 
     if let Value::Object(fields) = &mut event {
-        if let Some(value) = chunks_done {
+        if let Some(value) = chunk_progress.chunks_done {
             fields.insert("chunks_done".to_string(), json!(value));
         }
-        if let Some(value) = chunks_total {
+        if let Some(value) = chunk_progress.chunks_total {
             fields.insert("chunks_total".to_string(), json!(value));
         }
-        if let Some(value) = chunk_index {
+        if let Some(value) = chunk_progress.chunk_index {
             fields.insert("chunk_index".to_string(), json!(value));
         }
-        if let Some(value) = load_ms {
+        if let Some(value) = chunk_progress.load_ms {
             fields.insert("load_ms".to_string(), json!(value));
         }
     }
@@ -306,7 +307,7 @@ fn dump_run<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value, St
         .get("threads")
         .and_then(Value::as_u64)
         .map(|value| value as usize)
-        .unwrap_or(8)
+        .unwrap_or(DEFAULT_DUMP_THREADS)
         .max(1);
     let overwrite = request
         .payload
@@ -349,22 +350,7 @@ fn dump_run<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value, St
         return Err("dump.run found no tables to export".to_string());
     }
 
-    let table_stats = dump_table_stats(&endpoint, &schema.tables);
-    let row_counts = table_stats
-        .iter()
-        .map(|(table, stats)| (table.clone(), stats.rows))
-        .collect::<BTreeMap<_, _>>();
-    let range_eligible_tables = schema
-        .tables
-        .iter()
-        .filter(|table| single_numeric_primary_key(table).is_some())
-        .map(|table| table.name.clone())
-        .collect::<BTreeSet<_>>();
-    let avg_row_lengths = table_stats
-        .iter()
-        .filter(|(table, _)| range_eligible_tables.contains(*table))
-        .map(|(table, stats)| (table.clone(), stats.avg_row_bytes))
-        .collect::<BTreeMap<_, _>>();
+    let row_counts = dump_table_row_counts(&endpoint, &schema.tables);
     emit(dump_plan_event(
         request.request_id.clone(),
         &schema.tables,
@@ -372,13 +358,7 @@ fn dump_run<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value, St
     ));
 
     let table_total = schema.tables.len();
-    let parallel_limits = adaptive_dump_parallel_limits_with_avg(
-        threads,
-        table_total,
-        chunk_size,
-        &row_counts,
-        &avg_row_lengths,
-    );
+    let parallel_limits = dump_parallel_limits(threads, table_total);
     let export_tables = if threads > 1 && table_total > 1 {
         dump_schedule_order(&schema.tables, &row_counts)
     } else {
@@ -667,66 +647,6 @@ fn dump_parallel_limits(threads: usize, table_total: usize) -> DumpParallelLimit
         table_workers,
         range_workers_per_table,
     }
-}
-
-#[cfg(test)]
-fn adaptive_dump_parallel_limits(
-    threads: usize,
-    table_total: usize,
-    chunk_size: usize,
-    row_counts: &BTreeMap<String, u64>,
-) -> DumpParallelLimits {
-    adaptive_dump_parallel_limits_with_avg(
-        threads,
-        table_total,
-        chunk_size,
-        row_counts,
-        &BTreeMap::new(),
-    )
-}
-
-fn adaptive_dump_parallel_limits_with_avg(
-    threads: usize,
-    table_total: usize,
-    chunk_size: usize,
-    row_counts: &BTreeMap<String, u64>,
-    avg_row_lengths: &BTreeMap<String, u64>,
-) -> DumpParallelLimits {
-    let baseline = dump_parallel_limits(threads, table_total);
-    let thread_budget = threads.max(1);
-    if table_total <= 1 || row_counts.is_empty() {
-        return baseline;
-    }
-    let fallback_chunk_size = chunk_size.max(1);
-    let heavy_tables = row_counts
-        .iter()
-        .filter(|(table, rows)| {
-            let effective_chunk_size = mysql_range_chunk_size_for_avg_row(
-                fallback_chunk_size,
-                avg_row_lengths.get(*table).copied().unwrap_or(0),
-            ) as u64;
-            rows.saturating_add(effective_chunk_size - 1) / effective_chunk_size
-                >= (thread_budget as u64).saturating_mul(2)
-        })
-        .count();
-    let max_estimated_chunks = row_counts
-        .iter()
-        .map(|(table, rows)| {
-            let effective_chunk_size = mysql_range_chunk_size_for_avg_row(
-                fallback_chunk_size,
-                avg_row_lengths.get(table).copied().unwrap_or(0),
-            ) as u64;
-            rows.saturating_add(effective_chunk_size - 1) / effective_chunk_size
-        })
-        .max()
-        .unwrap_or(0);
-    if heavy_tables > 1 {
-        return baseline;
-    }
-    if max_estimated_chunks >= (thread_budget as u64).saturating_mul(2) {
-        return baseline;
-    }
-    baseline
 }
 
 fn dump_schedule_order(
@@ -2002,10 +1922,12 @@ mod tests {
             1_000,
             2_000,
             25,
-            Some(2),
-            Some(8),
-            Some(4),
-            Some(500),
+            ChunkProgress {
+                chunks_done: Some(2),
+                chunks_total: Some(8),
+                chunk_index: Some(4),
+                load_ms: Some(500),
+            },
             "load_data_local_infile",
         );
 
@@ -2037,7 +1959,7 @@ mod tests {
         counts.insert("huge".to_string(), 2_000_000);
         counts.insert("medium".to_string(), 500_000);
         counts.insert("tiny".to_string(), 10);
-        let limits = adaptive_dump_parallel_limits(8, 3, 50_000, &counts);
+        let limits = dump_parallel_limits(8, 3);
 
         let event = dump_schedule_event(
             Some("req-1".to_string()),
@@ -2083,12 +2005,7 @@ mod tests {
 
     #[test]
     fn adaptive_dump_limits_prioritize_range_workers_for_heavy_chunked_tables() {
-        let mut counts = BTreeMap::new();
-        counts.insert("huge".to_string(), 2_000_000);
-        counts.insert("medium".to_string(), 500_000);
-        counts.insert("tiny".to_string(), 10);
-
-        let limits = adaptive_dump_parallel_limits(8, 208, 50_000, &counts);
+        let limits = dump_parallel_limits(8, 208);
 
         assert_eq!(limits.table_workers, 2);
         assert_eq!(limits.range_workers_per_table, 4);
@@ -2096,14 +2013,7 @@ mod tests {
 
     #[test]
     fn adaptive_dump_limits_use_byte_chunks_for_wide_tables() {
-        let mut counts = BTreeMap::new();
-        counts.insert("df_subs".to_string(), 223_502);
-        counts.insert("tiny".to_string(), 10);
-        let mut avg_row_lengths = BTreeMap::new();
-        avg_row_lengths.insert("df_subs".to_string(), 9_462);
-
-        let limits =
-            adaptive_dump_parallel_limits_with_avg(8, 208, 50_000, &counts, &avg_row_lengths);
+        let limits = dump_parallel_limits(8, 208);
 
         assert_eq!(limits.table_workers, 2);
         assert_eq!(limits.range_workers_per_table, 4);
@@ -2111,17 +2021,7 @@ mod tests {
 
     #[test]
     fn adaptive_dump_limits_keep_table_parallelism_for_pathological_wide_table() {
-        let mut counts = BTreeMap::new();
-        counts.insert("df_subs".to_string(), 387_398);
-        counts.insert("qe_view_factors_result".to_string(), 1_946_153);
-        counts.insert("df_call_logs".to_string(), 1_076_142);
-        let mut avg_row_lengths = BTreeMap::new();
-        avg_row_lengths.insert("df_subs".to_string(), 9_462);
-        avg_row_lengths.insert("qe_view_factors_result".to_string(), 128);
-        avg_row_lengths.insert("df_call_logs".to_string(), 128);
-
-        let limits =
-            adaptive_dump_parallel_limits_with_avg(8, 208, 50_000, &counts, &avg_row_lengths);
+        let limits = dump_parallel_limits(8, 208);
 
         assert_eq!(limits.table_workers, 2);
         assert_eq!(limits.range_workers_per_table, 4);
@@ -2129,12 +2029,7 @@ mod tests {
 
     #[test]
     fn adaptive_dump_limits_keep_multiple_heavy_tables_in_parallel() {
-        let mut counts = BTreeMap::new();
-        counts.insert("huge_a".to_string(), 2_000_000);
-        counts.insert("huge_b".to_string(), 1_900_000);
-        counts.insert("tiny".to_string(), 10);
-
-        let limits = adaptive_dump_parallel_limits(8, 208, 50_000, &counts);
+        let limits = dump_parallel_limits(8, 208);
 
         assert_eq!(limits.table_workers, 2);
         assert_eq!(limits.range_workers_per_table, 4);

--- a/migration_core/src/dump.rs
+++ b/migration_core/src/dump.rs
@@ -714,6 +714,68 @@ fn dump_schedule_order(
     indexed.into_iter().map(|(_, table)| table).collect()
 }
 
+/// `run_bounded_pool`의 on_event 클로저가 반환하는, 워커 슬롯에 대한 지시.
+enum PoolAction {
+    /// 슬롯을 소비하지 않는 이벤트(진행률 pass-through 등). active/completed 불변.
+    KeepGoing,
+    /// 워커 하나가 종료. 슬롯을 반환하고 pending에서 다음 작업을 리필한다.
+    Advance,
+    /// 워커 하나가 종료. 슬롯은 반환하되 리필하지 않는다(에러 확산 중단 경로).
+    AdvanceNoRefill,
+}
+
+/// bounded worker-pool 디스패치 루프. `max_workers`개까지 워커를 채운 뒤, 각 이벤트를
+/// `on_event`에 넘긴다. on_event가 반환한 `PoolAction`에 따라 슬롯을 관리한다:
+/// KeepGoing은 슬롯 불변, Advance는 슬롯 반환 후 리필, AdvanceNoRefill은 반환만 한다.
+/// 이벤트별 emit·상태 누적·first_error 캡처는 전적으로 on_event가 담당해 각 호출자의
+/// bookkeeping을 그대로 보존한다. 종료 시 모든 워커 핸들을 join한다.
+fn run_bounded_pool<Item, Event>(
+    mut pending: VecDeque<Item>,
+    max_workers: usize,
+    receiver: &mpsc::Receiver<Event>,
+    mut spawn: impl FnMut(Item) -> thread::JoinHandle<()>,
+    mut on_event: impl FnMut(Event) -> PoolAction,
+) {
+    let total = pending.len();
+    let mut handles = Vec::new();
+    let mut active = 0_usize;
+    let mut completed = 0_usize;
+
+    while active < max_workers {
+        if let Some(item) = pending.pop_front() {
+            handles.push(spawn(item));
+            active += 1;
+        } else {
+            break;
+        }
+    }
+
+    while completed < total && active > 0 {
+        match receiver.recv() {
+            Ok(event) => match on_event(event) {
+                PoolAction::KeepGoing => {}
+                PoolAction::Advance => {
+                    completed += 1;
+                    active = active.saturating_sub(1);
+                    if let Some(item) = pending.pop_front() {
+                        handles.push(spawn(item));
+                        active += 1;
+                    }
+                }
+                PoolAction::AdvanceNoRefill => {
+                    completed += 1;
+                    active = active.saturating_sub(1);
+                }
+            },
+            Err(_) => break,
+        }
+    }
+
+    for handle in handles {
+        let _ = handle.join();
+    }
+}
+
 fn dump_tables_parallel<F: FnMut(Value)>(
     ctx: &DumpJobContext,
     tables: &[NormalizedTable],
@@ -723,81 +785,51 @@ fn dump_tables_parallel<F: FnMut(Value)>(
 ) -> Result<(Vec<DumpTableManifest>, u64, u64), String> {
     let table_total = tables.len();
     let max_threads = table_threads.max(1).min(table_total);
-    let mut pending = (0..table_total).collect::<VecDeque<_>>();
-    let mut active = 0_usize;
-    let mut completed = 0_usize;
+    let pending = (0..table_total).collect::<VecDeque<_>>();
     let mut total_rows = 0_u64;
     let mut total_chunks = 0_u64;
     let mut first_error: Option<String> = None;
     let mut manifests: Vec<Option<DumpTableManifest>> = vec![None; table_total];
-    let mut handles = Vec::new();
     let (sender, receiver) = mpsc::channel::<DumpTableEvent>();
 
-    while active < max_threads {
-        if let Some(index) = pending.pop_front() {
-            handles.push(spawn_dump_table_worker(
+    run_bounded_pool(
+        pending,
+        max_threads,
+        &receiver,
+        |index| {
+            spawn_dump_table_worker(
                 ctx.clone(),
                 tables[index].clone(),
                 index,
                 table_total,
                 range_threads,
                 sender.clone(),
-            ));
-            active += 1;
-        } else {
-            break;
-        }
-    }
-
-    while completed < table_total && active > 0 {
-        match receiver.recv() {
-            Ok(DumpTableEvent::Progress(event)) => emit(event),
-            Ok(DumpTableEvent::Done {
+            )
+        },
+        |event| match event {
+            DumpTableEvent::Progress(event) => {
+                emit(event);
+                PoolAction::KeepGoing
+            }
+            DumpTableEvent::Done {
                 index,
                 manifest,
                 rows,
                 chunks,
-            }) => {
+            } => {
                 manifests[index] = Some(manifest);
                 total_rows += rows;
                 total_chunks += chunks;
-                completed += 1;
-                active = active.saturating_sub(1);
-                if let Some(next_index) = pending.pop_front() {
-                    handles.push(spawn_dump_table_worker(
-                        ctx.clone(),
-                        tables[next_index].clone(),
-                        next_index,
-                        table_total,
-                        range_threads,
-                        sender.clone(),
-                    ));
-                    active += 1;
-                }
+                PoolAction::Advance
             }
-            Ok(DumpTableEvent::Error(err)) => {
+            // 에러가 나도 나머지 테이블 워커는 계속 리필해 진행한다(기존 동작 보존).
+            DumpTableEvent::Error(err) => {
                 first_error.get_or_insert(err);
-                completed += 1;
-                active = active.saturating_sub(1);
-                if let Some(next_index) = pending.pop_front() {
-                    handles.push(spawn_dump_table_worker(
-                        ctx.clone(),
-                        tables[next_index].clone(),
-                        next_index,
-                        table_total,
-                        range_threads,
-                        sender.clone(),
-                    ));
-                    active += 1;
-                }
+                PoolAction::Advance
             }
-            Err(_) => break,
-        }
-    }
+        },
+    );
 
-    for handle in handles {
-        let _ = handle.join();
-    }
     if let Some(err) = first_error {
         return Err(err);
     }
@@ -931,30 +963,20 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
         return Ok((Vec::new(), 0, 0));
     }
     let max_threads = threads.max(1).min(work_total);
-    let mut active = 0_usize;
-    let mut completed_work = 0_usize;
     let mut first_error: Option<String> = None;
-    let mut handles = Vec::new();
     let (sender, receiver) = mpsc::channel::<DumpGlobalEvent>();
 
-    while active < max_threads {
-        if let Some(work) = pending.pop_front() {
-            handles.push(spawn_dump_global_worker(
-                ctx.clone(),
-                work,
-                table_total,
-                sender.clone(),
-            ));
-            active += 1;
-        } else {
-            break;
-        }
-    }
-
-    while completed_work < work_total && active > 0 {
-        match receiver.recv() {
-            Ok(DumpGlobalEvent::Progress(event)) => emit(event),
-            Ok(DumpGlobalEvent::RangeDone {
+    run_bounded_pool(
+        pending,
+        max_threads,
+        &receiver,
+        |work| spawn_dump_global_worker(ctx.clone(), work, table_total, sender.clone()),
+        |event| match event {
+            DumpGlobalEvent::Progress(event) => {
+                emit(event);
+                PoolAction::KeepGoing
+            }
+            DumpGlobalEvent::RangeDone {
                 table_index,
                 chunk_index,
                 rows,
@@ -962,7 +984,7 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
                 range_start,
                 range_end,
                 checksum,
-            }) => {
+            } => {
                 let table = &tables[table_index];
                 let state = &mut states[table_index];
                 state.rows_dumped += rows;
@@ -972,8 +994,6 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
                     dump_chunk_name(chunk_index, &ctx.data_format, &ctx.compression),
                     checksum,
                 );
-                completed_work += 1;
-                active = active.saturating_sub(1);
                 emit(json!({
                     "event": "row_progress",
                     "request_id": ctx.request_id,
@@ -1007,53 +1027,30 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
                         "strategy": "global_pk_range_parallel"
                     }));
                 }
-                if let Some(work) = pending.pop_front() {
-                    handles.push(spawn_dump_global_worker(
-                        ctx.clone(),
-                        work,
-                        table_total,
-                        sender.clone(),
-                    ));
-                    active += 1;
-                }
+                PoolAction::Advance
             }
-            Ok(DumpGlobalEvent::TableDone {
+            DumpGlobalEvent::TableDone {
                 index,
                 manifest,
                 rows,
                 chunks,
                 duration_ms,
-            }) => {
+            } => {
                 let state = &mut states[index];
                 state.rows_dumped = rows;
                 state.chunks_done = chunks;
                 state.chunks_total = chunks;
                 state.work_ms = duration_ms.max(1);
                 state.manifest = Some(manifest);
-                completed_work += 1;
-                active = active.saturating_sub(1);
-                if let Some(work) = pending.pop_front() {
-                    handles.push(spawn_dump_global_worker(
-                        ctx.clone(),
-                        work,
-                        table_total,
-                        sender.clone(),
-                    ));
-                    active += 1;
-                }
+                PoolAction::Advance
             }
-            Ok(DumpGlobalEvent::Error(err)) => {
+            // 글로벌 경로 에러는 리필하지 않고 슬롯만 반환한다(기존 동작 보존).
+            DumpGlobalEvent::Error(err) => {
                 first_error.get_or_insert(err);
-                completed_work += 1;
-                active = active.saturating_sub(1);
+                PoolAction::AdvanceNoRefill
             }
-            Err(_) => break,
-        }
-    }
-
-    for handle in handles {
-        let _ = handle.join();
-    }
+        },
+    );
     if let Some(err) = first_error {
         return Err(err);
     }
@@ -1161,18 +1158,21 @@ fn dump_mysql_table_parallel_ranges<F: FnMut(Value)>(
     let ranges = pk_ranges(min_key, max_key, table_row_count, range_chunk_size);
     let total_ranges = ranges.len();
     let max_threads = threads.max(1).min(total_ranges.max(1));
-    let mut pending = ranges.into_iter().collect::<VecDeque<_>>();
-    let mut active = 0_usize;
-    let mut completed = 0_usize;
+    let pending = ranges.into_iter().collect::<VecDeque<_>>();
     let mut rows_dumped = 0_u64;
     let mut chunk_sha256 = BTreeMap::new();
     let mut first_error: Option<String> = None;
-    let mut handles = Vec::new();
+    // chunks_done는 기존 `completed`와 동일하게 매 종료 이벤트(Done+Error)마다 증가하며
+    // row_progress의 "chunks_done" 필드에 쓰인다. 풀 루프 카운터는 run_bounded_pool가 관리한다.
+    let mut chunks_done = 0_u64;
     let (sender, receiver) = mpsc::channel::<DumpRangeEvent>();
 
-    while active < max_threads {
-        if let Some(range) = pending.pop_front() {
-            handles.push(spawn_mysql_range_worker(
+    run_bounded_pool(
+        pending,
+        max_threads,
+        &receiver,
+        |range| {
+            spawn_mysql_range_worker(
                 ctx.endpoint.clone(),
                 ctx.output_path.clone(),
                 table.clone(),
@@ -1182,26 +1182,19 @@ fn dump_mysql_table_parallel_ranges<F: FnMut(Value)>(
                 ctx.data_format.clone(),
                 ctx.compression.clone(),
                 sender.clone(),
-            ));
-            active += 1;
-        } else {
-            break;
-        }
-    }
-
-    while completed < total_ranges && active > 0 {
-        match receiver.recv() {
-            Ok(DumpRangeEvent::Done {
+            )
+        },
+        |event| match event {
+            DumpRangeEvent::Done {
                 chunk_index,
                 rows,
                 stream_ms,
                 range_start,
                 range_end,
                 checksum,
-            }) => {
+            } => {
                 rows_dumped += rows;
-                completed += 1;
-                active = active.saturating_sub(1);
+                chunks_done += 1;
                 chunk_sha256.insert(
                     dump_chunk_name(chunk_index, &ctx.data_format, &ctx.compression),
                     checksum,
@@ -1213,7 +1206,7 @@ fn dump_mysql_table_parallel_ranges<F: FnMut(Value)>(
                     "rows": rows_dumped,
                     "total": table_row_count,
                     "chunk_rows": rows,
-                    "chunks_done": completed,
+                    "chunks_done": chunks_done,
                     "chunks_total": total_ranges,
                     "stream_ms": stream_ms,
                     "chunk_index": chunk_index,
@@ -1221,33 +1214,16 @@ fn dump_mysql_table_parallel_ranges<F: FnMut(Value)>(
                     "range_end": range_end,
                     "strategy": "pk_range_parallel"
                 }));
-                if let Some(range) = pending.pop_front() {
-                    handles.push(spawn_mysql_range_worker(
-                        ctx.endpoint.clone(),
-                        ctx.output_path.clone(),
-                        table.clone(),
-                        table_path.clone(),
-                        pk_column.to_string(),
-                        range,
-                        ctx.data_format.clone(),
-                        ctx.compression.clone(),
-                        sender.clone(),
-                    ));
-                    active += 1;
-                }
+                PoolAction::Advance
             }
-            Ok(DumpRangeEvent::Error(err)) => {
+            // range 워커 에러는 리필하지 않는다(기존 동작 보존). chunks_done는 계속 카운트.
+            DumpRangeEvent::Error(err) => {
                 first_error.get_or_insert(err);
-                completed += 1;
-                active = active.saturating_sub(1);
+                chunks_done += 1;
+                PoolAction::AdvanceNoRefill
             }
-            Err(_) => break,
-        }
-    }
-
-    for handle in handles {
-        let _ = handle.join();
-    }
+        },
+    );
     if let Some(err) = first_error {
         return Err(err);
     }

--- a/migration_core/src/dump.rs
+++ b/migration_core/src/dump.rs
@@ -379,73 +379,41 @@ fn dump_run<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value, St
             "table_parallel"
         },
     ));
+    let ctx = DumpJobContext {
+        endpoint: endpoint.clone(),
+        output_path: output_path.to_path_buf(),
+        chunk_size,
+        data_format: data_format.clone(),
+        compression: compression.clone(),
+        request_id: request.request_id.clone(),
+    };
     let (table_manifests, total_rows, total_chunks) =
         if endpoint.engine == "mysql" && threads > 1 && table_total == 1 {
             match dump_single_mysql_table_parallel(
-                &endpoint,
-                output_path,
+                &ctx,
                 &export_tables[0],
-                chunk_size,
-                &data_format,
-                &compression,
                 parallel_limits.range_workers_per_table,
-                request.request_id.clone(),
                 |event| emit(event),
             )? {
                 Some(result) => result,
                 None => {
                     let mut adapter = LiveAdapter::connect(&endpoint)?;
-                    dump_tables_sequential(
-                        &mut adapter,
-                        &endpoint,
-                        output_path,
-                        &export_tables,
-                        chunk_size,
-                        &data_format,
-                        &compression,
-                        request.request_id.clone(),
-                        |event| emit(event),
-                    )?
+                    dump_tables_sequential(&mut adapter, &ctx, &export_tables, |event| emit(event))?
                 }
             }
         } else if endpoint.engine == "mysql" && threads > 1 && table_total > 1 {
-            dump_tables_global_mysql(
-                &endpoint,
-                output_path,
-                &export_tables,
-                chunk_size,
-                &data_format,
-                &compression,
-                threads,
-                request.request_id.clone(),
-                |event| emit(event),
-            )?
+            dump_tables_global_mysql(&ctx, &export_tables, threads, |event| emit(event))?
         } else if threads > 1 && table_total > 1 {
             dump_tables_parallel(
-                &endpoint,
-                output_path,
+                &ctx,
                 &export_tables,
-                chunk_size,
-                &data_format,
-                &compression,
                 parallel_limits.table_workers,
                 parallel_limits.range_workers_per_table,
-                request.request_id.clone(),
                 |event| emit(event),
             )?
         } else {
             let mut adapter = LiveAdapter::connect(&endpoint)?;
-            dump_tables_sequential(
-                &mut adapter,
-                &endpoint,
-                output_path,
-                &export_tables,
-                chunk_size,
-                &data_format,
-                &compression,
-                request.request_id.clone(),
-                |event| emit(event),
-            )?
+            dump_tables_sequential(&mut adapter, &ctx, &export_tables, |event| emit(event))?
         };
 
     // View 정의 수집 (전체 export 시에만). 실패해도 테이블 덤프는 유효하므로 fatal로 보지 않는다.
@@ -573,13 +541,8 @@ fn has_tunnelforge_dump_marker(output_path: &Path) -> bool {
 
 fn dump_tables_sequential<F: FnMut(Value)>(
     adapter: &mut LiveAdapter,
-    endpoint: &Endpoint,
-    output_path: &Path,
+    ctx: &DumpJobContext,
     tables: &[NormalizedTable],
-    chunk_size: usize,
-    data_format: &str,
-    compression: &str,
-    request_id: Option<String>,
     mut emit: F,
 ) -> Result<(Vec<DumpTableManifest>, u64, u64), String> {
     let mut manifests = Vec::new();
@@ -588,19 +551,8 @@ fn dump_tables_sequential<F: FnMut(Value)>(
     let table_total = tables.len();
 
     for (index, table) in tables.iter().enumerate() {
-        let (manifest, rows, chunks) = dump_one_table(
-            adapter,
-            endpoint,
-            output_path,
-            table,
-            index,
-            table_total,
-            chunk_size,
-            data_format,
-            compression,
-            request_id.clone(),
-            |event| emit(event),
-        )?;
+        let (manifest, rows, chunks) =
+            dump_one_table(adapter, ctx, table, index, table_total, |event| emit(event))?;
         manifests.push(manifest);
         total_rows += rows;
         total_chunks += chunks;
@@ -631,6 +583,22 @@ impl DumpParallelLimits {
     fn estimated_mysql_connections(&self) -> usize {
         self.table_workers * (self.range_workers_per_table + 1)
     }
+}
+
+/// dump.run 한 번에 걸쳐 고정되는 공통 파라미터 묶음.
+///
+/// endpoint/output_path/chunk_size/data_format/compression/request_id는 모든 테이블·
+/// 청크 덤프 경로가 동일하게 참조하던 값이라, 개별 인자로 6개씩 관통시키는 대신
+/// 하나의 컨텍스트로 전달한다. 동기 경로는 `&DumpJobContext`로, 스레드 워커는
+/// clone 한 owned 값으로 넘긴다.
+#[derive(Clone)]
+struct DumpJobContext {
+    endpoint: Endpoint,
+    output_path: PathBuf,
+    chunk_size: usize,
+    data_format: String,
+    compression: String,
+    request_id: Option<String>,
 }
 
 fn dump_parallel_limits(threads: usize, table_total: usize) -> DumpParallelLimits {
@@ -670,15 +638,10 @@ fn dump_schedule_order(
 }
 
 fn dump_tables_parallel<F: FnMut(Value)>(
-    endpoint: &Endpoint,
-    output_path: &Path,
+    ctx: &DumpJobContext,
     tables: &[NormalizedTable],
-    chunk_size: usize,
-    data_format: &str,
-    compression: &str,
     table_threads: usize,
     range_threads: usize,
-    request_id: Option<String>,
     mut emit: F,
 ) -> Result<(Vec<DumpTableManifest>, u64, u64), String> {
     let table_total = tables.len();
@@ -696,16 +659,11 @@ fn dump_tables_parallel<F: FnMut(Value)>(
     while active < max_threads {
         if let Some(index) = pending.pop_front() {
             handles.push(spawn_dump_table_worker(
-                endpoint.clone(),
-                output_path.to_path_buf(),
+                ctx.clone(),
                 tables[index].clone(),
                 index,
                 table_total,
-                chunk_size,
-                data_format.to_string(),
-                compression.to_string(),
                 range_threads,
-                request_id.clone(),
                 sender.clone(),
             ));
             active += 1;
@@ -730,16 +688,11 @@ fn dump_tables_parallel<F: FnMut(Value)>(
                 active = active.saturating_sub(1);
                 if let Some(next_index) = pending.pop_front() {
                     handles.push(spawn_dump_table_worker(
-                        endpoint.clone(),
-                        output_path.to_path_buf(),
+                        ctx.clone(),
                         tables[next_index].clone(),
                         next_index,
                         table_total,
-                        chunk_size,
-                        data_format.to_string(),
-                        compression.to_string(),
                         range_threads,
-                        request_id.clone(),
                         sender.clone(),
                     ));
                     active += 1;
@@ -751,16 +704,11 @@ fn dump_tables_parallel<F: FnMut(Value)>(
                 active = active.saturating_sub(1);
                 if let Some(next_index) = pending.pop_front() {
                     handles.push(spawn_dump_table_worker(
-                        endpoint.clone(),
-                        output_path.to_path_buf(),
+                        ctx.clone(),
                         tables[next_index].clone(),
                         next_index,
                         table_total,
-                        chunk_size,
-                        data_format.to_string(),
-                        compression.to_string(),
                         range_threads,
-                        request_id.clone(),
                         sender.clone(),
                     ));
                     active += 1;
@@ -788,18 +736,13 @@ fn dump_tables_parallel<F: FnMut(Value)>(
 }
 
 fn dump_tables_global_mysql<F: FnMut(Value)>(
-    endpoint: &Endpoint,
-    output_path: &Path,
+    ctx: &DumpJobContext,
     tables: &[NormalizedTable],
-    chunk_size: usize,
-    data_format: &str,
-    compression: &str,
     threads: usize,
-    request_id: Option<String>,
     mut emit: F,
 ) -> Result<(Vec<DumpTableManifest>, u64, u64), String> {
     let table_total = tables.len();
-    let mut conn = match LiveAdapter::connect(endpoint)? {
+    let mut conn = match LiveAdapter::connect(&ctx.endpoint)? {
         LiveAdapter::MySql(conn) => conn,
         LiveAdapter::PostgreSql(_) => {
             return Err("global mysql dump requires mysql endpoint".to_string())
@@ -811,7 +754,7 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
 
     for (index, table) in tables.iter().enumerate() {
         let table_path = format!("{:04}_{}", index + 1, safe_dump_component(&table.name));
-        let table_dir = output_path.join(&table_path);
+        let table_dir = ctx.output_path.join(&table_path);
         fs::create_dir_all(&table_dir)
             .map_err(|err| format!("failed to create dump table dir: {err}"))?;
         let table_row_count = conn
@@ -819,11 +762,12 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
             .map(|count| count.unwrap_or(0))
             .unwrap_or(0);
         let mut chunks_total = 0_u64;
-        let avg_row_bytes = mysql_table_avg_row_length(&mut conn, endpoint, &table.name);
+        let avg_row_bytes = mysql_table_avg_row_length(&mut conn, &ctx.endpoint, &table.name);
         if let Some(pk_column) = single_numeric_primary_key(table) {
-            let profile_key = dump_profile_key(endpoint, &table.name, data_format, compression);
+            let profile_key =
+                dump_profile_key(&ctx.endpoint, &table.name, &ctx.data_format, &ctx.compression);
             let range_chunk_size = learned_mysql_range_chunk_size(
-                chunk_size,
+                ctx.chunk_size,
                 avg_row_bytes,
                 profiles.get(&profile_key),
             );
@@ -842,7 +786,7 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
                     ranges_by_table.insert(table.name.clone(), ranges);
                     emit(json!({
                         "event": "table_progress",
-                        "request_id": request_id,
+                        "request_id": ctx.request_id,
                         "table": table.name,
                         "status": "dumping",
                         "current": index + 1,
@@ -919,14 +863,9 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
     while active < max_threads {
         if let Some(work) = pending.pop_front() {
             handles.push(spawn_dump_global_worker(
-                endpoint.clone(),
-                output_path.to_path_buf(),
+                ctx.clone(),
                 work,
                 table_total,
-                chunk_size,
-                data_format.to_string(),
-                compression.to_string(),
-                request_id.clone(),
                 sender.clone(),
             ));
             active += 1;
@@ -953,14 +892,14 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
                 state.chunks_done += 1;
                 state.work_ms = state.work_ms.saturating_add(stream_ms.max(1));
                 state.chunk_sha256.insert(
-                    dump_chunk_name(chunk_index, data_format, compression),
+                    dump_chunk_name(chunk_index, &ctx.data_format, &ctx.compression),
                     checksum,
                 );
                 completed_work += 1;
                 active = active.saturating_sub(1);
                 emit(json!({
                     "event": "row_progress",
-                    "request_id": request_id,
+                    "request_id": ctx.request_id,
                     "table": table.name,
                     "rows": state.rows_dumped,
                     "total": state.rows_total,
@@ -983,7 +922,7 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
                     });
                     emit(json!({
                         "event": "table_progress",
-                        "request_id": request_id,
+                        "request_id": ctx.request_id,
                         "table": table.name,
                         "status": "completed",
                         "current": table_index + 1,
@@ -993,14 +932,9 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
                 }
                 if let Some(work) = pending.pop_front() {
                     handles.push(spawn_dump_global_worker(
-                        endpoint.clone(),
-                        output_path.to_path_buf(),
+                        ctx.clone(),
                         work,
                         table_total,
-                        chunk_size,
-                        data_format.to_string(),
-                        compression.to_string(),
-                        request_id.clone(),
                         sender.clone(),
                     ));
                     active += 1;
@@ -1023,14 +957,9 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
                 active = active.saturating_sub(1);
                 if let Some(work) = pending.pop_front() {
                     handles.push(spawn_dump_global_worker(
-                        endpoint.clone(),
-                        output_path.to_path_buf(),
+                        ctx.clone(),
                         work,
                         table_total,
-                        chunk_size,
-                        data_format.to_string(),
-                        compression.to_string(),
-                        request_id.clone(),
                         sender.clone(),
                     ));
                     active += 1;
@@ -1059,13 +988,13 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
             let duration_ms = state.work_ms.max(1);
             let rows_per_second = state.rows_dumped.saturating_mul(1000) / duration_ms;
             profiles.insert(
-                dump_profile_key(endpoint, &table.name, data_format, compression),
+                dump_profile_key(&ctx.endpoint, &table.name, &ctx.data_format, &ctx.compression),
                 DumpTablePerfProfile {
                     avg_row_bytes: state.avg_row_bytes,
                     chunk_rows: if state.chunks_done > 0 {
                         (state.rows_dumped / state.chunks_done).max(1) as usize
                     } else {
-                        chunk_size
+                        ctx.chunk_size
                     },
                     rows_per_second,
                     duration_ms,
@@ -1086,50 +1015,30 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
 }
 
 fn dump_single_mysql_table_parallel<F: FnMut(Value)>(
-    endpoint: &Endpoint,
-    output_path: &Path,
+    ctx: &DumpJobContext,
     table: &NormalizedTable,
-    chunk_size: usize,
-    data_format: &str,
-    compression: &str,
     threads: usize,
-    request_id: Option<String>,
     mut emit: F,
 ) -> Result<Option<(Vec<DumpTableManifest>, u64, u64)>, String> {
-    Ok(dump_mysql_table_parallel_ranges(
-        endpoint,
-        output_path,
-        table,
-        0,
-        1,
-        chunk_size,
-        data_format,
-        compression,
-        threads,
-        request_id,
-        |event| emit(event),
-    )?
-    .map(|(manifest, rows, chunks)| (vec![manifest], rows, chunks)))
+    Ok(
+        dump_mysql_table_parallel_ranges(ctx, table, 0, 1, threads, |event| emit(event))?
+            .map(|(manifest, rows, chunks)| (vec![manifest], rows, chunks)),
+    )
 }
 
 fn dump_mysql_table_parallel_ranges<F: FnMut(Value)>(
-    endpoint: &Endpoint,
-    output_path: &Path,
+    ctx: &DumpJobContext,
     table: &NormalizedTable,
     index: usize,
     table_total: usize,
-    chunk_size: usize,
-    data_format: &str,
-    compression: &str,
     threads: usize,
-    request_id: Option<String>,
     mut emit: F,
 ) -> Result<Option<(DumpTableManifest, u64, u64)>, String> {
     let Some(pk_column) = single_numeric_primary_key(table) else {
         return Ok(None);
     };
 
-    let mut conn = match LiveAdapter::connect(endpoint)? {
+    let mut conn = match LiveAdapter::connect(&ctx.endpoint)? {
         LiveAdapter::MySql(conn) => conn,
         LiveAdapter::PostgreSql(_) => return Ok(None),
     };
@@ -1137,8 +1046,8 @@ fn dump_mysql_table_parallel_ranges<F: FnMut(Value)>(
         .query_first::<u64, _>(count_sql("mysql", &table.name))
         .map(|count| count.unwrap_or(0))
         .unwrap_or(0);
-    let avg_row_bytes = mysql_table_avg_row_length(&mut conn, endpoint, &table.name);
-    let range_chunk_size = mysql_range_chunk_size_for_avg_row(chunk_size, avg_row_bytes);
+    let avg_row_bytes = mysql_table_avg_row_length(&mut conn, &ctx.endpoint, &table.name);
+    let range_chunk_size = mysql_range_chunk_size_for_avg_row(ctx.chunk_size, avg_row_bytes);
     if !should_use_pk_range_dump(table, table_row_count, range_chunk_size) {
         return Ok(None);
     }
@@ -1157,7 +1066,7 @@ fn dump_mysql_table_parallel_ranges<F: FnMut(Value)>(
 
     emit(json!({
         "event": "table_progress",
-        "request_id": request_id,
+        "request_id": ctx.request_id,
         "table": table.name,
         "status": "dumping",
         "current": index + 1,
@@ -1169,7 +1078,7 @@ fn dump_mysql_table_parallel_ranges<F: FnMut(Value)>(
     }));
 
     let table_path = format!("{:04}_{}", index + 1, safe_dump_component(&table.name));
-    let table_dir = output_path.join(&table_path);
+    let table_dir = ctx.output_path.join(&table_path);
     fs::create_dir_all(&table_dir)
         .map_err(|err| format!("failed to create dump table dir: {err}"))?;
     let ranges = pk_ranges(min_key, max_key, table_row_count, range_chunk_size);
@@ -1187,14 +1096,14 @@ fn dump_mysql_table_parallel_ranges<F: FnMut(Value)>(
     while active < max_threads {
         if let Some(range) = pending.pop_front() {
             handles.push(spawn_mysql_range_worker(
-                endpoint.clone(),
-                output_path.to_path_buf(),
+                ctx.endpoint.clone(),
+                ctx.output_path.clone(),
                 table.clone(),
                 table_path.clone(),
                 pk_column.to_string(),
                 range,
-                data_format.to_string(),
-                compression.to_string(),
+                ctx.data_format.clone(),
+                ctx.compression.clone(),
                 sender.clone(),
             ));
             active += 1;
@@ -1217,12 +1126,12 @@ fn dump_mysql_table_parallel_ranges<F: FnMut(Value)>(
                 completed += 1;
                 active = active.saturating_sub(1);
                 chunk_sha256.insert(
-                    dump_chunk_name(chunk_index, data_format, compression),
+                    dump_chunk_name(chunk_index, &ctx.data_format, &ctx.compression),
                     checksum,
                 );
                 emit(json!({
                     "event": "row_progress",
-                    "request_id": request_id,
+                    "request_id": ctx.request_id,
                     "table": table.name,
                     "rows": rows_dumped,
                     "total": table_row_count,
@@ -1237,14 +1146,14 @@ fn dump_mysql_table_parallel_ranges<F: FnMut(Value)>(
                 }));
                 if let Some(range) = pending.pop_front() {
                     handles.push(spawn_mysql_range_worker(
-                        endpoint.clone(),
-                        output_path.to_path_buf(),
+                        ctx.endpoint.clone(),
+                        ctx.output_path.clone(),
                         table.clone(),
                         table_path.clone(),
                         pk_column.to_string(),
                         range,
-                        data_format.to_string(),
-                        compression.to_string(),
+                        ctx.data_format.clone(),
+                        ctx.compression.clone(),
                         sender.clone(),
                     ));
                     active += 1;
@@ -1268,7 +1177,7 @@ fn dump_mysql_table_parallel_ranges<F: FnMut(Value)>(
 
     emit(json!({
         "event": "table_progress",
-        "request_id": request_id,
+        "request_id": ctx.request_id,
         "table": table.name,
         "status": "completed",
         "current": index + 1,
@@ -1330,14 +1239,9 @@ fn spawn_mysql_range_worker(
 }
 
 fn spawn_dump_global_worker(
-    endpoint: Endpoint,
-    output_path: PathBuf,
+    ctx: DumpJobContext,
     work: DumpGlobalWorkItem,
     table_total: usize,
-    chunk_size: usize,
-    data_format: String,
-    compression: String,
-    request_id: Option<String>,
     sender: mpsc::Sender<DumpGlobalEvent>,
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || match work.kind {
@@ -1347,14 +1251,14 @@ fn spawn_dump_global_worker(
             range,
         } => {
             let result = dump_mysql_range_chunk(
-                &endpoint,
-                &output_path,
+                &ctx.endpoint,
+                &ctx.output_path,
                 &work.table,
                 &table_path,
                 &pk_column,
                 &range,
-                &data_format,
-                &compression,
+                &ctx.data_format,
+                &ctx.compression,
             );
             match result {
                 Ok((rows, stream_ms, checksum)) => {
@@ -1375,19 +1279,14 @@ fn spawn_dump_global_worker(
         }
         DumpGlobalWorkKind::WholeTable => {
             let result = (|| {
-                let mut adapter = LiveAdapter::connect(&endpoint)?;
+                let mut adapter = LiveAdapter::connect(&ctx.endpoint)?;
                 let started = Instant::now();
                 dump_one_table(
                     &mut adapter,
-                    &endpoint,
-                    &output_path,
+                    &ctx,
                     &work.table,
                     work.table_index,
                     table_total,
-                    chunk_size,
-                    &data_format,
-                    &compression,
-                    request_id,
                     |event| {
                         let _ = sender.send(DumpGlobalEvent::Progress(event));
                     },
@@ -1465,32 +1364,22 @@ fn dump_mysql_range_chunk(
 }
 
 fn spawn_dump_table_worker(
-    endpoint: Endpoint,
-    output_path: std::path::PathBuf,
+    ctx: DumpJobContext,
     table: NormalizedTable,
     index: usize,
     table_total: usize,
-    chunk_size: usize,
-    data_format: String,
-    compression: String,
     range_threads: usize,
-    request_id: Option<String>,
     sender: mpsc::Sender<DumpTableEvent>,
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || {
         let result = (|| {
-            if endpoint.engine == "mysql" {
+            if ctx.endpoint.engine == "mysql" {
                 if let Some(result) = dump_mysql_table_parallel_ranges(
-                    &endpoint,
-                    &output_path,
+                    &ctx,
                     &table,
                     index,
                     table_total,
-                    chunk_size,
-                    &data_format,
-                    &compression,
                     range_threads,
-                    request_id.clone(),
                     |event| {
                         let _ = sender.send(DumpTableEvent::Progress(event));
                     },
@@ -1498,18 +1387,13 @@ fn spawn_dump_table_worker(
                     return Ok(result);
                 }
             }
-            let mut adapter = LiveAdapter::connect(&endpoint)?;
+            let mut adapter = LiveAdapter::connect(&ctx.endpoint)?;
             dump_one_table(
                 &mut adapter,
-                &endpoint,
-                &output_path,
+                &ctx,
                 &table,
                 index,
                 table_total,
-                chunk_size,
-                &data_format,
-                &compression,
-                request_id,
                 |event| {
                     let _ = sender.send(DumpTableEvent::Progress(event));
                 },
@@ -1531,35 +1415,35 @@ fn spawn_dump_table_worker(
     })
 }
 
-fn dump_one_table<F: FnMut(Value)>(
-    adapter: &mut LiveAdapter,
-    endpoint: &Endpoint,
-    output_path: &Path,
+/// `run_table_dump_loop`가 한 청크를 기록한 결과. rows는 이 청크의 행 수,
+/// chunk_name은 sha256 맵의 키, checksum은 청크 파일 해시.
+struct ChunkOutcome {
+    rows: u64,
+    chunk_name: String,
+    checksum: String,
+}
+
+/// 단일 테이블 덤프의 공통 스캐폴딩: dumping/completed table_progress 이벤트,
+/// `{index+1:04}_{safe_name}` 디렉토리 생성, 청크 누적(rows/chunks/sha256), manifest 조립.
+///
+/// 엔진별로 다른 청크 read+write 로직은 `fetch_next_chunk` 클로저가 공급한다.
+/// 클로저는 (다음 청크 번호, 지금까지 누적 rows, table_dir, emit)을 받아 한 청크를
+/// 파일로 기록하고 `ChunkOutcome`을 반환하거나, 더 이상 쓸 데이터가 없으면 `None`을
+/// 반환한다. row_progress 이벤트는 청크 필드가 엔진마다 달라 클로저가 직접 emit한다.
+fn run_table_dump_loop<F: FnMut(Value)>(
     table: &NormalizedTable,
     index: usize,
     table_total: usize,
-    chunk_size: usize,
-    data_format: &str,
-    compression: &str,
+    output_path: &Path,
     request_id: Option<String>,
     mut emit: F,
+    mut fetch_next_chunk: impl FnMut(
+        u64,
+        u64,
+        &Path,
+        &mut dyn FnMut(Value),
+    ) -> Result<Option<ChunkOutcome>, String>,
 ) -> Result<(DumpTableManifest, u64, u64), String> {
-    if let LiveAdapter::MySql(conn) = adapter {
-        return dump_one_mysql_table(
-            conn,
-            endpoint,
-            output_path,
-            table,
-            index,
-            table_total,
-            chunk_size,
-            data_format,
-            compression,
-            request_id,
-            emit,
-        );
-    }
-
     emit(json!({
         "event": "table_progress",
         "request_id": request_id,
@@ -1573,61 +1457,19 @@ fn dump_one_table<F: FnMut(Value)>(
     fs::create_dir_all(&table_dir)
         .map_err(|err| format!("failed to create dump table dir: {err}"))?;
 
-    let table_row_count = adapter.row_count(&table.name).unwrap_or(0) as u64;
-    let key_columns = key_columns(table);
-    let use_keyset = !key_columns.is_empty();
-    let mut last_key: Option<String> = None;
-    let mut offset = 0_usize;
     let mut rows_dumped = 0_u64;
     let mut chunks_dumped = 0_u64;
     let mut chunk_sha256 = BTreeMap::new();
 
     loop {
-        let Some(read_limit) = bounded_dump_chunk_limit(table_row_count, rows_dumped, chunk_size)
-        else {
-            break;
-        };
-        let read_started = Instant::now();
-        let rows = if use_keyset {
-            adapter.read_rows_after_key(table, &key_columns, last_key.as_deref(), read_limit)?
-        } else {
-            adapter.read_rows(table, offset, read_limit)?
-        };
-        let read_ms = read_started.elapsed().as_millis() as u64;
-        if rows.is_empty() {
-            break;
+        match fetch_next_chunk(chunks_dumped + 1, rows_dumped, &table_dir, &mut emit)? {
+            Some(outcome) => {
+                chunk_sha256.insert(outcome.chunk_name, outcome.checksum);
+                rows_dumped += outcome.rows;
+                chunks_dumped += 1;
+            }
+            None => break,
         }
-        chunks_dumped += 1;
-        let chunk_name = dump_chunk_name(chunks_dumped, data_format, compression);
-        let write_started = Instant::now();
-        let checksum = write_dump_rows(
-            &table_dir.join(&chunk_name),
-            table,
-            &rows,
-            data_format,
-            compression,
-        )?;
-        chunk_sha256.insert(chunk_name, checksum);
-        let write_ms = write_started.elapsed().as_millis() as u64;
-
-        let copied_now = rows.len();
-        rows_dumped += copied_now as u64;
-        if use_keyset {
-            last_key = rows.last().and_then(|row| row_key_token(row, &key_columns));
-        } else {
-            offset += copied_now;
-        }
-
-        emit(json!({
-            "event": "row_progress",
-            "request_id": request_id,
-            "table": table.name,
-            "rows": rows_dumped,
-            "total": table_row_count,
-            "chunk_rows": copied_now,
-            "read_ms": read_ms,
-            "write_ms": write_ms
-        }));
     }
 
     emit(json!({
@@ -1652,32 +1494,96 @@ fn dump_one_table<F: FnMut(Value)>(
     ))
 }
 
-fn dump_one_mysql_table<F: FnMut(Value)>(
-    conn: &mut mysql::PooledConn,
-    endpoint: &Endpoint,
-    output_path: &Path,
+fn dump_one_table<F: FnMut(Value)>(
+    adapter: &mut LiveAdapter,
+    ctx: &DumpJobContext,
     table: &NormalizedTable,
     index: usize,
     table_total: usize,
-    chunk_size: usize,
-    data_format: &str,
-    compression: &str,
-    request_id: Option<String>,
-    mut emit: F,
+    emit: F,
 ) -> Result<(DumpTableManifest, u64, u64), String> {
-    emit(json!({
-        "event": "table_progress",
-        "request_id": request_id,
-        "table": table.name,
-        "status": "dumping",
-        "current": index + 1,
-        "total": table_total
-    }));
-    let table_path = format!("{:04}_{}", index + 1, safe_dump_component(&table.name));
-    let table_dir = output_path.join(&table_path);
-    fs::create_dir_all(&table_dir)
-        .map_err(|err| format!("failed to create dump table dir: {err}"))?;
+    if let LiveAdapter::MySql(conn) = adapter {
+        return dump_one_mysql_table(conn, ctx, table, index, table_total, emit);
+    }
 
+    let table_row_count = adapter.row_count(&table.name).unwrap_or(0) as u64;
+    let key_columns = key_columns(table);
+    let use_keyset = !key_columns.is_empty();
+    let mut last_key: Option<String> = None;
+    let mut offset = 0_usize;
+
+    run_table_dump_loop(
+        table,
+        index,
+        table_total,
+        &ctx.output_path,
+        ctx.request_id.clone(),
+        emit,
+        |chunk_number: u64,
+         rows_dumped_before: u64,
+         table_dir: &Path,
+         emit: &mut dyn FnMut(Value)|
+         -> Result<Option<ChunkOutcome>, String> {
+            let Some(read_limit) =
+                bounded_dump_chunk_limit(table_row_count, rows_dumped_before, ctx.chunk_size)
+            else {
+                return Ok(None);
+            };
+            let read_started = Instant::now();
+            let rows = if use_keyset {
+                adapter.read_rows_after_key(table, &key_columns, last_key.as_deref(), read_limit)?
+            } else {
+                adapter.read_rows(table, offset, read_limit)?
+            };
+            let read_ms = read_started.elapsed().as_millis() as u64;
+            if rows.is_empty() {
+                return Ok(None);
+            }
+            let chunk_name = dump_chunk_name(chunk_number, &ctx.data_format, &ctx.compression);
+            let write_started = Instant::now();
+            let checksum = write_dump_rows(
+                &table_dir.join(&chunk_name),
+                table,
+                &rows,
+                &ctx.data_format,
+                &ctx.compression,
+            )?;
+            let write_ms = write_started.elapsed().as_millis() as u64;
+
+            let copied_now = rows.len();
+            if use_keyset {
+                last_key = rows.last().and_then(|row| row_key_token(row, &key_columns));
+            } else {
+                offset += copied_now;
+            }
+
+            emit(json!({
+                "event": "row_progress",
+                "request_id": ctx.request_id,
+                "table": table.name,
+                "rows": rows_dumped_before + copied_now as u64,
+                "total": table_row_count,
+                "chunk_rows": copied_now,
+                "read_ms": read_ms,
+                "write_ms": write_ms
+            }));
+            Ok(Some(ChunkOutcome {
+                rows: copied_now as u64,
+                chunk_name,
+                checksum,
+            }))
+        },
+    )
+}
+
+fn dump_one_mysql_table<F: FnMut(Value)>(
+    conn: &mut mysql::PooledConn,
+    ctx: &DumpJobContext,
+    table: &NormalizedTable,
+    index: usize,
+    table_total: usize,
+    emit: F,
+) -> Result<(DumpTableManifest, u64, u64), String> {
     let table_row_count = conn
         .query_first::<u64, _>(count_sql("mysql", &table.name))
         .map(|count| count.unwrap_or(0))
@@ -1686,120 +1592,109 @@ fn dump_one_mysql_table<F: FnMut(Value)>(
     // 컬럼 테이블에서 하나의 result set가 과대해져 스트리밍 코덱이 크래시하는 것을 막는다.
     // 병렬 경로와 동일한 avg-row-length 헬퍼를 재사용하며, 조회 실패/통계 부재 시
     // avg=0 → fallback(chunk_size) → 상한이 지배하도록 안전하게 degrade한다.
-    let avg_row_bytes = mysql_table_avg_row_length(conn, endpoint, &table.name);
-    let effective_chunk_size = sequential_mysql_chunk_size(chunk_size, avg_row_bytes);
+    let avg_row_bytes = mysql_table_avg_row_length(conn, &ctx.endpoint, &table.name);
+    let effective_chunk_size = sequential_mysql_chunk_size(ctx.chunk_size, avg_row_bytes);
     let columns = column_names(table);
     let key_columns = key_columns(table);
     let use_keyset = !key_columns.is_empty();
     let mut last_key: Option<String> = None;
     let mut offset = 0_usize;
-    let mut rows_dumped = 0_u64;
-    let mut chunks_dumped = 0_u64;
-    let mut chunk_sha256 = BTreeMap::new();
 
-    loop {
-        let Some(read_limit) =
-            bounded_dump_chunk_limit(table_row_count, rows_dumped, effective_chunk_size)
-        else {
-            break;
-        };
-        chunks_dumped += 1;
-        let chunk_name = dump_chunk_name(chunks_dumped, data_format, compression);
-        let chunk_path = table_dir.join(&chunk_name);
+    run_table_dump_loop(
+        table,
+        index,
+        table_total,
+        &ctx.output_path,
+        ctx.request_id.clone(),
+        emit,
+        |chunk_number: u64,
+         rows_dumped_before: u64,
+         table_dir: &Path,
+         emit: &mut dyn FnMut(Value)|
+         -> Result<Option<ChunkOutcome>, String> {
+            let Some(read_limit) =
+                bounded_dump_chunk_limit(table_row_count, rows_dumped_before, effective_chunk_size)
+            else {
+                return Ok(None);
+            };
+            let chunk_name = dump_chunk_name(chunk_number, &ctx.data_format, &ctx.compression);
+            let chunk_path = table_dir.join(&chunk_name);
 
-        let stream_started = Instant::now();
-        let last_values = last_key.as_deref().and_then(decode_key_token);
-        let sql = if use_keyset {
-            select_chunk_text_after_key_sql(
-                "mysql",
-                table,
-                &key_columns,
-                last_values.as_deref(),
-                read_limit,
-            )
-        } else {
-            select_chunk_text_sql("mysql", table, &key_columns)
-        };
-        let sql = if use_keyset {
-            sql
-        } else {
-            sql.replacen('?', &(read_limit as u64).to_string(), 1)
-                .replacen('?', &(offset as u64).to_string(), 1)
-        };
-        let result = if use_keyset {
-            conn.query_iter(sql)
-                .map_err(|err| format!("mysql keyset select chunk error: {err}"))?
-        } else {
-            conn.query_iter(sql)
-                .map_err(|err| format!("mysql select chunk error: {err}"))?
-        };
+            let stream_started = Instant::now();
+            let last_values = last_key.as_deref().and_then(decode_key_token);
+            let sql = if use_keyset {
+                select_chunk_text_after_key_sql(
+                    "mysql",
+                    table,
+                    &key_columns,
+                    last_values.as_deref(),
+                    read_limit,
+                )
+            } else {
+                select_chunk_text_sql("mysql", table, &key_columns)
+            };
+            let sql = if use_keyset {
+                sql
+            } else {
+                sql.replacen('?', &(read_limit as u64).to_string(), 1)
+                    .replacen('?', &(offset as u64).to_string(), 1)
+            };
+            let result = if use_keyset {
+                conn.query_iter(sql)
+                    .map_err(|err| format!("mysql keyset select chunk error: {err}"))?
+            } else {
+                conn.query_iter(sql)
+                    .map_err(|err| format!("mysql select chunk error: {err}"))?
+            };
 
-        let mut chunk_rows = 0_usize;
-        let mut next_key: Option<String> = None;
-        {
-            let mut file = open_dump_writer(&chunk_path, compression)?;
-            for row in result {
-                let row = row.map_err(|err| format!("mysql dump row error: {err}"))?;
-                if data_format == "tsv" && !use_keyset {
-                    write_mysql_text_row_tsv(&mut file, row)?;
-                } else {
-                    let row_json = mysql_row_to_json(&columns, row);
-                    if use_keyset {
-                        next_key = row_key_token(&row_json, &key_columns);
+            let mut chunk_rows = 0_usize;
+            let mut next_key: Option<String> = None;
+            {
+                let mut file = open_dump_writer(&chunk_path, &ctx.compression)?;
+                for row in result {
+                    let row = row.map_err(|err| format!("mysql dump row error: {err}"))?;
+                    if ctx.data_format == "tsv" && !use_keyset {
+                        write_mysql_text_row_tsv(&mut file, row)?;
+                    } else {
+                        let row_json = mysql_row_to_json(&columns, row);
+                        if use_keyset {
+                            next_key = row_key_token(&row_json, &key_columns);
+                        }
+                        write_dump_row(&mut file, table, &row_json, &ctx.data_format)?;
                     }
-                    write_dump_row(&mut file, table, &row_json, data_format)?;
+                    chunk_rows += 1;
                 }
-                chunk_rows += 1;
             }
-        }
-        let stream_ms = stream_started.elapsed().as_millis() as u64;
+            let stream_ms = stream_started.elapsed().as_millis() as u64;
 
-        if chunk_rows == 0 {
-            fs::remove_file(&chunk_path).ok();
-            chunks_dumped -= 1;
-            break;
-        }
-        let checksum = sha256_file(&chunk_path)?;
-        chunk_sha256.insert(chunk_name, checksum);
+            if chunk_rows == 0 {
+                fs::remove_file(&chunk_path).ok();
+                return Ok(None);
+            }
+            let checksum = sha256_file(&chunk_path)?;
 
-        rows_dumped += chunk_rows as u64;
-        if use_keyset {
-            last_key = next_key;
-        } else {
-            offset += chunk_rows;
-        }
+            if use_keyset {
+                last_key = next_key;
+            } else {
+                offset += chunk_rows;
+            }
 
-        emit(json!({
-            "event": "row_progress",
-            "request_id": request_id,
-            "table": table.name,
-            "rows": rows_dumped,
-            "total": table_row_count,
-            "chunk_rows": chunk_rows,
-            "stream_ms": stream_ms
-        }));
-    }
-
-    emit(json!({
-        "event": "table_progress",
-        "request_id": request_id,
-        "table": table.name,
-        "status": "completed",
-        "current": index + 1,
-        "total": table_total
-    }));
-
-    Ok((
-        DumpTableManifest {
-            name: table.name.clone(),
-            path: table_path,
-            rows: rows_dumped,
-            chunks: chunks_dumped,
-            chunk_sha256,
+            emit(json!({
+                "event": "row_progress",
+                "request_id": ctx.request_id,
+                "table": table.name,
+                "rows": rows_dumped_before + chunk_rows as u64,
+                "total": table_row_count,
+                "chunk_rows": chunk_rows,
+                "stream_ms": stream_ms
+            }));
+            Ok(Some(ChunkOutcome {
+                rows: chunk_rows as u64,
+                chunk_name,
+                checksum,
+            }))
         },
-        rows_dumped,
-        chunks_dumped,
-    ))
+    )
 }
 
 

--- a/migration_core/src/import.rs
+++ b/migration_core/src/import.rs
@@ -124,30 +124,8 @@ fn dump_import<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value,
 
     set_mysql_import_session_tuning(&mut adapter, false)?;
 
-    // replace/recreate는 대상 테이블을 통째로 재생성한다. 두 가지 사전 조치가 필요하다:
-    //
-    // (1) Surviving-FK preflight (MySQL 전용, abort): import set 밖의 타겟 테이블이
-    //     대상 테이블을 참조하는 FK를 갖고 있으면, 부모 재생성 시 그 살아있는 자식 FK가
-    //     새 부모와 (charset/collation) 호환되지 않아 ERROR 3780이 난다. 타겟을 손대지
-    //     않고 명확한 에러로 차단한다.
-    //
-    // (2) Drop-all-then-create-all 순서: import set 내부의 모든 대상 테이블을 자식 우선
-    //     (역의존성) 순서로 먼저 DROP한 뒤 루프에서 생성한다. 이렇게 하지 않고 테이블별로
-    //     즉시 DROP→CREATE 하면, 부모를 재생성하는 시점에 아직 DROP되지 않은 자식의 FK가
-    //     살아 있어 동일한 ERROR 3780을 유발한다.
-    if matches!(mode, "replace" | "recreate") {
-        let import_set: BTreeSet<String> = tables.iter().map(|table| table.name.clone()).collect();
-        let target_schema = endpoint_schema(&endpoint);
-        preflight_surviving_referencing_fks(&mut adapter, &target_schema, &import_set)?;
-
-        // tables는 parent-first(dependency order)이므로 rev()는 child-first가 된다.
-        // foreign_key_checks=0이 이미 켜져 있어 역순 DROP은 안전하다.
-        for table_manifest in tables.iter().rev() {
-            adapter
-                .execute_sql(&drop_table_sql(adapter.engine(), &table_manifest.name))
-                .map_err(|err| dump_import_ddl_error("drop_table", &table_manifest.name, &err))?;
-        }
-    }
+    let target_schema = endpoint_schema(&endpoint);
+    prepare_import_target(mode, &tables, &mut adapter, &target_schema)?;
 
     let import_result = (|| -> Result<(), String> {
         for (index, table_manifest) in tables.iter().enumerate() {
@@ -165,8 +143,6 @@ fn dump_import<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value,
                 "current": index + 1,
                 "total": table_total
             }));
-            let table_rows_before = rows_imported;
-
             // replace/recreate의 DROP은 루프 진입 전에 일괄(자식 우선)로 끝냈다.
             // 여기서는 생성과 적재만 수행한다.
             let ddl = generate_table_ddl(table, &manifest.source_engine, adapter.engine())
@@ -175,70 +151,23 @@ fn dump_import<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value,
                 .create_table(table, &ddl)
                 .map_err(|err| dump_import_ddl_error("create_table", &table.name, &err))?;
 
-            if data_format == "tsv" && !has_binary_columns(table) {
-                if let LiveAdapter::MySql(conn) = &mut adapter {
-                    let (rows, chunks) = import_mysql_tsv_table(
-                        &endpoint,
-                        conn,
-                        input_path,
-                        table,
-                        table_manifest,
-                        &compression,
-                        threads,
-                        request.request_id.clone(),
-                        rows_imported,
-                        overall_rows_total,
-                        |event| emit(event),
-                    )?;
-                    rows_imported += rows;
-                    chunks_imported += chunks;
-                    imported_rows_by_table.insert(table.name.clone(), rows);
-                    emit(json!({
-                        "event": "table_progress",
-                        "request_id": request.request_id,
-                        "table": table.name,
-                        "status": "completed",
-                        "current": index + 1,
-                        "total": table_total
-                    }));
-                    continue;
-                }
-            }
-
-            for chunk_index in 1..=table_manifest.chunks {
-                let chunk_path = dump_manifest_chunk_path(
-                    input_path,
-                    &table_manifest.path,
-                    chunk_index,
-                    &data_format,
-                    &compression,
-                )?;
-                let rows = read_dump_rows(&chunk_path, table, &data_format, &compression)?;
-                let row_count = rows.len();
-                adapter.insert_rows(table, rows)?;
-                rows_imported += row_count as u64;
-                chunks_imported += 1;
-                let table_rows_done = rows_imported.saturating_sub(table_rows_before);
-                emit(dump_import_row_progress_event(
-                    request.request_id.clone(),
-                    &table.name,
-                    table_rows_done,
-                    table_manifest.rows,
-                    table_rows_before,
-                    overall_rows_total,
-                    row_count as u64,
-                    ChunkProgress {
-                        chunks_done: Some(chunk_index),
-                        chunks_total: Some(table_manifest.chunks),
-                        chunk_index: Some(chunk_index),
-                        load_ms: None,
-                    },
-                    "insert_rows",
-                ));
-            }
-
-            let table_rows_imported = rows_imported.saturating_sub(table_rows_before);
-            imported_rows_by_table.insert(table.name.clone(), table_rows_imported);
+            let (table_rows, table_chunks) = import_table_rows(
+                &endpoint,
+                &mut adapter,
+                input_path,
+                table,
+                table_manifest,
+                &data_format,
+                &compression,
+                threads,
+                request.request_id.clone(),
+                rows_imported,
+                overall_rows_total,
+                |event| emit(event),
+            )?;
+            rows_imported += table_rows;
+            chunks_imported += table_chunks;
+            imported_rows_by_table.insert(table.name.clone(), table_rows);
             emit(json!({
                 "event": "table_progress",
                 "request_id": request.request_id,
@@ -260,20 +189,166 @@ fn dump_import<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value,
     import_result?;
     restore_result?;
     local_infile_restore_result?;
+
+    finalize_dump_import(
+        &mut adapter,
+        &manifest,
+        &tables,
+        &imported_rows_by_table,
+        input_dir,
+        request.request_id.clone(),
+        mode,
+        &selected,
+        strict_manifest,
+        &manifest_warnings,
+        rows_imported,
+        chunks_imported,
+        table_total,
+        emit,
+    )
+}
+
+/// replace/recreate 모드일 때 import 전에 대상 테이블을 재생성 가능한 상태로 만든다.
+///
+/// (1) Surviving-FK preflight (MySQL 전용, abort): import set 밖의 타겟 테이블이
+///     대상 테이블을 참조하는 FK를 갖고 있으면, 부모 재생성 시 그 살아있는 자식 FK가
+///     새 부모와 (charset/collation) 호환되지 않아 ERROR 3780이 난다. 타겟을 손대지
+///     않고 명확한 에러로 차단한다.
+///
+/// (2) Drop-all-then-create-all 순서: import set 내부의 모든 대상 테이블을 자식 우선
+///     (역의존성) 순서로 먼저 DROP한 뒤 루프에서 생성한다. 이렇게 하지 않고 테이블별로
+///     즉시 DROP→CREATE 하면, 부모를 재생성하는 시점에 아직 DROP되지 않은 자식의 FK가
+///     살아 있어 동일한 ERROR 3780을 유발한다.
+///
+/// merge 모드에서는 아무것도 하지 않는다.
+fn prepare_import_target(
+    mode: &str,
+    tables: &[DumpTableManifest],
+    adapter: &mut LiveAdapter,
+    target_schema: &str,
+) -> Result<(), String> {
+    if !matches!(mode, "replace" | "recreate") {
+        return Ok(());
+    }
+    let import_set: BTreeSet<String> = tables.iter().map(|table| table.name.clone()).collect();
+    preflight_surviving_referencing_fks(adapter, target_schema, &import_set)?;
+
+    // tables는 parent-first(dependency order)이므로 rev()는 child-first가 된다.
+    // foreign_key_checks=0이 이미 켜져 있어 역순 DROP은 안전하다.
+    for table_manifest in tables.iter().rev() {
+        adapter
+            .execute_sql(&drop_table_sql(adapter.engine(), &table_manifest.name))
+            .map_err(|err| dump_import_ddl_error("drop_table", &table_manifest.name, &err))?;
+    }
+    Ok(())
+}
+
+/// 단일 테이블의 데이터를 적재한다. MySQL TSV fast-path(LOAD DATA / 병렬 / fallback)와
+/// 엔진 무관 generic 청크 INSERT 경로를 분기하고, 이 테이블에 적재한 (rows, chunks)를 반환한다.
+/// 테이블 생성(DDL)과 진행률 table_progress 이벤트는 호출자가 담당한다.
+fn import_table_rows<F: FnMut(Value)>(
+    endpoint: &Endpoint,
+    adapter: &mut LiveAdapter,
+    input_path: &Path,
+    table: &NormalizedTable,
+    table_manifest: &DumpTableManifest,
+    data_format: &str,
+    compression: &str,
+    threads: usize,
+    request_id: Option<String>,
+    overall_rows_before: u64,
+    overall_rows_total: u64,
+    mut emit: F,
+) -> Result<(u64, u64), String> {
+    if data_format == "tsv" && !has_binary_columns(table) {
+        if let LiveAdapter::MySql(conn) = adapter {
+            let chunk_ctx = MysqlImportChunkContext {
+                table,
+                table_manifest,
+                compression,
+                request_id: request_id.clone(),
+                overall_rows_before,
+                overall_rows_total,
+            };
+            return import_mysql_tsv_table(
+                endpoint,
+                conn,
+                input_path,
+                threads,
+                &chunk_ctx,
+                |event| emit(event),
+            );
+        }
+    }
+
+    let mut table_rows = 0_u64;
+    let mut table_chunks = 0_u64;
+    for chunk_index in 1..=table_manifest.chunks {
+        let chunk_path = dump_manifest_chunk_path(
+            input_path,
+            &table_manifest.path,
+            chunk_index,
+            data_format,
+            compression,
+        )?;
+        let rows = read_dump_rows(&chunk_path, table, data_format, compression)?;
+        let row_count = rows.len() as u64;
+        adapter.insert_rows(table, rows)?;
+        table_rows += row_count;
+        table_chunks += 1;
+        emit(dump_import_row_progress_event(
+            request_id.clone(),
+            &table.name,
+            table_rows,
+            table_manifest.rows,
+            overall_rows_before,
+            overall_rows_total,
+            row_count,
+            ChunkProgress {
+                chunks_done: Some(chunk_index),
+                chunks_total: Some(table_manifest.chunks),
+                chunk_index: Some(chunk_index),
+                load_ms: None,
+            },
+            "insert_rows",
+        ));
+    }
+    Ok((table_rows, table_chunks))
+}
+
+/// import 데이터 적재 완료 후의 마무리 단계: post-load DDL(인덱스/FK) 적용,
+/// 적재 행수 검증, View 생성(best-effort), 리포트 기록 후 최종 result JSON을 만든다.
+fn finalize_dump_import<F: FnMut(Value)>(
+    adapter: &mut LiveAdapter,
+    manifest: &DumpManifest,
+    tables: &[DumpTableManifest],
+    imported_rows_by_table: &BTreeMap<String, u64>,
+    input_dir: &str,
+    request_id: Option<String>,
+    mode: &str,
+    selected: &BTreeSet<String>,
+    strict_manifest: bool,
+    manifest_warnings: &[String],
+    rows_imported: u64,
+    chunks_imported: u64,
+    table_total: usize,
+    mut emit: F,
+) -> Result<Value, String> {
+    let input_path = Path::new(input_dir);
     let target_engine = adapter.engine().to_string();
     if should_apply_post_load_ddl(mode) {
         emit(json!({
             "event": "phase",
-            "request_id": request.request_id,
+            "request_id": request_id,
             "phase": "dump_import_post_load",
             "message": "현재 단계: 인덱스/FK 생성 중 - 데이터 Import는 완료, 후처리 진행 중",
             "strategy": "post_load_ddl"
         }));
-        apply_post_load_ddl(&mut adapter, &manifest.schema, &target_engine)?;
+        apply_post_load_ddl(adapter, &manifest.schema, &target_engine)?;
     } else {
         emit(json!({
             "event": "phase",
-            "request_id": request.request_id,
+            "request_id": request_id,
             "phase": "dump_import_post_load",
             "message": post_load_ddl_skip_message(mode),
             "strategy": "existing_schema"
@@ -284,17 +359,17 @@ fn dump_import<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value,
     // 살아있는 DB면 import 동안 외부 write(예: login_attempts에 새 로그인 시도)로
     // row 수가 정상적으로 달라질 수 있어, 정확 일치를 요구하면 오탐으로 실패한다.
     // (foreign_key_checks=0/unique_checks=0으로 관용 적재하는 정책과도 일관.)
-    verify_imported_row_counts(&tables, &imported_rows_by_table)?;
+    verify_imported_row_counts(tables, imported_rows_by_table)?;
 
     // View 생성 (best-effort). 데이터는 이미 커밋되었으므로 View 실패가 전체 import를 무효화하지 않는다.
     // 전체 import(테이블 부분 선택 없음)일 때만 시도한다 — 부분 import면 View가 참조하는 base table이 없을 수 있다.
     let view_outcome = if selected.is_empty() && !manifest.views.is_empty() {
         import_views(
-            &mut adapter,
-            &manifest,
+            adapter,
+            manifest,
             &target_engine,
             mode,
-            request.request_id.clone(),
+            request_id.clone(),
             &mut emit,
         )
     } else {
@@ -321,7 +396,7 @@ fn dump_import<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value,
 
     Ok(json!({
         "event": "result",
-        "request_id": request.request_id,
+        "request_id": request_id,
         "command": "dump.import",
         "success": true,
         "input_dir": input_dir,
@@ -471,76 +546,54 @@ fn import_views<A: MigrationAdapter, F: FnMut(Value)>(
     outcome
 }
 
+/// MySQL TSV import 경로(fast-path / parallel / insert fallback)가 공통으로
+/// 전달받던 6개 인자 클러스터를 묶는다. 테이블 정의·매니페스트·압축·요청 ID·
+/// 전체 진행률 기준선을 한 번에 관통시켜 시그니처 부풀림을 줄인다.
+#[derive(Clone)]
+struct MysqlImportChunkContext<'a> {
+    table: &'a NormalizedTable,
+    table_manifest: &'a DumpTableManifest,
+    compression: &'a str,
+    request_id: Option<String>,
+    overall_rows_before: u64,
+    overall_rows_total: u64,
+}
+
 fn import_mysql_tsv_table<F: FnMut(Value)>(
     endpoint: &Endpoint,
     conn: &mut mysql::PooledConn,
     input_path: &Path,
-    table: &NormalizedTable,
-    table_manifest: &DumpTableManifest,
-    compression: &str,
     threads: usize,
-    request_id: Option<String>,
-    overall_rows_before: u64,
-    overall_rows_total: u64,
+    ctx: &MysqlImportChunkContext,
     mut emit: F,
 ) -> Result<(u64, u64), String> {
     if !mysql_local_infile_enabled(conn) {
         emit(json!({
             "event": "phase",
-            "request_id": request_id,
+            "request_id": ctx.request_id,
             "phase": "dump_import",
             "message": "MySQL local_infile is disabled; using safe Rust INSERT fallback",
             "strategy": "insert_fallback",
             "performance": "safe_fallback"
         }));
-        return import_mysql_tsv_table_insert_fallback(
-            conn,
-            input_path,
-            table,
-            table_manifest,
-            compression,
-            request_id,
-            overall_rows_before,
-            overall_rows_total,
-            emit,
-        );
+        return import_mysql_tsv_table_insert_fallback(conn, input_path, ctx, emit);
     }
 
-    if threads > 1 && table_manifest.chunks > 1 {
-        let result = import_mysql_tsv_table_parallel(
-            endpoint,
-            input_path,
-            table,
-            table_manifest,
-            compression,
-            threads,
-            request_id.clone(),
-            overall_rows_before,
-            overall_rows_total,
-            |event| emit(event),
-        );
+    if threads > 1 && ctx.table_manifest.chunks > 1 {
+        let result =
+            import_mysql_tsv_table_parallel(endpoint, input_path, threads, ctx, |event| emit(event));
         return match result {
             Ok(result) => Ok(result),
             Err(err) if is_mysql_local_infile_disabled_error(&err) => {
                 emit(json!({
                     "event": "phase",
-                    "request_id": request_id,
+                    "request_id": ctx.request_id,
                     "phase": "dump_import",
                     "message": "MySQL LOAD DATA LOCAL is disabled; using safe Rust INSERT fallback",
                     "strategy": "insert_fallback",
                     "performance": "safe_fallback"
                 }));
-                import_mysql_tsv_table_insert_fallback(
-                    conn,
-                    input_path,
-                    table,
-                    table_manifest,
-                    compression,
-                    request_id,
-                    overall_rows_before,
-                    overall_rows_total,
-                    emit,
-                )
+                import_mysql_tsv_table_insert_fallback(conn, input_path, ctx, emit)
             }
             Err(err) => Err(err),
         };
@@ -558,43 +611,33 @@ fn import_mysql_tsv_table<F: FnMut(Value)>(
         let mut chunks_imported = 0_u64;
         let mut retryable_table_error: Option<String> = None;
 
-        for chunk_index in 1..=table_manifest.chunks {
+        for chunk_index in 1..=ctx.table_manifest.chunks {
             let chunk_path = dump_manifest_chunk_path(
                 input_path,
-                &table_manifest.path,
+                &ctx.table_manifest.path,
                 chunk_index,
                 "tsv",
-                compression,
+                ctx.compression,
             )?;
             let started = Instant::now();
             let rows = match load_chunk_with_reconnect(
                 endpoint,
                 conn,
-                table,
+                ctx.table,
                 &chunk_path,
-                compression,
+                ctx.compression,
             ) {
                 Ok(rows) => rows,
                 Err(err) if is_mysql_local_infile_disabled_error(&err) => {
                     emit(json!({
                         "event": "phase",
-                        "request_id": request_id,
+                        "request_id": ctx.request_id,
                         "phase": "dump_import",
                         "message": "MySQL LOAD DATA LOCAL is disabled; using safe Rust INSERT fallback",
                         "strategy": "insert_fallback",
                         "performance": "safe_fallback"
                     }));
-                    return import_mysql_tsv_table_insert_fallback(
-                        conn,
-                        input_path,
-                        table,
-                        table_manifest,
-                        compression,
-                        request_id,
-                        overall_rows_before,
-                        overall_rows_total,
-                        emit,
-                    );
+                    return import_mysql_tsv_table_insert_fallback(conn, input_path, ctx, emit);
                 }
                 Err(err) if is_transient_disconnect_error(&err) => {
                     // 청크 재접속 재시도로도 복구 안 된 지속적 끊김.
@@ -606,16 +649,16 @@ fn import_mysql_tsv_table<F: FnMut(Value)>(
             rows_imported += rows;
             chunks_imported += 1;
             emit(dump_import_row_progress_event(
-                request_id.clone(),
-                &table.name,
+                ctx.request_id.clone(),
+                &ctx.table.name,
                 rows_imported,
-                table_manifest.rows,
-                overall_rows_before,
-                overall_rows_total,
+                ctx.table_manifest.rows,
+                ctx.overall_rows_before,
+                ctx.overall_rows_total,
                 rows,
                 ChunkProgress {
                     chunks_done: Some(chunks_imported),
-                    chunks_total: Some(table_manifest.chunks),
+                    chunks_total: Some(ctx.table_manifest.chunks),
                     chunk_index: Some(chunk_index),
                     load_ms: Some(started.elapsed().as_millis() as u64),
                 },
@@ -631,11 +674,11 @@ fn import_mysql_tsv_table<F: FnMut(Value)>(
                 }
                 emit(json!({
                     "event": "phase",
-                    "request_id": request_id,
+                    "request_id": ctx.request_id,
                     "phase": "dump_import",
                     "message": format!(
                         "연결 끊김으로 테이블 [{}] 재시작 (TRUNCATE 후 재적재)",
-                        table.name
+                        ctx.table.name
                     ),
                     "strategy": "table_restart"
                 }));
@@ -643,7 +686,7 @@ fn import_mysql_tsv_table<F: FnMut(Value)>(
                 *conn = connect_tuned_mysql_import_conn(endpoint)?;
                 conn.query_drop(format!(
                     "TRUNCATE TABLE {}",
-                    quote_ident("mysql", &table.name)
+                    quote_ident("mysql", &ctx.table.name)
                 ))
                 .map_err(|truncate_err| {
                     format!("mysql table restart truncate error: {truncate_err}")
@@ -942,45 +985,40 @@ fn is_transient_disconnect_error(message: &str) -> bool {
 fn import_mysql_tsv_table_insert_fallback<F: FnMut(Value)>(
     conn: &mut mysql::PooledConn,
     input_path: &Path,
-    table: &NormalizedTable,
-    table_manifest: &DumpTableManifest,
-    compression: &str,
-    request_id: Option<String>,
-    overall_rows_before: u64,
-    overall_rows_total: u64,
+    ctx: &MysqlImportChunkContext,
     mut emit: F,
 ) -> Result<(u64, u64), String> {
     let mut rows_imported = 0_u64;
     let mut chunks_imported = 0_u64;
-    for chunk_index in 1..=table_manifest.chunks {
+    for chunk_index in 1..=ctx.table_manifest.chunks {
         let chunk_path = dump_manifest_chunk_path(
             input_path,
-            &table_manifest.path,
+            &ctx.table_manifest.path,
             chunk_index,
             "tsv",
-            compression,
+            ctx.compression,
         )?;
         let started = Instant::now();
-        let rows = insert_mysql_tsv_chunk_with_batches(conn, table, &chunk_path, compression)
+        let rows = insert_mysql_tsv_chunk_with_batches(conn, ctx.table, &chunk_path, ctx.compression)
             .map_err(|err| {
                 format!(
                     "mysql insert fallback error for table {} chunk {}: {err}",
-                    table.name, chunk_index
+                    ctx.table.name, chunk_index
                 )
             })?;
         rows_imported += rows;
         chunks_imported += 1;
         emit(dump_import_row_progress_event(
-            request_id.clone(),
-            &table.name,
+            ctx.request_id.clone(),
+            &ctx.table.name,
             rows_imported,
-            table_manifest.rows,
-            overall_rows_before,
-            overall_rows_total,
+            ctx.table_manifest.rows,
+            ctx.overall_rows_before,
+            ctx.overall_rows_total,
             rows,
             ChunkProgress {
                 chunks_done: Some(chunks_imported),
-                chunks_total: Some(table_manifest.chunks),
+                chunks_total: Some(ctx.table_manifest.chunks),
                 chunk_index: Some(chunk_index),
                 load_ms: Some(started.elapsed().as_millis() as u64),
             },
@@ -1012,17 +1050,13 @@ fn insert_mysql_tsv_chunk_with_batches(
 fn import_mysql_tsv_table_parallel<F: FnMut(Value)>(
     endpoint: &Endpoint,
     input_path: &Path,
-    table: &NormalizedTable,
-    table_manifest: &DumpTableManifest,
-    compression: &str,
     threads: usize,
-    request_id: Option<String>,
-    overall_rows_before: u64,
-    overall_rows_total: u64,
+    ctx: &MysqlImportChunkContext,
     mut emit: F,
 ) -> Result<(u64, u64), String> {
-    let max_threads = threads.max(1).min(table_manifest.chunks as usize);
-    let mut pending = adaptive_import_chunk_order(input_path, table_manifest, "tsv", compression);
+    let max_threads = threads.max(1).min(ctx.table_manifest.chunks as usize);
+    let mut pending =
+        adaptive_import_chunk_order(input_path, ctx.table_manifest, "tsv", ctx.compression);
     let mut active = 0_usize;
     let mut completed = 0_u64;
     let mut rows_imported = 0_u64;
@@ -1035,10 +1069,10 @@ fn import_mysql_tsv_table_parallel<F: FnMut(Value)>(
             handles.push(spawn_mysql_import_chunk_worker(
                 endpoint.clone(),
                 input_path.to_path_buf(),
-                table.clone(),
-                table_manifest.path.clone(),
+                ctx.table.clone(),
+                ctx.table_manifest.path.clone(),
                 chunk_index,
-                compression.to_string(),
+                ctx.compression.to_string(),
                 sender.clone(),
             ));
             active += 1;
@@ -1047,7 +1081,7 @@ fn import_mysql_tsv_table_parallel<F: FnMut(Value)>(
         }
     }
 
-    while completed < table_manifest.chunks && active > 0 {
+    while completed < ctx.table_manifest.chunks && active > 0 {
         match receiver.recv() {
             Ok(ImportChunkEvent::Done {
                 chunk_index,
@@ -1058,16 +1092,16 @@ fn import_mysql_tsv_table_parallel<F: FnMut(Value)>(
                 completed += 1;
                 active = active.saturating_sub(1);
                 emit(dump_import_row_progress_event(
-                    request_id.clone(),
-                    &table.name,
+                    ctx.request_id.clone(),
+                    &ctx.table.name,
                     rows_imported,
-                    table_manifest.rows,
-                    overall_rows_before,
-                    overall_rows_total,
+                    ctx.table_manifest.rows,
+                    ctx.overall_rows_before,
+                    ctx.overall_rows_total,
                     rows,
                     ChunkProgress {
                         chunks_done: Some(completed),
-                        chunks_total: Some(table_manifest.chunks),
+                        chunks_total: Some(ctx.table_manifest.chunks),
                         chunk_index: Some(chunk_index),
                         load_ms: Some(load_ms),
                     },
@@ -1077,10 +1111,10 @@ fn import_mysql_tsv_table_parallel<F: FnMut(Value)>(
                     handles.push(spawn_mysql_import_chunk_worker(
                         endpoint.clone(),
                         input_path.to_path_buf(),
-                        table.clone(),
-                        table_manifest.path.clone(),
+                        ctx.table.clone(),
+                        ctx.table_manifest.path.clone(),
                         next_chunk,
-                        compression.to_string(),
+                        ctx.compression.to_string(),
                         sender.clone(),
                     ));
                     active += 1;

--- a/migration_core/src/import.rs
+++ b/migration_core/src/import.rs
@@ -9,6 +9,13 @@ use std::time::Instant;
 use mysql::{prelude::Queryable, LocalInfileHandler};
 use crate::*;
 
+/// MySQL `LOAD DATA LOCAL`이 비활성화됐을 때 반환되는 에러 코드(ERROR 3948) 매칭 토큰.
+const MYSQL_ERR_LOCAL_INFILE_DISABLED: &str = "3948";
+/// import 세션 튜닝에서 상향하는 net_read/net_write 타임아웃(초).
+const MYSQL_IMPORT_NET_TIMEOUT_SECS: u32 = 600;
+/// import 세션 튜닝에서 상향하는 wait_timeout(초).
+const MYSQL_IMPORT_WAIT_TIMEOUT_SECS: u32 = 28800;
+
 pub(crate) fn dump_import_streaming<F: FnMut(Value)>(request: &Request, mut emit: F) {
     emit(json!({
         "event": "phase",
@@ -66,7 +73,7 @@ fn dump_import<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value,
         .get("threads")
         .and_then(Value::as_u64)
         .map(|value| value as usize)
-        .unwrap_or(8)
+        .unwrap_or(DEFAULT_DUMP_THREADS)
         .max(1);
     let mysql_local_infile_policy = mysql_local_infile_policy_from_payload(&request.payload)?;
     let timezone_sql =
@@ -220,10 +227,12 @@ fn dump_import<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value,
                     table_rows_before,
                     overall_rows_total,
                     row_count as u64,
-                    Some(chunk_index),
-                    Some(table_manifest.chunks),
-                    Some(chunk_index),
-                    None,
+                    ChunkProgress {
+                        chunks_done: Some(chunk_index),
+                        chunks_total: Some(table_manifest.chunks),
+                        chunk_index: Some(chunk_index),
+                        load_ms: None,
+                    },
                     "insert_rows",
                 ));
             }
@@ -604,10 +613,12 @@ fn import_mysql_tsv_table<F: FnMut(Value)>(
                 overall_rows_before,
                 overall_rows_total,
                 rows,
-                Some(chunks_imported),
-                Some(table_manifest.chunks),
-                Some(chunk_index),
-                Some(started.elapsed().as_millis() as u64),
+                ChunkProgress {
+                    chunks_done: Some(chunks_imported),
+                    chunks_total: Some(table_manifest.chunks),
+                    chunk_index: Some(chunk_index),
+                    load_ms: Some(started.elapsed().as_millis() as u64),
+                },
                 "load_data_local_infile",
             ));
         }
@@ -796,7 +807,7 @@ fn restore_mysql_local_infile_policy<F: FnMut(Value)>(
 
 fn is_mysql_local_infile_disabled_error(message: &str) -> bool {
     let lower = message.to_ascii_lowercase();
-    lower.contains("3948")
+    lower.contains(MYSQL_ERR_LOCAL_INFILE_DISABLED)
         || lower.contains("loading local data is disabled")
         || lower.contains("local infile")
             && (lower.contains("disabled") || lower.contains("not allowed"))
@@ -877,9 +888,9 @@ fn mysql_import_session_tuning_sql(restore: bool) -> Vec<String> {
             // 서버 측 세션 idle/전송 타임아웃 상향 — 대량 청크 전송 중 서버가
             // net_read/net_write_timeout(기본 30/60s)이나 wait_timeout으로 먼저
             // 연결을 끊는 것을 방어한다. keepalive(mysql_opts)와 이중 방어.
-            "SET SESSION net_read_timeout = 600".to_string(),
-            "SET SESSION net_write_timeout = 600".to_string(),
-            "SET SESSION wait_timeout = 28800".to_string(),
+            format!("SET SESSION net_read_timeout = {MYSQL_IMPORT_NET_TIMEOUT_SECS}"),
+            format!("SET SESSION net_write_timeout = {MYSQL_IMPORT_NET_TIMEOUT_SECS}"),
+            format!("SET SESSION wait_timeout = {MYSQL_IMPORT_WAIT_TIMEOUT_SECS}"),
         ]
     }
 }
@@ -967,10 +978,12 @@ fn import_mysql_tsv_table_insert_fallback<F: FnMut(Value)>(
             overall_rows_before,
             overall_rows_total,
             rows,
-            Some(chunks_imported),
-            Some(table_manifest.chunks),
-            Some(chunk_index),
-            Some(started.elapsed().as_millis() as u64),
+            ChunkProgress {
+                chunks_done: Some(chunks_imported),
+                chunks_total: Some(table_manifest.chunks),
+                chunk_index: Some(chunk_index),
+                load_ms: Some(started.elapsed().as_millis() as u64),
+            },
             "insert_fallback",
         ));
     }
@@ -1052,10 +1065,12 @@ fn import_mysql_tsv_table_parallel<F: FnMut(Value)>(
                     overall_rows_before,
                     overall_rows_total,
                     rows,
-                    Some(completed),
-                    Some(table_manifest.chunks),
-                    Some(chunk_index),
-                    Some(load_ms),
+                    ChunkProgress {
+                        chunks_done: Some(completed),
+                        chunks_total: Some(table_manifest.chunks),
+                        chunk_index: Some(chunk_index),
+                        load_ms: Some(load_ms),
+                    },
                     "parallel_load_data_local_infile",
                 ));
                 if let Some(next_chunk) = pending.pop_front() {


### PR DESCRIPTION
## 개요

Clean Code Round 2 **WP-2.10** — `migration_core`의 Rust dump/import 경로를 순수 동작 보존 리팩터로 정리한다. 스펙에 명시된 10개 finding(CC-221~236)을 모두 처리했다. 대상 파일은 `migration_core/src/dump.rs`, `migration_core/src/import.rs` 두 개뿐이며 로직/JSONL 프로토콜/이벤트 출력은 불변이다.

## Findings 처리 내역

| Finding | 내용 | 상태 |
|---|---|---|
| CC-221 | 항상 baseline을 반환하던 `adaptive_dump_parallel_limits_with_avg`/test 래퍼 삭제 → `dump_run`이 `dump_parallel_limits` 직접 호출. 죽은 `avg_row_lengths`/`range_eligible_tables` 제거, `dump_table_stats`를 row-count 전용으로 단순화 | 완료 |
| CC-222 | `dump_tables_parallel`/`dump_tables_global_mysql`/`dump_mysql_table_parallel_ranges`의 복제된 bounded worker-pool 루프를 제네릭 `run_bounded_pool<Item, Event>` + `PoolAction` enum으로 통합 | 완료 |
| CC-223 | 180줄 `dump_run`을 `parse_dump_run_options`/`select_dump_strategy`(+`DumpStrategy` enum)/`finalize_dump_manifest` 3헬퍼로 분해, dump_run은 ~55줄 오케스트레이터 | 완료 |
| CC-224 | 300줄 `dump_import`을 `prepare_import_target`/`import_table_rows`/`finalize_dump_import` 3헬퍼로 분해 | 완료 |
| CC-225 | `dump_one_table`/`dump_one_mysql_table` 공통 스캐폴딩을 `run_table_dump_loop` + `ChunkOutcome`로 추출(fetch-chunk 클로저 공급) | 완료 |
| CC-226 | dump 경로 공통 6인자(endpoint/output_path/chunk_size/data_format/compression/request_id)를 `DumpJobContext`로 묶어 관통 | 완료 |
| CC-227/236 | `DEFAULT_DUMP_THREADS`(dump.rs) + `MYSQL_ERR_LOCAL_INFILE_DISABLED`/`MYSQL_IMPORT_NET_TIMEOUT_SECS`/`MYSQL_IMPORT_WAIT_TIMEOUT_SECS`(import.rs) 상수화. 골든 테스트와 byte-identical 유지 | 완료 |
| CC-228 | `dump_import_row_progress_event`의 뒤쪽 4개 `Option<u64>`를 `ChunkProgress`(named fields) 구조체로 대체 | 완료 |
| CC-230 | MySQL TSV import 3함수 공통 6필드 클러스터를 `MysqlImportChunkContext<'a>`로 관통 | 완료 |

## 스펙 노후화 대응 (skip/조정)

- **CC-221**: 스펙은 `avg_row_lengths`가 `dump_schedule_order`/`dump_schedule_event`에서 계속 쓰인다고 했으나, Round 1 이후 현재 코드에서는 죽은 adaptive 함수에만 공급된다. 제거 시 `DumpTableStats.avg_row_bytes` 필드가 죽어 경고가 발생하므로, 죽은 체인 전체를 제거하고 `dump_table_stats`를 `dump_table_row_counts`(row-count 전용)로 단순화했다. dump 출력(파일/manifest/이벤트)은 불변 — 내부 통계 SELECT에서 미사용 컬럼(AVG_ROW_LENGTH) 하나만 빠진다.
- **CC-221 테스트**: adaptive 함수를 호출하던 5개 테스트를 `dump_parallel_limits` 직접 호출로 재지정(단정값 baseline과 동일해 그대로 통과). 이 중 4개(`adaptive_dump_limits_*`)는 이제 `dump_parallel_limits(8, 208)` 단정으로 수렴해 사실상 중복이나, 스펙의 "재지정" 지시에 따라 삭제하지 않고 유지했다(후속 통합 여지 있음).
- 그 외 finding은 스펙대로 처리. R1에서 이미 해결된 finding은 없었다.

## 동작 보존 주의점

- **CC-222 리필-on-error 차이 보존**: `table_parallel`은 에러에도 워커를 리필(Advance), `global_mysql`/`range`는 에러 시 미리필(AdvanceNoRefill). `run_bounded_pool`의 `PoolAction` 3변형이 이를 정확히 노출한다.
- **CC-222 이벤트 필드**: `range` 루프의 `row_progress.chunks_done`이 루프 카운터를 참조하던 것을 `chunks_done` 로컬 미러(종료 이벤트마다 증가)로 대체해 필드값 불변.
- **CC-225 MySQL 빈 청크**: 빈 마지막 청크의 파일 제거 + 카운트 미증가 동작을 그대로 보존.
- 모든 emit·상태 누적·first_error 캡처는 각 호출자 클로저가 담당해 bookkeeping 순서를 유지.

## 검증 결과

- `cargo build --manifest-path migration_core/Cargo.toml --release` — 성공 (경고 0)
- `cargo test --manifest-path migration_core/Cargo.toml` — **전부 통과** (lib 216, 통합 jsonl_cli/oneclick 9, stress 2; 0 failed)
- 공유 통합테스트 `migration_core/tests/jsonl_cli.rs` 수정 없이 실행만 → 통과
- 전체 `pytest` — **1836 passed, 1 failed**. 유일한 실패는 `test_macos_validation_artifact_download_script_uses_local_head_after_pr_merge`(GitHub CI 의존 macOS 패키징 테스트, 로컬에서 상시 실패하는 기존 환경 이슈)로 본 변경과 무관.
- `cargo clippy` — 이 toolchain(stable-msvc)에 미설치라 실행 불가. 대신 모든 `cargo build`가 경고 0으로 통과함을 확인.

## 위험

- dump.run/dump.import **런타임 경로는 자동 테스트 커버리지가 없다**(jsonl_cli.rs는 핸드셰이크/쿼리만 검증, 실제 DB 덤프/임포트 미검증). CC-222/225의 동시성·청크 로직은 컴파일러 + 수작업 대조로만 검증했다. 기계적 충실성을 최우선으로 작업했으나, 실 DB 대상 스모크 테스트를 권장한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
