### PR TITLE
chore: prepare v2.4.0 release candidate

### DIFF
--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -60,7 +60,7 @@ jobs:
           git config --global --add safe.directory "$PWD"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -328,7 +328,7 @@ jobs:
           PY
 
       - name: Upload macOS app artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: TunnelForge-macOS-${{ steps.version.outputs.version }}-${{ matrix.arch }}
           path: |

--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout trusted base
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
@@ -74,13 +74,13 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -138,13 +138,13 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -321,7 +321,7 @@ jobs:
           PY
 
       - name: Upload macOS validation artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: TunnelForge-macOS-${{ steps.version.outputs.version }}-${{ matrix.arch }}
           path: |
@@ -342,7 +342,7 @@ jobs:
 
     steps:
       - name: Checkout trusted base
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
@@ -406,14 +406,14 @@ jobs:
 
     steps:
       - name: Checkout trusted base
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.x'
 

--- a/docs/current_status.md
+++ b/docs/current_status.md
@@ -57,6 +57,24 @@ TunnelForge is in a strong build/test state. The active architecture baseline
 is Rust Core ownership of DB operations through `tunnelforge-core`, with
 Python/PyQt responsible for UI, orchestration, signals, and dialogs.
 
+The `2.4.0` release candidate packages the completed anonymous error reporting
+work from TF-STATUS-092: affirmative-consent desktop collection, strict local
+sanitization and allowlists, credential-free relay transport, bounded D1 abuse
+controls, and GitHub App issue creation through the active Cloudflare Worker.
+All three release version sources are aligned at `2.4.0`. TF-STATUS-093 is
+`fixed_pending_full_verify` until full local verification, the protected
+version PR and hosted gates, exact-main annotated tag creation, draft artifact
+and digest inspection, and stable publication complete. macOS remains an
+explicitly unsigned direct-download artifact under the accepted project policy;
+this release candidate makes no real-Mac hardware-validation claim.
+Fresh release-candidate verification passed the full Python suite at 2697
+passed / 1 skipped / 4 warnings, the Rust Core regression gate and Cargo
+test/release build, Worker 316/typecheck/audit-zero/dry-run, the complete
+Windows clean build, frozen main-app UI/Rust Core smoke, and WebSetup
+self-check. The clean-build review also made the installer command build and
+verify WebSetup itself, stopped it from rewriting the tracked Inno source, and
+pinned all external actions in the required version and macOS workflows.
+
 The `2.3.1` release candidate now contains the completed release-trust scope:
 GitHub Release asset `digest` verification prevents unverified downloaded
 packages from launching, unknown-environment confirmation protects dangerous
@@ -601,7 +619,7 @@ Historical release-review snapshots (preserved for audit):
     | `pytest -q` | PASS, 1827 passed, 6 warnings |
     | `pytest -q` | PASS, 1955 passed, 1 skipped, 4 warnings, 60.38s, exit 0 |
 
-Version references are aligned at `2.3.1` across:
+Version references are aligned at `2.4.0` across:
 
 - `src/version.py`
 - `pyproject.toml`
@@ -699,6 +717,7 @@ Commands run locally:
 
 | Date | Scope | Command | Result | Notes |
 | --- | --- | --- | --- | --- |
+| 2026-07-15 | `2.4.0` release-candidate preparation / TF-STATUS-093 | RED/GREEN status and version sync; full Python; Rust regression/Cargo test+release; Worker test/typecheck/audit/dry-run; `build-installer.ps1 -Clean`; frozen UI/Rust Core and WebSetup self-checks; workflow pin scan; `git diff --check` | RED proved the source remained `2.3.1`; deterministic minor bump aligned all three sources at `2.4.0`; release-candidate full Python 2697 passed / 1 skipped / 4 warnings; Rust and Worker gates passed; all external actions in `version-gate.yml` are full-SHA pinned; `build-installer.ps1 -Clean` completed end to end and produced the main app, WebSetup, and `TunnelForge-Setup-2.4.0.exe`; Installer source unchanged; frozen checks passed | The initial local installer command exposed stale-output handling, missing bootstrapper creation after clean, tracked Inno-source rewriting, and Windows PowerShell 5.1 UTF-8 parsing problems. TDD added bootstrapper build/self-check, read-only version validation, and a UTF-8 BOM contract. A concurrent clean-build deleted one independent-review test's transient evidence ZIP; two focused reruns and a later standalone full suite passed. Protected version PR, exact-main tag, draft asset/digest inspection, and publication remain. |
 | 2026-07-15 | TF-STATUS-092 protected merge closure | `gh pr checks 245 --watch`; `gh pr ready 245`; `gh pr merge 245 --merge`; post-merge PR/main ancestry, repository-secret inventory, and production health verification | fresh-head runs `29385868513` and `29385868516` passed all required gates; PR #245 merged at `2026-07-15T03:22:13Z` as `6dbcd51c8c60acef3569697fa79a9e6914a7c0e0`; `origin/main` has the expected two-parent merge ancestry; `GH_APP_PRIVATE_KEY` remains absent while exactly the two Releaser secrets remain; relay health returned schema 1 and mode `active` | TF-STATUS-092 is closed. The exposed Reporter key, its possible derived-token lifetime, the unused repository secret, client credential retirement, replacement canary/rollout, frozen package smoke, fresh-head hosted gates, and protected merge are all complete. |
 | 2026-07-15 | TF-STATUS-092 exposed-key deletion, repository-secret containment, and protected PR gate | GitHub Developer Settings exact-fingerprint deletion and post-action key inventory; one-hour containment wait; `gh secret delete GH_APP_PRIVATE_KEY`; repository-secret name inventory; `dist\TunnelForge\TunnelForge.exe --ui-smoke-check`; `git push`; draft PR #245; `gh pr checks 245 --watch` | exposed Reporter fingerprint `SHA256:hLY6...nt+k=` deleted at `2026-07-15T02:06:03Z`; containment completed at `2026-07-15T03:06:03Z`; unused `GH_APP_PRIVATE_KEY` deleted at `2026-07-15T03:06:23Z`; only `RELEASER_APP_ID` and `RELEASER_APP_PRIVATE_KEY` remain; replacement `SHA256:6Yki...GYB4=` remains; frozen UI smoke returned `success=true` with bundled Rust Core service hello; commit `9367faa` pushed; PR #245 opened; hosted runs `29382607405` and `29382607434` passed Python, Rust, version, macOS support tracking, and both internal/external macOS arm64/x86_64 gates | The replacement Reporter key and separate Releaser lane were not changed. TF-STATUS-092 remains `fixed_pending_full_verify` until the final status commit, fresh-head CI, and protected PR completion are recorded. |
 | 2026-07-15 | TF-STATUS-092 Task 13 canary, emergency off, active, and client binding | authenticated synthetic canary POSTs; GitHub issue/D1 inspection; `gh issue close 244`; Wrangler deploy/health/smoke for off and active; Cloudflare GraphQL `workersInvocationsAdaptive`; full Python/Rust/Worker/package gates | canary created and updated `https://github.com/sanghyun-io/tunnelforge/issues/244` with exact App attribution, fixed labels, one comment, one hidden fingerprint marker, and no forbidden credential/path pattern; emergency-off version `615088ce-96d6-406f-9d5a-d511675c70e6` passed; active version `9dbed64a-0d60-43bf-b946-24ab96e312f5` passed; full Python 2697 passed / 1 skipped; Rust gate, Cargo test/release build, Worker 316, typecheck, audit 0, dry-run, and PyInstaller passed | The first authenticated canary exposed a Workers-runtime incompatibility where `fetch(..., redirect:"error")` threw before GitHub; TDD changed GitHub requests to `redirect:"manual"`, preserving no-follow behavior, and explicit hostile-302 tests prove token and mutation requests stop after one fetch. Same-installation retry correctly returned `duplicate`; a new anonymous installation ID with the same server fingerprint produced the one intended `updated` recurrence. D1 has one complete create and one complete comment. The last-24-hour analytics window reported 61 successful invocations and zero errors; raw grouped `cpuTimeP50/P99` values ranged 213-15189, and the dataset exposed no cold/warm dimension, so no unsupported cold/warm or percentile claim is made. The exact client route is `https://tunnelforge-issue-relay.ppkimsanh.workers.dev/v1/reports`. Old-key deletion, the one-hour derived-token interval, and unused repository-secret deletion are now complete; final fresh-head hosted PR gates remain. |
@@ -2483,6 +2502,7 @@ Next action:
 | TF-STATUS-090 | High | watch | macOS release signing / notarization | Protected Environment intentionally has no paid Apple Developer credentials | Publish explicitly unsigned macOS artifacts for this release; revisit signing/notarization when an Apple Developer account is available |
 | TF-STATUS-091 | Medium | watch | Release governance / independent approval | Only one write/admin collaborator exists | Keep single-maintainer approval enabled; revisit independent approval after adding a second trusted maintainer |
 | TF-STATUS-092 | High | closed | Security / GitHub App credentials | Legacy issue-reporter App private key was embedded in public releases | Keep the exposed key and unused legacy repository secret absent; retain the replacement Reporter key, separate Releaser credentials, D1 global mutation caps, affirmative consent, strict allowlists, fail-closed edge free text, emergency off, and protected hosted gates |
+| TF-STATUS-093 | High | fixed_pending_full_verify | Release readiness / `2.4.0` publication | Anonymous error reporting is merged but not present in the latest stable `v2.3.1` release | Complete the protected version PR, exact-main annotated `v2.4.0` tag, approved draft build, asset/digest inspection, stable publication, updater check, and post-release relay health verification |
 
 ## Recommended Execution Order
 
@@ -2506,35 +2526,39 @@ Next action:
    `docs/superpowers/specs/2026-07-14-anonymous-error-reporting-design.md`;
    never distribute the replacement private key in TunnelForge clients and
    keep the retired credential paths absent.
-7. Keep TF-STATUS-090 on watch: unsigned macOS distribution is accepted for
+7. Complete TF-STATUS-093 through the protected version PR, full hosted gates,
+   exact-current-main annotated `v2.4.0` tag, separately approved draft build,
+   asset and GitHub SHA-256 digest inspection, stable/latest publication,
+   updater visibility check, and post-release relay health verification.
+8. Keep TF-STATUS-090 on watch: unsigned macOS distribution is accepted for
    this release; add signing/notarization only when paid Apple credentials are
    available.
-8. Keep TF-STATUS-091 on watch under the accepted single-maintainer approval
+9. Keep TF-STATUS-091 on watch under the accepted single-maintainer approval
    policy; revisit independent approval after adding another trusted maintainer.
-9. Keep TF-STATUS-084 closed by retaining the verification-to-launch lease,
+10. Keep TF-STATUS-084 closed by retaining the verification-to-launch lease,
    owned cleanup/no-clobber, cancellation generation, and streaming bound in
    place. Do not claim external Actions, branch protection, tag/release,
    GitHub closure, or Mac hardware validation.
-10. Keep TF-STATUS-079 closed by retaining GitHub Release asset `digest`
+11. Keep TF-STATUS-079 closed by retaining GitHub Release asset `digest`
    verification before every downloaded-package launch.
-11. Keep TF-STATUS-080 closed by retaining unknown-environment confirmation for
+12. Keep TF-STATUS-080 closed by retaining unknown-environment confirmation for
    dangerous operations without classified tunnel metadata.
-12. Keep TF-STATUS-083 closed by retaining strict required checks and the
+13. Keep TF-STATUS-083 closed by retaining strict required checks and the
    terminal gate that aggregates Python, Rust Core, macOS tracking, and both
    macOS architectures.
-13. Keep TF-STATUS-082 closed by preserving the bilingual Schedule correction
+14. Keep TF-STATUS-082 closed by preserving the bilingual Schedule correction
    while the feature flag remains disabled.
-14. Keep TF-STATUS-081 closed by retaining the protected `v2.3.1` tag, approved
+15. Keep TF-STATUS-081 closed by retaining the protected `v2.3.1` tag, approved
    release execution evidence, and all expected asset digest metadata.
-15. Complete TF-STATUS-008 / GitHub #116 on the frozen release candidate because
+16. Complete TF-STATUS-008 / GitHub #116 on the frozen release candidate because
    #116 remains external, with both current-HEAD manual workflow evidence and
    the real-Mac report. Do not hard-code exact current-head workflow run IDs or
    SHAs as durable status summary evidence; use #116 comments and the final gate
    for current proof.
-16. Resolve TF-STATUS-078: close #170 after confirming the merged fix from PR
+17. Resolve TF-STATUS-078: close #170 after confirming the merged fix from PR
    #171 / commit `a4c7a06`; reopen implementation work only if it reproduces on
    a release that contains the fix.
-17. Defer another broad Clean Code round, Schedule reactivation, One-Click scope
+18. Defer another broad Clean Code round, Schedule reactivation, One-Click scope
    expansion, and Rust Core concurrency redesign until the release-trust work is
    complete and user/benchmark evidence justifies them.
 
@@ -2542,6 +2566,7 @@ Next action:
 
 | Date | Session Summary | Files Touched | Verification |
 | --- | --- | --- | --- |
+| 2026-07-15 | Prepared the `2.4.0` release candidate for anonymous error reporting and opened TF-STATUS-093. Hardened the local clean-build path and full-SHA-pinned the version/macOS workflow actions before release. Historical `v2.3.1` publication evidence remains immutable. | version sources, installer/bootstrapper build script and contract, CI workflows/tests, canonical status | Focused RED/GREEN; standalone full Python 2697/1 skipped/4 warnings; Rust and Worker gates passed; corrected `build-installer.ps1 -Clean` completed without source mutation; frozen main/WebSetup checks passed; diff check passed. Protected hosted gates, tag, draft inspection, and publication remain. |
 | 2026-07-15 | Closed TF-STATUS-092 after protected PR #245 merged. The replacement anonymous error-reporting path, credential containment, client retirement, hosted gates, and protected integration are complete. | PR #245, `origin/main`, GitHub repository-secret inventory, production relay health, canonical status | Fresh-head runs `29385868513` and `29385868516` passed; PR #245 merged at `2026-07-15T03:22:13Z` as two-parent merge commit `6dbcd51c8c60acef3569697fa79a9e6914a7c0e0`; the legacy secret remains absent, only the separate Releaser secrets remain, and post-merge relay health is schema 1 / `active`. |
 | 2026-07-15 | Removed the unused `GH_APP_PRIVATE_KEY` repository secret after the full derived-token containment interval. The replacement Reporter credential and independent Releaser credentials remain in their intended lanes. | GitHub repository secret inventory, frozen package smoke, canonical status | Containment completed at `2026-07-15T03:06:03Z`; secret deletion completed at `2026-07-15T03:06:23Z`; the remaining repository secret names are exactly `RELEASER_APP_ID` and `RELEASER_APP_PRIVATE_KEY`. `dist\TunnelForge\TunnelForge.exe --ui-smoke-check` returned `success=true`, found the bundled Rust Core, and completed its service hello. Fresh-head hosted checks and protected PR #245 remain. |
 | 2026-07-15 | Deleted the exposed Reporter key after replacement canary approval and opened protected draft PR #245. The exact old fingerprint disappeared, the replacement Reporter fingerprint remained, and the independent Releaser lane was untouched. | GitHub App private-key inventory, remote feature branch, PR #245, canonical status | Deletion recorded at `2026-07-15T02:06:03Z`; commit `9367faa` pushed; runs `29382607405` and `29382607434` passed all Python, Rust, version, support-tracking, and macOS arm64/x86_64 gates. At this checkpoint, the one-hour token containment ended at `2026-07-15T03:06:03Z` and repository secret removal remained; the newer row records its completion. |

--- a/installer/TunnelForge.iss
+++ b/installer/TunnelForge.iss
@@ -7,7 +7,7 @@
 ;   3. 또는: .\scripts\build-installer.ps1
 
 #define MyAppName "TunnelForge"
-#define MyAppVersion "2.3.1"
+#define MyAppVersion "2.4.0"
 #define MyAppPublisher "sanghyun-io"
 #define MyAppURL "https://github.com/sanghyun-io/tunnelforge"
 #define MyAppExeName "TunnelForge.exe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tunnelforge"
-version = "2.3.1"
+version = "2.4.0"
 description = "SSH Tunnel and Rust DB Core Manager"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -1,30 +1,29 @@
-<#
+﻿<#
 #############################################################################
-# ⚠️  DO NOT DELETE - GitHub Actions 전용 스크립트
+# ⚠️  DO NOT DELETE - GitHub Actions 및 로컬 검증 스크립트
 #
 # 이 파일은 .github/workflows/release.yml에서 사용됩니다.
 # Windows Installer 빌드를 위해 반드시 필요합니다.
 #
-# 로컬에서 릴리스하려면 대신 다음 스크립트를 사용하세요:
-#   python scripts/smart_release.py
-#   ./scripts/smart-release.sh
+# 실제 태그와 릴리스는 보호된 수동 GitHub Actions 워크플로를 사용합니다.
 #############################################################################
 
 .SYNOPSIS
-    TunnelForge Windows Installer를 빌드합니다. (GitHub Actions 전용)
+    TunnelForge Windows Installer를 빌드하고 로컬 릴리스 후보를 검증합니다.
 
 .DESCRIPTION
     이 스크립트는 PyInstaller와 Inno Setup을 사용하여 Windows 설치 프로그램을 생성합니다.
 
     빌드 프로세스:
-    1. src/version.py에서 버전 읽기
+    1. 세 릴리스 버전 파일의 일치 검증
     2. Rust tunnelforge-core DB service 빌드
     3. PyInstaller로 실행 파일(.exe) 빌드
-    4. 버전을 installer/TunnelForge.iss에 동기화
+    4. WebSetup bootstrapper 빌드 및 frozen self-check
     5. Inno Setup으로 Windows Installer(.exe) 생성
 
     출력 파일:
     - dist\TunnelForge\TunnelForge.exe (실행 파일)
+    - dist\TunnelForge-WebSetup.exe (온라인 설치 및 복구 프로그램)
     - output\TunnelForge-Setup-{version}.exe (설치 프로그램)
 
 .PARAMETER Clean
@@ -32,8 +31,7 @@
     깨끗한 상태에서 빌드를 시작하려면 이 옵션을 사용하세요.
 
 .PARAMETER SkipPyInstaller
-    PyInstaller 빌드를 건너뛰고 기존 EXE로 Installer만 생성합니다.
-    EXE가 이미 빌드되어 있고 Installer만 다시 만들 때 유용합니다.
+    PyInstaller 빌드를 건너뛰고 기존 본체 EXE와 WebSetup으로 Installer만 생성합니다.
 
 .EXAMPLE
     .\scripts\build-installer.ps1
@@ -49,12 +47,7 @@
     .\scripts\build-installer.ps1 -SkipPyInstaller
 
     PyInstaller 빌드를 건너뛰고 기존 EXE로 Installer만 생성합니다.
-    EXE가 이미 dist\TunnelForge\TunnelForge.exe에 있어야 합니다.
-
-.EXAMPLE
-    .\scripts\build-installer.ps1 -Clean -SkipPyInstaller
-
-    이전 output 디렉토리를 삭제하고 기존 EXE로 Installer만 생성합니다.
+    본체 EXE와 dist\TunnelForge-WebSetup.exe가 이미 있어야 합니다.
 
 .NOTES
     파일명: build-installer.ps1
@@ -65,8 +58,8 @@
     - Inno Setup 6 (https://jrsoftware.org/isinfo.php)
 
     참고:
-    - GitHub Actions는 자동으로 빌드를 수행하므로 로컬 테스트용으로만 사용하세요.
-    - 릴리스는 bump-version.ps1 -AutoRelease로 자동화할 수 있습니다.
+    - 이 명령은 로컬 릴리스 후보 검증에도 사용합니다.
+    - 태그 생성과 draft 릴리스는 보호된 수동 GitHub Actions 워크플로에서 수행합니다.
 
 .LINK
     https://github.com/sanghyun-io/tunnelforge
@@ -99,13 +92,15 @@ if ($Help) {
     Write-Host "  -Help, -h        이 도움말 출력" -ForegroundColor White
     Write-Host ""
     Write-Host "빌드 프로세스:" -ForegroundColor Yellow
-    Write-Host "  1. src/version.py에서 버전 읽기" -ForegroundColor Gray
+    Write-Host "  1. 세 릴리스 버전 파일 일치 검증" -ForegroundColor Gray
     Write-Host "  2. Rust tunnelforge-core DB service 빌드" -ForegroundColor Gray
     Write-Host "  3. PyInstaller로 EXE 빌드" -ForegroundColor Gray
-    Write-Host "  4. Inno Setup으로 Windows Installer 생성" -ForegroundColor Gray
+    Write-Host "  4. WebSetup bootstrapper 빌드 및 frozen self-check" -ForegroundColor Gray
+    Write-Host "  5. Inno Setup으로 Windows Installer 생성" -ForegroundColor Gray
     Write-Host ""
     Write-Host "출력:" -ForegroundColor Yellow
     Write-Host "  - dist\TunnelForge\TunnelForge.exe                    (실행 파일)" -ForegroundColor Gray
+    Write-Host "  - dist\TunnelForge-WebSetup.exe                       (온라인 설치 및 복구)" -ForegroundColor Gray
     Write-Host "  - output\TunnelForge-Setup-{version}.exe  (설치 프로그램)" -ForegroundColor Gray
     Write-Host ""
     Write-Host "예제:" -ForegroundColor Yellow
@@ -137,7 +132,7 @@ Write-Host ""
 
 # Clean 옵션: 빌드 디렉토리 삭제
 if ($Clean) {
-    Write-Host "[1/5] 이전 빌드 파일 정리 중..." -ForegroundColor Yellow
+    Write-Host "[1/7] 이전 빌드 파일 정리 중..." -ForegroundColor Yellow
 
     if (Test-Path "build") {
         Remove-Item -Path "build" -Recurse -Force
@@ -159,7 +154,7 @@ if ($Clean) {
 
 # Rust helper 빌드
 if (-not $SkipPyInstaller) {
-    Write-Host "[2/6] Rust tunnelforge-core DB service 빌드 중..." -ForegroundColor Yellow
+    Write-Host "[2/7] Rust tunnelforge-core DB service 빌드 중..." -ForegroundColor Yellow
 
     $cargoCheck = cargo --version 2>&1
     if ($LASTEXITCODE -ne 0) {
@@ -184,7 +179,7 @@ if (-not $SkipPyInstaller) {
     Write-Host "  ✅ tunnelforge-core DB service 빌드 완료" -ForegroundColor Green
     Write-Host ""
 
-    Write-Host "[3/6] PyInstaller로 실행 파일 빌드 중..." -ForegroundColor Yellow
+    Write-Host "[3/7] PyInstaller로 실행 파일 빌드 중..." -ForegroundColor Yellow
 
     # PyInstaller 설치 확인
     $pyinstallerCheck = python -m PyInstaller --version 2>&1
@@ -213,8 +208,16 @@ if (-not $SkipPyInstaller) {
     $exeSize = (Get-Item "dist\TunnelForge\TunnelForge.exe").Length / 1MB
     Write-Host "  ✅ EXE 빌드 완료: dist\TunnelForge\TunnelForge.exe ($($exeSize.ToString('0.0')) MB)" -ForegroundColor Green
     Write-Host ""
+
+    Write-Host "[4/7] 온라인 설치 bootstrapper 빌드 중..." -ForegroundColor Yellow
+    & "$PSScriptRoot\build-bootstrapper.ps1"
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  ❌ TunnelForge-WebSetup.exe 빌드 실패" -ForegroundColor Red
+        exit 1
+    }
 } else {
-    Write-Host "[2/6] Rust helper/PyInstaller 빌드 건너뛰기 (-SkipPyInstaller)" -ForegroundColor Gray
+    Write-Host "[2-4/7] Rust helper/PyInstaller/bootstrapper 빌드 건너뛰기 (-SkipPyInstaller)" -ForegroundColor Gray
 
     # EXE 파일 존재 확인
     if (-not (Test-Path "dist\TunnelForge\TunnelForge.exe")) {
@@ -227,8 +230,23 @@ if (-not $SkipPyInstaller) {
     Write-Host ""
 }
 
+$webSetupPath = "dist\TunnelForge-WebSetup.exe"
+if (-not (Test-Path $webSetupPath)) {
+    Write-Host "  ❌ $webSetupPath 파일을 찾을 수 없습니다." -ForegroundColor Red
+    Write-Host "  먼저 전체 빌드를 실행하거나 -SkipPyInstaller 옵션을 제거하세요." -ForegroundColor Yellow
+    exit 1
+}
+
+$webSetupSelfCheck = (& ".\$webSetupPath" --self-check 2>&1 | Out-String).Trim()
+if ($LASTEXITCODE -ne 0 -or $webSetupSelfCheck -ne "TUNNELFORGE_WEBSETUP_SELF_CHECK_OK") {
+    Write-Host "  ❌ TunnelForge-WebSetup.exe self-check 실패" -ForegroundColor Red
+    exit 1
+}
+Write-Host "  ✅ TunnelForge-WebSetup.exe self-check 통과" -ForegroundColor Green
+Write-Host ""
+
 # Inno Setup 경로 찾기
-Write-Host "[4/6] Inno Setup 확인 중..." -ForegroundColor Yellow
+Write-Host "[5/7] Inno Setup 확인 중..." -ForegroundColor Yellow
 
 $InnoSetupPaths = @(
     "C:\Program Files (x86)\Inno Setup 6\ISCC.exe",
@@ -264,8 +282,8 @@ Write-Host "  ✅ Inno Setup 발견: $ISCC" -ForegroundColor Green
 Write-Host "  버전: $innoVersion" -ForegroundColor Gray
 Write-Host ""
 
-# version.py에서 버전 추출 및 동기화
-Write-Host "[5/6] 버전 정보 동기화 중..." -ForegroundColor Yellow
+# 세 릴리스 버전 파일 일치 검증
+Write-Host "[6/7] 버전 정보 검증 중..." -ForegroundColor Yellow
 
 # version.py에서 버전 추출
 $versionPy = "src\version.py"
@@ -283,22 +301,39 @@ if ($versionContent -match '__version__\s*=\s*[''"]([^''"]+)[''"]') {
     exit 1
 }
 
-# TunnelForge.iss 파일 업데이트
-$issFile = "installer\TunnelForge.iss"
-if (-not (Test-Path $issFile)) {
-    Write-Host "  ❌ $issFile 파일을 찾을 수 없습니다." -ForegroundColor Red
+$projectContent = Get-Content "pyproject.toml" -Raw
+if ($projectContent -match '(?m)^version\s*=\s*"([^"]+)"\s*$') {
+    $projectVersion = $matches[1]
+} else {
+    Write-Host "  ❌ pyproject.toml 에서 project version을 추출할 수 없습니다." -ForegroundColor Red
     exit 1
 }
 
-$issContent = Get-Content $issFile -Raw
-$issContent = $issContent -replace '#define MyAppVersion ".*"', "#define MyAppVersion `"$version`""
-Set-Content -Path $issFile -Value $issContent -NoNewline
+# TunnelForge.iss 버전 검증
+if (-not (Test-Path "installer\TunnelForge.iss")) {
+    Write-Host "  ❌ installer\TunnelForge.iss 파일을 찾을 수 없습니다." -ForegroundColor Red
+    exit 1
+}
 
-Write-Host "  ✅ $issFile 버전 업데이트 완료: $version" -ForegroundColor Green
+$issContent = Get-Content "installer\TunnelForge.iss" -Raw
+if ($issContent -match '#define\s+MyAppVersion\s+"([^"]+)"') {
+    $installerVersion = $matches[1]
+} else {
+    Write-Host "  ❌ installer\TunnelForge.iss 에서 MyAppVersion을 추출할 수 없습니다." -ForegroundColor Red
+    exit 1
+}
+
+if ($projectVersion -ne $version -or $installerVersion -ne $version) {
+    Write-Host "  ❌ 릴리스 버전 불일치: version.py=$version pyproject=$projectVersion installer=$installerVersion" -ForegroundColor Red
+    Write-Host "  scripts\bump_version.py로 세 버전 파일을 먼저 동기화하세요." -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "  ✅ 릴리스 버전 일치: $version" -ForegroundColor Green
 Write-Host ""
 
 # Inno Setup으로 Installer 컴파일
-Write-Host "[6/6] Windows Installer 생성 중..." -ForegroundColor Yellow
+Write-Host "[7/7] Windows Installer 생성 중..." -ForegroundColor Yellow
 
 $crashLog = "dist\TunnelForge\crash.log"
 if (Test-Path $crashLog) {

--- a/src/version.py
+++ b/src/version.py
@@ -4,7 +4,7 @@
 모든 버전 참조는 이 파일을 사용해야 합니다.
 """
 
-__version__ = "2.3.1"
+__version__ = "2.4.0"
 __app_name__ = "TunnelForge"
 
 # GitHub 저장소 정보 (업데이트 확인용)

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -43,6 +43,7 @@ def assert_external_actions_are_sha_pinned(workflow_text):
 
 def test_version_gate_exposes_required_regression_jobs():
     jobs = load_version_gate()["jobs"]
+    assert_external_actions_are_sha_pinned(VERSION_GATE_PATH.read_text(encoding="utf-8"))
 
     assert "rust-core-regression-gate" in jobs
     assert "python-regression" in jobs
@@ -125,6 +126,8 @@ def test_write_capable_jobs_checkout_and_execute_only_trusted_base_code():
     }
 
     assert write_jobs == {"version-validation", "version-bump"}
+    for job_name in write_jobs:
+        assert_external_actions_are_sha_pinned(version_gate_job_text(job_name))
 
     version_validation = jobs["version-validation"]
     assert version_validation["permissions"] == {
@@ -396,7 +399,7 @@ def test_python_regression_runs_full_suite_with_built_core():
     assert job["env"]["QT_QPA_PLATFORM"] == "offscreen"
     assert str(job["env"]["PYTHONUTF8"]) == "1"
     assert "${{ github.event.pull_request.head.sha }}" in job_text
-    assert "actions/setup-python@v6" in job_text
+    assert "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1" in job_text
     assert 'python-version: "3.12"' in job_text
     assert "rustc --version" in job_text
     assert "cargo --version" in job_text

--- a/tests/test_current_status_docs.py
+++ b/tests/test_current_status_docs.py
@@ -913,18 +913,14 @@ def test_current_status_records_strategy_review_findings_and_priority():
 
 def test_current_status_records_231_release_candidate_handoff():
     doc = (PROJECT_ROOT / "docs" / "current_status.md").read_text(encoding="utf-8")
-    version_source = (PROJECT_ROOT / "src" / "version.py").read_text(encoding="utf-8")
-    source_version = re.search(r'__version__\s*=\s*"([^"]+)"', version_source).group(1)
+    release_version = "2.3.1"
     summary = " ".join(_section(doc, "Summary").split())
-    baseline = " ".join(_section(doc, "Current Baseline Verification").split())
     tracker = " ".join(_section(doc, "Issue Tracker").split())
     verification = " ".join(_section(doc, "Verification Log").split())
     order = " ".join(_section(doc, "Recommended Execution Order").split())
     sessions = " ".join(_section(doc, "Session Log").split())
 
-    assert source_version == "2.3.1"
-    assert f"`{source_version}` release candidate" in summary
-    assert f"Version references are aligned at `{source_version}`" in baseline
+    assert f"`{release_version}` release candidate" in summary
 
     assert "TF-STATUS-079 | High | closed" in tracker
     assert "TF-STATUS-080 | Medium | closed" in tracker
@@ -939,7 +935,7 @@ def test_current_status_records_231_release_candidate_handoff():
         "unknown-environment confirmation",
         "`python-regression`",
         "bilingual Schedule correction",
-        f"`{source_version}` release candidate",
+        f"`{release_version}` release candidate",
     ]:
         assert phrase in verification
 
@@ -950,6 +946,31 @@ def test_current_status_records_231_release_candidate_handoff():
     assert "TF-STATUS-078" in order
     assert "GitHub Release asset `digest` verification" in sessions
     assert "unknown-environment confirmation" in sessions
+
+
+def test_current_status_records_240_release_candidate():
+    doc = (PROJECT_ROOT / "docs" / "current_status.md").read_text(encoding="utf-8")
+    version_source = (PROJECT_ROOT / "src" / "version.py").read_text(encoding="utf-8")
+    source_version = re.search(r'__version__\s*=\s*"([^"]+)"', version_source).group(1)
+    summary = " ".join(_section(doc, "Summary").split())
+    baseline = " ".join(_section(doc, "Current Baseline Verification").split())
+    tracker = " ".join(_section(doc, "Issue Tracker").split())
+    verification = " ".join(_section(doc, "Verification Log").split())
+    order = " ".join(_section(doc, "Recommended Execution Order").split())
+    sessions = " ".join(_section(doc, "Session Log").split())
+
+    assert source_version == "2.4.0"
+    assert "The `2.4.0` release candidate" in summary
+    assert "anonymous error reporting" in summary
+    assert "Version references are aligned at `2.4.0`" in baseline
+    assert "TF-STATUS-093 | High | fixed_pending_full_verify" in tracker
+    assert "`2.4.0` release-candidate preparation" in verification
+    assert "release-candidate full Python 2697 passed / 1 skipped" in verification
+    assert "all external actions in `version-gate.yml` are full-SHA pinned" in verification
+    assert "`build-installer.ps1 -Clean` completed end to end" in verification
+    assert "Installer source unchanged" in verification
+    assert "Complete TF-STATUS-093 through the protected version PR" in order
+    assert "Prepared the `2.4.0` release candidate" in sessions
 
 
 def test_current_status_closes_final_review_update_boundary_after_fresh_verification():

--- a/tests/test_rust_core_packaging.py
+++ b/tests/test_rust_core_packaging.py
@@ -229,12 +229,27 @@ def test_pyinstaller_spec_includes_core_service_binaries_cross_platform():
 
 
 def test_windows_installer_builds_and_checks_core_service_binaries():
-    script = (PROJECT_ROOT / "scripts" / "build-installer.ps1").read_text(encoding="utf-8")
+    script_path = PROJECT_ROOT / "scripts" / "build-installer.ps1"
+    assert script_path.read_bytes().startswith(b"\xef\xbb\xbf")
+    script = script_path.read_text(encoding="utf-8-sig")
 
     assert "cargo build --manifest-path migration_core\\Cargo.toml --release" in script
     assert "migration_core\\target\\release\\tunnelforge-core.exe" in script
     assert "tunnelforge-core DB service 빌드 완료" in script
     assert "dist\\TunnelForge\\TunnelForge.exe" in script
+    assert '& "$PSScriptRoot\\build-bootstrapper.ps1"' in script
+    assert "dist\\TunnelForge-WebSetup.exe" in script
+    assert "--self-check" in script
+    assert ".\\scripts\\build-installer.ps1 -Clean -SkipPyInstaller" not in script
+    assert "세 릴리스 버전 파일 일치 검증" in script
+    assert "WebSetup bootstrapper 빌드 및 frozen self-check" in script
+    assert "Set-Content -Path $issFile" not in script
+    assert 'Get-Content "pyproject.toml" -Raw' in script
+    assert "$projectVersion -ne $version" in script
+    assert "$installerVersion -ne $version" in script
+    assert script.index('& "$PSScriptRoot\\build-bootstrapper.ps1"') < script.index(
+        '& $ISCC "installer\\TunnelForge.iss"'
+    )
 
 
 def test_dev_dependencies_include_yaml_parser_for_workflow_tests():
@@ -2014,7 +2029,7 @@ def test_version_gate_runs_macos_validation_from_existing_pr_workflow():
     assert "--skip-pr-checks" in workflow
     version_gate_text = workflow.split("  version-gate:", 1)[1].split("\n  version-bump:", 1)[0]
     assert "actions/create-github-app-token" not in version_gate_text
-    assert "uses: actions/checkout@v5" in workflow
+    assert "uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd" in workflow
     assert "ref: ${{ github.event.pull_request.head.sha }}" in workflow
     assert "ref: ${{ github.event.pull_request.base.sha }}" in workflow
     assert "persist-credentials: false" in workflow


### PR DESCRIPTION
## Summary
- bump TunnelForge release metadata to 2.4.0
- harden the Windows release build and version consistency checks
- full-SHA pin privileged GitHub Actions dependencies
- record TF-STATUS-093 release evidence and closure criteria

## Verification
- Python: 2697 passed, 1 skipped
- focused release/workflow/status checks: 86 passed
- Rust core regression gate and cargo test suites passed
- Worker tests, typecheck, audit, and Wrangler dry-run passed
- clean Windows installer build completed end to end
- main UI smoke check and WebSetup self-check passed
- independent release review: APPROVE

## Distribution
macOS artifacts remain unsigned and are distributed directly through GitHub Releases. Apple App Store submission is intentionally out of scope.