### PR TITLE
Fix: MySQL-standard dump export and import

### DIFF
--- a/docs/current_status.md
+++ b/docs/current_status.md
@@ -1,6 +1,6 @@
 # TunnelForge Current Status
 
-Last reviewed: 2026-07-15
+Last reviewed: 2026-07-21
 
 This document is the current repository status index. It separates verified
 state from planning documents and lists the next actionable issues.
@@ -77,6 +77,14 @@ Windows clean build, frozen main-app UI/Rust Core smoke, and WebSetup
 self-check. The clean-build review also made the installer command build and
 verify WebSetup itself, stopped it from rewriting the tracked Inno source, and
 pinned all external actions in the required version and macOS workflows.
+
+The `2.4.1` patch release candidate fixes MySQL dump/import behavior from
+TF-STATUS-094. Replace/recreate now scopes destructive work to dump-contained
+tables and preserves compatible target-only FK tables. MySQL export uses fixed
+worker sessions on one shared InnoDB snapshot: the initial global read lock is
+bounded to two seconds and released immediately, normal DML remains available,
+and only DDL is held by the backup lock until export finishes. TF-STATUS-095
+tracks protected merge, tag, asset verification, and stable publication.
 
 The `2.3.1` release candidate now contains the completed release-trust scope:
 GitHub Release asset `digest` verification prevents unverified downloaded
@@ -622,7 +630,7 @@ Historical release-review snapshots (preserved for audit):
     | `pytest -q` | PASS, 1827 passed, 6 warnings |
     | `pytest -q` | PASS, 1955 passed, 1 skipped, 4 warnings, 60.38s, exit 0 |
 
-Version references are aligned at `2.4.0` across:
+Version references are aligned at `2.4.1` across:
 
 - `src/version.py`
 - `pyproject.toml`
@@ -720,6 +728,7 @@ Commands run locally:
 
 | Date | Scope | Command | Result | Notes |
 | --- | --- | --- | --- | --- |
+| 2026-07-21 | TF-STATUS-004/094/095 MySQL dump/import patch candidate | Cargo full test with disposable MySQL 8.4; focused Python Export/Import/UI/i18n; split broad Python groups; release build; version sync; `git diff --check` | Rust 221 lib, 2 JSONL CLI, 10 live, and 2 stress passed / 1 ignored; target-only FK live roundtrip passed; focused Python/UI 144 passed and i18n gate passed; split `a-h`, `i-m`, `n-p`, non-macOS Rust packaging, remaining Rust-focused, and `s-z` groups passed after status alignment; release build and version sync passed | MySQL uses fixed shared-snapshot workers, a two-second bounded initial global read lock, and a backup lock that permits DML while restricting DDL. Compatible target-only FK tables survive replace import. The monolithic Python command was not used as the closure claim because the existing macOS packaging-test group blocks on this Windows host; hosted CI remains required before closure/publication. |
 | 2026-07-15 | `v2.4.0` protected publication closure / TF-STATUS-093 | PR #247 hosted checks and merge; protected `create-release-tag.yml` run `29391247402`; approved `release.yml` run `29391317995`; annotated-tag object/peeled-commit inspection; draft asset/digest and checksum-sidecar inspection; stable/latest API and live `UpdateChecker` checks; post-release relay health and repository-secret inventory | runs `29390539762`, `29390540655`, and `29390539802` passed the required Python, Rust, version, support-tracking, and internal/external macOS arm64/x86_64 gates; PR #247 merged at `2026-07-15T05:21:06Z` as `bfee81613c7f77d96136346fa305858bf62670d7`; tag object `34a111cc90373a485c6dd168d4755f43cfccc768` peels to that exact commit; release run built all platforms and published at `2026-07-15T05:33:59Z`; all 10 expected assets have GitHub SHA-256 digests and all four macOS sidecars match their DMG/ZIP asset digests; `UpdateChecker` returned latest `2.4.0` with no error; relay health returned HTTP 200, schema 1, mode `active`; exactly `RELEASER_APP_ID` and `RELEASER_APP_PRIVATE_KEY` remain | `v2.4.0` is stable/latest at `https://github.com/sanghyun-io/tunnelforge/releases/tag/v2.4.0`. Release notes explicitly identify macOS artifacts as unsigned and unnotarized. TF-STATUS-093 is closed; TF-STATUS-090 and TF-STATUS-091 remain watch items. |
 | 2026-07-15 | `2.4.0` release-candidate preparation / TF-STATUS-093 | RED/GREEN status and version sync; full Python; Rust regression/Cargo test+release; Worker test/typecheck/audit/dry-run; `build-installer.ps1 -Clean`; frozen UI/Rust Core and WebSetup self-checks; workflow pin scan; `git diff --check` | RED proved the source remained `2.3.1`; deterministic minor bump aligned all three sources at `2.4.0`; release-candidate full Python 2697 passed / 1 skipped / 4 warnings; Rust and Worker gates passed; all external actions in `version-gate.yml` are full-SHA pinned; `build-installer.ps1 -Clean` completed end to end and produced the main app, WebSetup, and `TunnelForge-Setup-2.4.0.exe`; Installer source unchanged; frozen checks passed | The initial local installer command exposed stale-output handling, missing bootstrapper creation after clean, tracked Inno-source rewriting, and Windows PowerShell 5.1 UTF-8 parsing problems. TDD added bootstrapper build/self-check, read-only version validation, and a UTF-8 BOM contract. A concurrent clean-build deleted one independent-review test's transient evidence ZIP; two focused reruns and a later standalone full suite passed. Protected version PR, exact-main tag, draft asset/digest inspection, and publication remain. |
 | 2026-07-15 | TF-STATUS-092 protected merge closure | `gh pr checks 245 --watch`; `gh pr ready 245`; `gh pr merge 245 --merge`; post-merge PR/main ancestry, repository-secret inventory, and production health verification | fresh-head runs `29385868513` and `29385868516` passed all required gates; PR #245 merged at `2026-07-15T03:22:13Z` as `6dbcd51c8c60acef3569697fa79a9e6914a7c0e0`; `origin/main` has the expected two-parent merge ancestry; `GH_APP_PRIVATE_KEY` remains absent while exactly the two Releaser secrets remain; relay health returned schema 1 and mode `active` | TF-STATUS-092 is closed. The exposed Reporter key, its possible derived-token lifetime, the unused repository secret, client credential retirement, replacement canary/rollout, frozen package smoke, fresh-head hosted gates, and protected merge are all complete. |
@@ -1042,6 +1051,16 @@ Evidence:
 - 2026-06-26 update: new single-thread exports are marked
   `connection_consistent` and strict; parallel exports are marked
   `non_consistent_parallel`, non-strict, with a warning.
+- 2026-07-21 update: MySQL exports now pre-open the requested fixed worker
+  sessions, start every worker on the same `REPEATABLE READ` consistent
+  snapshot under a brief global read lock, acquire a backup lock, and release
+  the global read lock before scanning data. Successful manifests are strict
+  and use `snapshot_policy = "mysql_shared_consistent_snapshot"` for both
+  single- and multi-worker exports.
+- The global read-lock acquisition is bounded to two seconds. DML remains
+  available during the dump; DDL is restricted until the coordinator releases
+  `LOCK INSTANCE FOR BACKUP`. Non-InnoDB selections fail closed instead of
+  claiming transactional consistency.
 
 Impact:
 
@@ -1050,7 +1069,8 @@ Impact:
 
 Next action:
 
-1. Keep export consistency metadata coverage when export scheduling changes.
+1. Keep the shared-snapshot, short-lock, InnoDB, and manifest metadata coverage
+   aligned when export scheduling changes.
 
 ## Medium Priority Issues
 
@@ -2410,6 +2430,57 @@ Next action:
    as a Rust Core command instead of reviving a generic Python `execute_many`
    helper.
 
+### TF-STATUS-094: MySQL-Like Dump-Scoped Replace Import
+
+Status: `fixed_pending_full_verify`
+Severity: High
+Area: Rust Core dump.import / Import UI
+
+Evidence:
+
+- The `2.4.0` production failure log showed a 241-table dump while the target
+  also contained `supplement_review_api_call`, whose FKs referenced two dump
+  tables. The old preflight treated any such target-only FK as a global
+  blocker and Python then marked all 241 pending tables as failed.
+- Replace/recreate still drops only manifest-selected tables, with
+  `foreign_key_checks=0`, matching MySQL dump restore scope. Target-only tables
+  and compatible FKs are not dropped.
+- The preflight now compares only the surviving FK contract that the recreated
+  parent must preserve: referenced column type/sign, effective charset and
+  collation, and referenced-index prefix. It blocks before mutation only when
+  that structure actually changes.
+- Python keeps table rows pending for operation-scoped preflight failures
+  instead of reporting every dump table as independently failed.
+- A disposable MySQL 8.4 live roundtrip exported a parent with eight workers,
+  created a target-only child/FK afterward, replaced the parent from the dump,
+  and verified the child table, child row, FK constraint, and restored parent
+  data all remained correct.
+
+Next action:
+
+1. Close after protected CI/merge evidence for the `2.4.1` release commit.
+
+### TF-STATUS-095: `2.4.1` MySQL Export/Import Patch Publication
+
+Status: `fixed_pending_full_verify`
+Severity: High
+Area: Release readiness / versioning
+
+Evidence:
+
+- `src/version.py`, `pyproject.toml`, and `installer/TunnelForge.iss` are
+  aligned at `2.4.1`.
+- Local Rust unit/CLI/live/stress tests, the target-only FK MySQL 8.4
+  roundtrip, focused Python/UI/i18n tests, version sync, release build, and
+  diff check passed. The broad Python suite was split because the existing
+  macOS packaging-test group blocks on this Windows host; all other collected
+  groups passed, while that file's non-macOS/version gate passed separately.
+
+Next action:
+
+1. Complete protected PR checks, exact-main annotated tag creation, release
+   artifact/digest verification, stable publication, and updater visibility.
+
 ## Issue Tracker
 
 | ID | Severity | Status | Area | Short Title | Next Action |
@@ -2507,9 +2578,15 @@ Next action:
 | TF-STATUS-091 | Medium | watch | Release governance / independent approval | Only one write/admin collaborator exists | Keep single-maintainer approval enabled; revisit independent approval after adding a second trusted maintainer |
 | TF-STATUS-092 | High | closed | Security / GitHub App credentials | Legacy issue-reporter App private key was embedded in public releases | Keep the exposed key and unused legacy repository secret absent; retain the replacement Reporter key, separate Releaser credentials, D1 global mutation caps, affirmative consent, strict allowlists, fail-closed edge free text, emergency off, and protected hosted gates |
 | TF-STATUS-093 | High | closed | Release readiness / `2.4.0` publication | Anonymous error reporting is merged but not present in the latest stable `v2.3.1` release | Keep `v2.4.0` stable/latest with its exact-main annotated tag, 10 verified assets, explicit unsigned macOS notice, updater visibility, active relay health, and separate Releaser credential lane |
+| TF-STATUS-094 | High | fixed_pending_full_verify | Rust Core dump.import / Import UI | Over-broad target-only FK preflight blocked MySQL-like dump-scoped restore | Close after protected `2.4.1` CI/merge evidence; preserve compatible target-only tables and report operation-level failures once |
+| TF-STATUS-095 | High | fixed_pending_full_verify | Release readiness / `2.4.1` publication | MySQL shared-snapshot and dump-scoped import fixes await protected publication | Complete protected merge, exact-main tag, release asset/digest verification, stable publication, and updater visibility |
 
 ## Recommended Execution Order
 
+1. Complete TF-STATUS-094/095 through protected `2.4.1` CI, merge, exact-main
+   tag creation, release asset/digest verification, stable publication, and
+   updater visibility. Keep compatible target-only FK tables intact and retain
+   the bounded shared-snapshot lock behavior.
 1. Keep TF-STATUS-085 closed by retaining the POSIX residue policy,
    pre-dispatch abandonment cleanup, and manual-SQL Fix Wizard wording.
 2. Keep TF-STATUS-086 closed by retaining synchronized cancellation/result
@@ -2570,6 +2647,7 @@ Next action:
 
 | Date | Session Summary | Files Touched | Verification |
 | --- | --- | --- | --- |
+| 2026-07-21 | Implemented the `2.4.1` MySQL-standard dump/import patch: compatible target-only FK tables are preserved, incompatible surviving contracts alone fail preflight, operation-level failures are not expanded to every table, and all MySQL workers share one bounded-lock InnoDB snapshot while DML stays available. Completed direct review and prepared the patch version for protected publication. | Rust dump/import core, Python Export/Import bridge and UI/i18n, live/focused tests, version sources, design/status docs | Cargo full including disposable MySQL 8.4 live roundtrip passed; focused/split Python groups passed after translation/status fixes; release build, version sync, and diff check passed. Hosted protected checks and publication remain TF-STATUS-094/095 closure gates. |
 | 2026-07-15 | Published `v2.4.0` as the stable/latest release and closed TF-STATUS-093 after the complete protected PR, exact-main tag, approved draft-build, asset inspection, updater, and production-health sequence. Release notes now explicitly identify the free macOS downloads as unsigned and unnotarized. | PR #247, tag `v2.4.0`, release workflow/metadata, canonical status and status regression contract | Runs `29390539762`, `29390540655`, and `29390539802` passed; merge commit `bfee81613c7f77d96136346fa305858bf62670d7`; tag run `29391247402` and release run `29391317995` passed; 10/10 assets had valid GitHub digests and four macOS sidecars matched; public latest and `UpdateChecker` returned `2.4.0`; relay health was HTTP 200/schema 1/`active`; only the two Releaser repository secrets remain. |
 | 2026-07-15 | Prepared the `2.4.0` release candidate for anonymous error reporting and opened TF-STATUS-093. Hardened the local clean-build path and full-SHA-pinned the version/macOS workflow actions before release. Historical `v2.3.1` publication evidence remains immutable. | version sources, installer/bootstrapper build script and contract, CI workflows/tests, canonical status | Focused RED/GREEN; standalone full Python 2697/1 skipped/4 warnings; Rust and Worker gates passed; corrected `build-installer.ps1 -Clean` completed without source mutation; frozen main/WebSetup checks passed; diff check passed. Protected hosted gates, tag, draft inspection, and publication remain. |
 | 2026-07-15 | Closed TF-STATUS-092 after protected PR #245 merged. The replacement anonymous error-reporting path, credential containment, client retirement, hosted gates, and protected integration are complete. | PR #245, `origin/main`, GitHub repository-secret inventory, production relay health, canonical status | Fresh-head runs `29385868513` and `29385868516` passed; PR #245 merged at `2026-07-15T03:22:13Z` as two-parent merge commit `6dbcd51c8c60acef3569697fa79a9e6914a7c0e0`; the legacy secret remains absent, only the separate Releaser secrets remain, and post-merge relay health is schema 1 / `active`. |

--- a/docs/superpowers/specs/2026-07-21-mysql-standard-dump-import-design.md
+++ b/docs/superpowers/specs/2026-07-21-mysql-standard-dump-import-design.md
@@ -1,0 +1,252 @@
+# MySQL-Standard Dump/Import Design
+
+## Goal
+
+Make TunnelForge's MySQL dump and load behavior match the object scope and
+consistency expectations of `mysqldump` and MySQL Shell while preserving the
+Rust Core architecture, eight-worker throughput, and production safety.
+
+This change resolves TF-STATUS-004 and TF-STATUS-084 and ships as patch release
+`2.4.1` after review and release verification.
+
+## Scope
+
+This release covers:
+
+1. MySQL full and partial exports use one shared consistent InnoDB snapshot
+   across all database-reading workers.
+2. Eight workers remain the default; the export does not hold table read locks
+   for the duration of large-table scans.
+3. Replace/recreate imports drop and recreate only tables present in the dump.
+   Target-only tables and their rows remain untouched.
+4. Target-only foreign keys into imported tables no longer cause a blanket
+   preflight abort. Only proven structural incompatibilities block before
+   mutation.
+5. A global preflight failure is reported once and is not copied onto every
+   table as an apparent independent failure.
+6. Export and Import UI copy states these contracts and exposes snapshot setup,
+   lock timing, and actionable privilege/timeout failures.
+7. Version sources are synchronized to `2.4.1`; the reviewed branch is merged,
+   tagged, built, and published through the existing release workflow.
+
+PostgreSQL dump/import behavior is not redesigned in this release. Its current
+paths must remain regression-clean.
+
+## MySQL Reference Semantics
+
+TunnelForge adopts these MySQL-compatible meanings:
+
+- A dump contains DDL and data only for selected objects.
+- Replace/recreate affects only objects present in that dump.
+- Objects absent from the dump are preserved.
+- Existing-object behavior is explicit: merge uses existing tables;
+  replace/recreate rebuild dumped tables.
+- Foreign-key checks may be disabled during ordered restore, but structural
+  requirements for surviving foreign keys are checked before destructive DDL.
+- A consistent parallel dump coordinates worker transactions before releasing
+  the short write barrier.
+
+TunnelForge may fail earlier than raw `mysql < dump.sql` when it can prove that
+the requested operation cannot complete safely, but it must not reject a load
+solely because a target-only object exists.
+
+## Export Architecture
+
+### Shared snapshot coordinator
+
+MySQL parallel export uses a coordinator connection plus a fixed set of worker
+connections. Connections are opened before any global lock is requested.
+
+The coordinator performs the following sequence:
+
+1. Set a two-second acquisition bound for metadata/backup lock setup.
+2. Acquire `FLUSH TABLES WITH READ LOCK`.
+3. Acquire `LOCK INSTANCE FOR BACKUP` while the global read lock is held.
+4. On every worker connection, set `REPEATABLE READ`, read-only mode, and start
+   `START TRANSACTION WITH CONSISTENT SNAPSHOT`.
+5. Release the global read lock immediately after every worker snapshot is
+   established.
+6. Keep only the instance backup lock until all worker reads finish.
+7. Commit or roll back worker transactions and release the backup lock on every
+   success, error, cancellation, panic, and connection-loss path.
+
+The global read lock is never held while table data is streamed. Normal DML can
+continue after snapshot setup. The backup lock intentionally blocks DDL and
+other file-changing operations for the export duration.
+
+If the server version or account cannot support this protocol, strict export
+fails before any table data file is written. TunnelForge does not silently
+downgrade to independent worker snapshots. The error names the missing
+privilege or unsupported server operation and recommends retrying with the
+proper backup account.
+
+### Fixed worker sessions
+
+Current workers open a new connection per range or table. The new scheduler
+starts exactly the bounded worker count, gives each worker one snapshot-bound
+connection, and lets each worker consume multiple queue items until completion.
+No work item may create a fresh MySQL read connection.
+
+Planning reads that define the dump boundary—row counts, primary-key min/max,
+and range planning—run on a snapshot-bound connection. Schema inspection and
+view collection run under the backup-lock lifecycle so DDL cannot change the
+object definitions between inspection and manifest finalization.
+
+Single-thread MySQL export uses the same transaction protocol with one worker.
+It no longer claims consistency merely because one connection was used.
+
+### Manifest and progress contract
+
+Successful MySQL dumps record:
+
+- `snapshot_policy = "mysql_shared_consistent_snapshot"`;
+- `strict_export = true`;
+- no non-consistent snapshot warning;
+- worker count and snapshot setup duration in result/progress metadata.
+
+Snapshot setup emits distinct phases for connection preparation, lock
+acquisition, snapshot establishment, and lock release. The UI remains
+responsive and keeps the existing thread-count control with eight as default.
+
+## Import Architecture
+
+### Dump-scoped replacement
+
+For `replace` and `recreate`, Rust Core builds the import set from the selected
+dump manifest tables. It drops those tables child-first and creates/loads only
+those tables. It never adds a target-only table to the import set and never
+drops that table merely because it references an imported parent.
+
+`merge` keeps its existing non-recreate behavior.
+
+### Compatibility-aware surviving FK preflight
+
+The existing table-name-only `surviving_fk_offenders` check is replaced by a
+structural compatibility check. For every target-only FK that references an
+imported table, Rust Core inspects:
+
+- ordered child and referenced column names;
+- MySQL data type, unsigned/signed attributes, and fixed-precision size;
+- character set and collation for nonbinary character columns;
+- the required referenced-key index and column order;
+- storage-engine compatibility;
+- the intended imported parent definition from the manifest.
+
+If those definitions are compatible, Import proceeds and MySQL preserves the
+target-only table and its FK metadata through the parent rebuild. If a mismatch
+is proven, Import stops before any DROP and reports one actionable global
+preflight error naming the child table, constraint, columns, and mismatch.
+
+This patch does not add an expensive dump-wide row-value preflight. As with
+standard MySQL logical restore under disabled foreign-key checks, re-enabling
+checks does not retroactively scan existing target-only child rows. The Import
+completion report therefore records surviving external FKs and explicitly
+states that structural compatibility—not historical row revalidation—was
+performed. Row-integrity validation can be added as an explicit verification
+mode later without redefining replace semantics.
+
+### Global failure reporting
+
+Errors raised before table processing remain operation-level failures. Python
+does not synthesize the same error for every manifest table. The UI and saved
+log show zero completed tables, one preflight failure, and the affected FK list.
+Table-level failures remain reserved for failures that occur while processing a
+specific table.
+
+## UX Contract
+
+Normal users keep the existing workflow and eight-thread default. New visible
+states are:
+
+- `일관된 스냅샷 준비 중...`
+- `8개 워커 스냅샷 준비 완료 (쓰기 중단 N ms)`
+- `DDL 보호 잠금 유지 중 — 일반 읽기/쓰기는 계속 가능합니다.`
+- completion metadata stating that a shared snapshot was guaranteed.
+
+The initial global write barrier has a two-second acquisition bound. Failure
+shows that no data files were produced and recommends a lower-traffic retry.
+Privilege failure lists `RELOAD` or `FLUSH_TABLES` and `BACKUP_ADMIN` as
+applicable to the server version.
+
+Import copy states `덤프에 포함된 테이블만 교체하며, 대상에만 있는 테이블은 유지됩니다.`
+The confirmation dialog retains the existing production guard.
+
+## Cleanup and Failure Safety
+
+- Snapshot setup failure releases any acquired global and backup locks before
+  returning.
+- Worker startup is all-or-nothing; partial snapshot pools are rolled back.
+- Worker failure cancels further scheduling, joins every worker, rolls back all
+  snapshot transactions, and releases coordinator locks.
+- User cancellation follows the same cleanup path.
+- Output directories retain TunnelForge's marker-based deletion boundary. A
+  failed strict snapshot setup does not leave table data files.
+- Import structural preflight completes before the first destructive DDL.
+- Import failure after destructive DDL retains the existing report/resume
+  behavior; no new claim of transactional DDL rollback is introduced.
+
+## Testing
+
+### Rust unit and protocol tests
+
+- Snapshot setup SQL order and two-second lock bound.
+- All worker connections begin a consistent read-only transaction before the
+  global lock is released.
+- Worker jobs reuse fixed connections and never connect per chunk.
+- Cleanup releases locks and transactions for setup failure, worker failure,
+  cancellation, and success.
+- Single-thread and eight-thread manifests both report strict shared snapshots.
+- Replace/recreate affects dump tables only.
+- Compatible target-only FKs pass; type, signedness, charset/collation, index,
+  and engine mismatches fail before DROP.
+- Operation-level preflight errors are distinct from table failures.
+
+### Python/UI tests
+
+- Export payload, progress phases, strict-snapshot completion copy, privilege
+  errors, and timeout errors.
+- Import confirmation explains dump-scoped replacement.
+- A global Rust preflight error produces one operation failure and no fabricated
+  241-table failure list.
+- Existing PostgreSQL and partial-export behavior remains unchanged.
+
+### Live MySQL verification
+
+A disposable MySQL 8 instance verifies:
+
+1. eight snapshot workers observe one consistent point while concurrent DML
+   continues after setup;
+2. no long-lived table read lock exists during a large-table scan;
+3. DDL waits while the backup lock is held;
+4. target-only tables survive replace Import;
+5. compatible external FKs survive and incompatible external FKs fail before
+   mutation.
+
+Final gates are full Rust tests, full Python tests with a sufficiently long
+timeout, release build, formatting, compile checks, version synchronization,
+installer/package checks, and `git diff --check`.
+
+## Review, Version, and Release
+
+After implementation:
+
+1. Run focused correctness and safety review against this design.
+2. Run repository code review and address actionable findings.
+3. Update `docs/current_status.md`: close TF-STATUS-004 and TF-STATUS-084 only
+   with fresh live/focused/full verification evidence.
+4. Bump `src/version.py`, `pyproject.toml`, and
+   `installer/TunnelForge.iss` from `2.4.0` to `2.4.1` using the repository
+   versioning workflow.
+5. Push the reviewed branch, open a pull request, wait for required checks, and
+   merge through the protected branch workflow.
+6. Tag the merged release commit `v2.4.1` and run the existing Build and Release
+   workflow.
+7. Verify the published release assets and checksums before reporting the
+   release complete.
+
+## Deferred Work
+
+- PostgreSQL exported-snapshot sharing across parallel workers.
+- Historical row-level revalidation for target-only children after replace.
+- Unsafe non-consistent Export override in the UI.
+- Long-lived table locks as a compatibility fallback.

--- a/installer/TunnelForge.iss
+++ b/installer/TunnelForge.iss
@@ -7,7 +7,7 @@
 ;   3. 또는: .\scripts\build-installer.ps1
 
 #define MyAppName "TunnelForge"
-#define MyAppVersion "2.4.0"
+#define MyAppVersion "2.4.1"
 #define MyAppPublisher "sanghyun-io"
 #define MyAppURL "https://github.com/sanghyun-io/tunnelforge"
 #define MyAppExeName "TunnelForge.exe"

--- a/migration_core/src/adapters.rs
+++ b/migration_core/src/adapters.rs
@@ -709,12 +709,15 @@ fn default_snapshot_policy() -> String {
     "unknown".to_string()
 }
 
-pub(crate) fn dump_manifest_consistency_metadata(threads: usize) -> (String, bool, Vec<String>) {
-    if threads > 1 {
+pub(crate) fn dump_manifest_consistency_metadata(
+    engine: &str,
+    _threads: usize,
+) -> (String, bool, Vec<String>) {
+    if engine == "mysql" {
         (
-            "non_consistent_parallel".to_string(),
-            false,
-            vec!["parallel export did not prove a shared consistent snapshot".to_string()],
+            "mysql_shared_consistent_snapshot".to_string(),
+            true,
+            Vec::new(),
         )
     } else {
         ("connection_consistent".to_string(), true, Vec::new())
@@ -1038,20 +1041,29 @@ mod tests {
     }
 
     #[test]
-    fn dump_manifest_consistency_metadata_marks_parallel_as_non_strict() {
-        let (snapshot_policy, strict_export, warnings) = dump_manifest_consistency_metadata(8);
+    fn dump_manifest_consistency_metadata_marks_mysql_parallel_as_shared_snapshot() {
+        let (snapshot_policy, strict_export, warnings) =
+            dump_manifest_consistency_metadata("mysql", 8);
 
-        assert_eq!(snapshot_policy, "non_consistent_parallel");
-        assert!(!strict_export);
-        assert_eq!(
-            warnings,
-            vec!["parallel export did not prove a shared consistent snapshot".to_string()]
-        );
+        assert_eq!(snapshot_policy, "mysql_shared_consistent_snapshot");
+        assert!(strict_export);
+        assert!(warnings.is_empty());
     }
 
     #[test]
     fn dump_manifest_consistency_metadata_marks_single_thread_as_strict() {
-        let (snapshot_policy, strict_export, warnings) = dump_manifest_consistency_metadata(1);
+        let (snapshot_policy, strict_export, warnings) =
+            dump_manifest_consistency_metadata("mysql", 1);
+
+        assert_eq!(snapshot_policy, "mysql_shared_consistent_snapshot");
+        assert!(strict_export);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn dump_manifest_consistency_metadata_keeps_postgres_policy_separate() {
+        let (snapshot_policy, strict_export, warnings) =
+            dump_manifest_consistency_metadata("postgresql", 8);
 
         assert_eq!(snapshot_policy, "connection_consistent");
         assert!(strict_export);

--- a/migration_core/src/dump.rs
+++ b/migration_core/src/dump.rs
@@ -4,14 +4,173 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use mysql::prelude::Queryable;
 use crate::*;
 
 /// dump.run / dump.import 요청에 threads가 명시되지 않았을 때 사용하는 기본 워커 수.
 pub(crate) const DEFAULT_DUMP_THREADS: usize = 8;
+const MYSQL_GLOBAL_READ_LOCK_TIMEOUT: Duration = Duration::from_secs(2);
+
+fn mysql_snapshot_worker_setup_sql() -> [&'static str; 2] {
+    [
+        "SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+        "START TRANSACTION WITH CONSISTENT SNAPSHOT, READ ONLY",
+    ]
+}
+
+fn mysql_snapshot_coordinator_sql() -> [&'static str; 4] {
+    [
+        "SET SESSION lock_wait_timeout=2",
+        "FLUSH TABLES WITH READ LOCK",
+        "LOCK INSTANCE FOR BACKUP",
+        "UNLOCK TABLES",
+    ]
+}
+
+struct MysqlSharedSnapshot {
+    coordinator: mysql::PooledConn,
+    workers: Vec<mysql::PooledConn>,
+    setup_ms: u64,
+}
+
+impl MysqlSharedSnapshot {
+    fn acquire(endpoint: &Endpoint, worker_count: usize) -> Result<Self, String> {
+        let started = Instant::now();
+        let mut coordinator = mysql_connection(endpoint)?;
+        let mut control = mysql_connection(endpoint)?;
+        let mut workers = (0..worker_count.max(1))
+            .map(|_| mysql_connection(endpoint))
+            .collect::<Result<Vec<_>, _>>()?;
+        let [isolation_sql, snapshot_sql] = mysql_snapshot_worker_setup_sql();
+        for worker in &mut workers {
+            worker
+                .query_drop(isolation_sql)
+                .map_err(|err| format!("mysql snapshot isolation setup failed: {err}"))?;
+        }
+
+        let [timeout_sql, global_lock_sql, backup_lock_sql, unlock_tables_sql] =
+            mysql_snapshot_coordinator_sql();
+        coordinator
+            .query_drop(timeout_sql)
+            .map_err(|err| format!("mysql snapshot lock timeout setup failed: {err}"))?;
+        let connection_id = coordinator
+            .query_first::<u64, _>("SELECT CONNECTION_ID()")
+            .map_err(|err| format!("mysql snapshot coordinator id failed: {err}"))?
+            .ok_or_else(|| "mysql snapshot coordinator id was empty".to_string())?;
+        let (cancel_tx, cancel_rx) = mpsc::channel::<()>();
+        let watchdog = thread::spawn(move || {
+            if cancel_rx.recv_timeout(MYSQL_GLOBAL_READ_LOCK_TIMEOUT).is_err() {
+                let _ = control.query_drop(format!("KILL QUERY {connection_id}"));
+            }
+        });
+        let global_lock_result = coordinator.query_drop(global_lock_sql);
+        let _ = cancel_tx.send(());
+        let _ = watchdog.join();
+        global_lock_result.map_err(|err| {
+            format!(
+                "mysql consistent snapshot could not acquire the brief global read lock within 2 seconds: {err}"
+            )
+        })?;
+
+        let setup_result = (|| -> Result<(), String> {
+            for worker in &mut workers {
+                worker.query_drop(snapshot_sql).map_err(|err| {
+                    format!("mysql worker consistent snapshot start failed: {err}")
+                })?;
+            }
+            coordinator.query_drop(backup_lock_sql).map_err(|err| {
+                format!(
+                    "mysql backup lock failed; BACKUP_ADMIN is required for a safe online export: {err}"
+                )
+            })?;
+            coordinator
+                .query_drop(unlock_tables_sql)
+                .map_err(|err| format!("mysql global read lock release failed: {err}"))?;
+            Ok(())
+        })();
+        if let Err(err) = setup_result {
+            let _ = coordinator.query_drop("UNLOCK TABLES");
+            let _ = coordinator.query_drop("UNLOCK INSTANCE");
+            for worker in &mut workers {
+                let _ = worker.query_drop("ROLLBACK");
+            }
+            return Err(err);
+        }
+
+        Ok(Self {
+            coordinator,
+            workers,
+            setup_ms: started.elapsed().as_millis().max(1) as u64,
+        })
+    }
+
+    fn take_workers(&mut self) -> Vec<mysql::PooledConn> {
+        std::mem::take(&mut self.workers)
+    }
+
+    fn validate_transactional_tables(
+        &mut self,
+        endpoint: &Endpoint,
+        tables: &[NormalizedTable],
+    ) -> Result<(), String> {
+        let worker = self
+            .workers
+            .first_mut()
+            .ok_or_else(|| "mysql snapshot worker was not initialized".to_string())?;
+        let table_names = tables
+            .iter()
+            .map(|table| sql_literal(&Value::String(table.name.clone())))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let rows = worker
+            .query::<(String, String), _>(format!(
+                "SELECT TABLE_NAME, ENGINE FROM information_schema.TABLES WHERE TABLE_SCHEMA = {} AND TABLE_NAME IN ({})",
+                sql_literal(&Value::String(endpoint_schema(endpoint))),
+                table_names
+            ))
+            .map_err(|err| format!("mysql snapshot table-engine inspection failed: {err}"))?;
+        let offenders = non_transactional_mysql_tables(&rows);
+        if offenders.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "mysql online consistent export requires InnoDB tables; convert or separately handle: {}",
+                offenders.join(", ")
+            ))
+        }
+    }
+}
+
+fn non_transactional_mysql_tables(rows: &[(String, String)]) -> Vec<String> {
+    let mut offenders = rows
+        .iter()
+        .filter(|(_, engine)| !engine.eq_ignore_ascii_case("innodb"))
+        .map(|(table, engine)| format!("{table} ({engine})"))
+        .collect::<Vec<_>>();
+    offenders.sort();
+    offenders
+}
+
+impl Drop for MysqlSharedSnapshot {
+    fn drop(&mut self) {
+        for worker in &mut self.workers {
+            let _ = worker.query_drop("ROLLBACK");
+        }
+        let _ = self.coordinator.query_drop("UNLOCK TABLES");
+        let _ = self.coordinator.query_drop("UNLOCK INSTANCE");
+    }
+}
+
+fn mysql_connection(endpoint: &Endpoint) -> Result<mysql::PooledConn, String> {
+    match LiveAdapter::connect(endpoint)? {
+        LiveAdapter::MySql(conn) => Ok(conn),
+        LiveAdapter::PostgreSql(_) => Err("mysql connection requires mysql endpoint".to_string()),
+    }
+}
 
 pub(crate) fn dump_run_streaming<F: FnMut(Value)>(request: &Request, mut emit: F) {
     emit(json!({
@@ -357,7 +516,6 @@ fn parse_dump_run_options(request: &Request) -> Result<DumpRunOptions, String> {
 
 /// engine/threads/table_total로 결정되는 덤프 실행 전략.
 enum DumpStrategy {
-    SingleMysqlParallel,
     GlobalMysql,
     TableParallel,
     Sequential,
@@ -373,9 +531,7 @@ impl DumpStrategy {
 }
 
 fn select_dump_strategy(engine: &str, threads: usize, table_total: usize) -> DumpStrategy {
-    if engine == "mysql" && threads > 1 && table_total == 1 {
-        DumpStrategy::SingleMysqlParallel
-    } else if engine == "mysql" && threads > 1 && table_total > 1 {
+    if engine == "mysql" {
         DumpStrategy::GlobalMysql
     } else if threads > 1 && table_total > 1 {
         DumpStrategy::TableParallel
@@ -414,7 +570,7 @@ fn finalize_dump_manifest<F: FnMut(Value)>(
     };
     let views_count = views.len();
     let (snapshot_policy, strict_export, manifest_warnings) =
-        dump_manifest_consistency_metadata(options.threads);
+        dump_manifest_consistency_metadata(&endpoint.engine, options.threads);
 
     let manifest = DumpManifest {
         format: "tunnelforge-dump".to_string(),
@@ -443,6 +599,31 @@ fn dump_run<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value, St
     let output_path = Path::new(&options.output_dir);
     prepare_dump_output_dir(output_path, options.overwrite)?;
 
+    let mut mysql_snapshot = if endpoint.engine == "mysql" {
+        emit(json!({
+            "event": "phase",
+            "request_id": request.request_id,
+            "phase": "snapshot",
+            "message": "공유 일관 스냅샷 준비 중 (쓰기 잠금은 최대 2초 내 획득 후 즉시 해제)"
+        }));
+        let snapshot = MysqlSharedSnapshot::acquire(&endpoint, options.threads)?;
+        emit(json!({
+            "event": "phase",
+            "request_id": request.request_id,
+            "phase": "snapshot",
+            "message": format!(
+                "MySQL 공유 일관 스냅샷 준비 완료: {}개 워커, {} ms (일반 쓰기 가능, DDL만 export 종료까지 제한)",
+                snapshot.workers.len(), snapshot.setup_ms
+            ),
+            "snapshot_policy": "mysql_shared_consistent_snapshot",
+            "worker_count": snapshot.workers.len(),
+            "setup_ms": snapshot.setup_ms
+        }));
+        Some(snapshot)
+    } else {
+        None
+    };
+
     // 부분 export(tables 지정) 시에는 View가 참조하는 base table이 빠질 수 있으므로 View를 수집하지 않는다.
     let full_export = options.selected_tables.is_empty();
     let inspection = inspect_live(&endpoint)?;
@@ -454,6 +635,9 @@ fn dump_run<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value, St
     schema = dependency_ordered_schema(&schema);
     if schema.tables.is_empty() {
         return Err("dump.run found no tables to export".to_string());
+    }
+    if let Some(snapshot) = mysql_snapshot.as_mut() {
+        snapshot.validate_transactional_tables(&endpoint, &schema.tables)?;
     }
 
     let row_counts = dump_table_row_counts(&endpoint, &schema.tables);
@@ -491,22 +675,12 @@ fn dump_run<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value, St
         request_id: request.request_id.clone(),
     };
     let (table_manifests, total_rows, total_chunks) = match strategy {
-        DumpStrategy::SingleMysqlParallel => {
-            match dump_single_mysql_table_parallel(
-                &ctx,
-                &export_tables[0],
-                parallel_limits.range_workers_per_table,
-                |event| emit(event),
-            )? {
-                Some(result) => result,
-                None => {
-                    let mut adapter = LiveAdapter::connect(&endpoint)?;
-                    dump_tables_sequential(&mut adapter, &ctx, &export_tables, |event| emit(event))?
-                }
-            }
-        }
         DumpStrategy::GlobalMysql => {
-            dump_tables_global_mysql(&ctx, &export_tables, options.threads, |event| emit(event))?
+            let workers = mysql_snapshot
+                .as_mut()
+                .ok_or_else(|| "mysql snapshot session was not initialized".to_string())?
+                .take_workers();
+            dump_tables_global_mysql(&ctx, &export_tables, workers, |event| emit(event))?
         }
         DumpStrategy::TableParallel => dump_tables_parallel(
             &ctx,
@@ -847,16 +1021,13 @@ fn dump_tables_parallel<F: FnMut(Value)>(
 fn dump_tables_global_mysql<F: FnMut(Value)>(
     ctx: &DumpJobContext,
     tables: &[NormalizedTable],
-    threads: usize,
+    mut workers: Vec<mysql::PooledConn>,
     mut emit: F,
 ) -> Result<(Vec<DumpTableManifest>, u64, u64), String> {
     let table_total = tables.len();
-    let mut conn = match LiveAdapter::connect(&ctx.endpoint)? {
-        LiveAdapter::MySql(conn) => conn,
-        LiveAdapter::PostgreSql(_) => {
-            return Err("global mysql dump requires mysql endpoint".to_string())
-        }
-    };
+    let mut conn = workers
+        .pop()
+        .ok_or_else(|| "global mysql dump requires at least one snapshot worker".to_string())?;
     let profiles = load_dump_perf_profiles();
     let mut ranges_by_table = BTreeMap::<String, Vec<DumpRange>>::new();
     let mut states = Vec::<DumpGlobalTableState>::new();
@@ -920,6 +1091,7 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
             manifest: None,
         });
     }
+    workers.push(conn);
 
     let plan = global_dump_work_plan_for_ranges(tables, &ranges_by_table);
     let table_index_by_name = tables
@@ -962,19 +1134,41 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
     if work_total == 0 {
         return Ok((Vec::new(), 0, 0));
     }
-    let max_threads = threads.max(1).min(work_total);
+    let max_threads = workers.len().max(1).min(work_total);
     let mut first_error: Option<String> = None;
     let (sender, receiver) = mpsc::channel::<DumpGlobalEvent>();
+    let pending = Arc::new(Mutex::new(pending));
+    let mut handles = Vec::with_capacity(max_threads);
+    for conn in workers.into_iter().take(max_threads) {
+        let pending = Arc::clone(&pending);
+        let sender = sender.clone();
+        let ctx = ctx.clone();
+        handles.push(thread::spawn(move || {
+            let mut adapter = LiveAdapter::MySql(conn);
+            loop {
+                let work = pending.lock().ok().and_then(|mut queue| queue.pop_front());
+                let Some(work) = work else { break };
+                run_dump_global_work(
+                    &mut adapter,
+                    &ctx,
+                    work,
+                    table_total,
+                    &sender,
+                );
+            }
+            let _ = adapter.execute_sql("ROLLBACK");
+        }));
+    }
+    drop(sender);
 
-    run_bounded_pool(
-        pending,
-        max_threads,
-        &receiver,
-        |work| spawn_dump_global_worker(ctx.clone(), work, table_total, sender.clone()),
-        |event| match event {
+    let mut completed = 0_usize;
+    while completed < work_total {
+        let event = receiver
+            .recv()
+            .map_err(|_| "mysql snapshot worker pool stopped unexpectedly".to_string())?;
+        match event {
             DumpGlobalEvent::Progress(event) => {
                 emit(event);
-                PoolAction::KeepGoing
             }
             DumpGlobalEvent::RangeDone {
                 table_index,
@@ -1027,7 +1221,7 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
                         "strategy": "global_pk_range_parallel"
                     }));
                 }
-                PoolAction::Advance
+                completed += 1;
             }
             DumpGlobalEvent::TableDone {
                 index,
@@ -1042,15 +1236,17 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
                 state.chunks_total = chunks;
                 state.work_ms = duration_ms.max(1);
                 state.manifest = Some(manifest);
-                PoolAction::Advance
+                completed += 1;
             }
-            // 글로벌 경로 에러는 리필하지 않고 슬롯만 반환한다(기존 동작 보존).
             DumpGlobalEvent::Error(err) => {
                 first_error.get_or_insert(err);
-                PoolAction::AdvanceNoRefill
+                completed += 1;
             }
-        },
-    );
+        }
+    }
+    for handle in handles {
+        let _ = handle.join();
+    }
     if let Some(err) = first_error {
         return Err(err);
     }
@@ -1086,18 +1282,6 @@ fn dump_tables_global_mysql<F: FnMut(Value)>(
     let total_rows = manifests.iter().map(|table| table.rows).sum();
     let total_chunks = manifests.iter().map(|table| table.chunks).sum();
     Ok((manifests, total_rows, total_chunks))
-}
-
-fn dump_single_mysql_table_parallel<F: FnMut(Value)>(
-    ctx: &DumpJobContext,
-    table: &NormalizedTable,
-    threads: usize,
-    mut emit: F,
-) -> Result<Option<(Vec<DumpTableManifest>, u64, u64)>, String> {
-    Ok(
-        dump_mysql_table_parallel_ranges(ctx, table, 0, 1, threads, |event| emit(event))?
-            .map(|(manifest, rows, chunks)| (vec![manifest], rows, chunks)),
-    )
 }
 
 fn dump_mysql_table_parallel_ranges<F: FnMut(Value)>(
@@ -1291,28 +1475,34 @@ fn spawn_mysql_range_worker(
     })
 }
 
-fn spawn_dump_global_worker(
-    ctx: DumpJobContext,
+fn run_dump_global_work(
+    adapter: &mut LiveAdapter,
+    ctx: &DumpJobContext,
     work: DumpGlobalWorkItem,
     table_total: usize,
-    sender: mpsc::Sender<DumpGlobalEvent>,
-) -> thread::JoinHandle<()> {
-    thread::spawn(move || match work.kind {
+    sender: &mpsc::Sender<DumpGlobalEvent>,
+) {
+    match work.kind {
         DumpGlobalWorkKind::MysqlRange {
             table_path,
             pk_column,
             range,
         } => {
-            let result = dump_mysql_range_chunk(
-                &ctx.endpoint,
-                &ctx.output_path,
-                &work.table,
-                &table_path,
-                &pk_column,
-                &range,
-                &ctx.data_format,
-                &ctx.compression,
-            );
+            let result = match adapter {
+                LiveAdapter::MySql(conn) => dump_mysql_range_chunk_on_conn(
+                    conn,
+                    &ctx.output_path,
+                    &work.table,
+                    &table_path,
+                    &pk_column,
+                    &range,
+                    &ctx.data_format,
+                    &ctx.compression,
+                ),
+                LiveAdapter::PostgreSql(_) => {
+                    Err("global mysql worker received a PostgreSQL connection".to_string())
+                }
+            };
             match result {
                 Ok((rows, stream_ms, checksum)) => {
                     let _ = sender.send(DumpGlobalEvent::RangeDone {
@@ -1331,28 +1521,25 @@ fn spawn_dump_global_worker(
             }
         }
         DumpGlobalWorkKind::WholeTable => {
-            let result = (|| {
-                let mut adapter = LiveAdapter::connect(&ctx.endpoint)?;
-                let started = Instant::now();
-                dump_one_table(
-                    &mut adapter,
-                    &ctx,
-                    &work.table,
-                    work.table_index,
-                    table_total,
-                    |event| {
-                        let _ = sender.send(DumpGlobalEvent::Progress(event));
-                    },
+            let started = Instant::now();
+            let result = dump_one_table(
+                adapter,
+                ctx,
+                &work.table,
+                work.table_index,
+                table_total,
+                |event| {
+                    let _ = sender.send(DumpGlobalEvent::Progress(event));
+                },
+            )
+            .map(|(manifest, rows, chunks)| {
+                (
+                    manifest,
+                    rows,
+                    chunks,
+                    started.elapsed().as_millis().max(1) as u64,
                 )
-                .map(|(manifest, rows, chunks)| {
-                    (
-                        manifest,
-                        rows,
-                        chunks,
-                        started.elapsed().as_millis().max(1) as u64,
-                    )
-                })
-            })();
+            });
             match result {
                 Ok((manifest, rows, chunks, duration_ms)) => {
                     let _ = sender.send(DumpGlobalEvent::TableDone {
@@ -1368,11 +1555,11 @@ fn spawn_dump_global_worker(
                 }
             }
         }
-    })
+    }
 }
 
-fn dump_mysql_range_chunk(
-    endpoint: &Endpoint,
+fn dump_mysql_range_chunk_on_conn(
+    conn: &mut mysql::PooledConn,
     output_path: &Path,
     table: &NormalizedTable,
     table_path: &str,
@@ -1381,12 +1568,6 @@ fn dump_mysql_range_chunk(
     data_format: &str,
     compression: &str,
 ) -> Result<(u64, u64, String), String> {
-    let mut conn = match LiveAdapter::connect(endpoint)? {
-        LiveAdapter::MySql(conn) => conn,
-        LiveAdapter::PostgreSql(_) => {
-            return Err("pk range dump requires mysql endpoint".to_string())
-        }
-    };
     let chunk_path = output_path.join(table_path).join(dump_chunk_name(
         range.chunk_index,
         data_format,
@@ -1414,6 +1595,34 @@ fn dump_mysql_range_chunk(
     }
     let checksum = sha256_file(&chunk_path)?;
     Ok((rows, stream_started.elapsed().as_millis() as u64, checksum))
+}
+
+fn dump_mysql_range_chunk(
+    endpoint: &Endpoint,
+    output_path: &Path,
+    table: &NormalizedTable,
+    table_path: &str,
+    pk_column: &str,
+    range: &DumpRange,
+    data_format: &str,
+    compression: &str,
+) -> Result<(u64, u64, String), String> {
+    let mut conn = match LiveAdapter::connect(endpoint)? {
+        LiveAdapter::MySql(conn) => conn,
+        LiveAdapter::PostgreSql(_) => {
+            return Err("pk range dump requires mysql endpoint".to_string())
+        }
+    };
+    dump_mysql_range_chunk_on_conn(
+        &mut conn,
+        output_path,
+        table,
+        table_path,
+        pk_column,
+        range,
+        data_format,
+        compression,
+    )
 }
 
 fn spawn_dump_table_worker(
@@ -1858,6 +2067,43 @@ mod tests {
         assert_eq!(event["rows_total"], 42);
         assert_eq!(event["tables"][0]["name"], "users");
         assert_eq!(event["tables"][0]["rows"], 42);
+    }
+
+    #[test]
+    fn mysql_snapshot_setup_uses_repeatable_read_read_only_transactions() {
+        assert_eq!(
+            mysql_snapshot_worker_setup_sql(),
+            [
+                "SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+                "START TRANSACTION WITH CONSISTENT SNAPSHOT, READ ONLY",
+            ]
+        );
+    }
+
+    #[test]
+    fn mysql_snapshot_lock_sequence_releases_global_lock_before_dumping() {
+        assert_eq!(
+            mysql_snapshot_coordinator_sql(),
+            [
+                "SET SESSION lock_wait_timeout=2",
+                "FLUSH TABLES WITH READ LOCK",
+                "LOCK INSTANCE FOR BACKUP",
+                "UNLOCK TABLES",
+            ]
+        );
+    }
+
+    #[test]
+    fn mysql_shared_snapshot_rejects_non_transactional_tables() {
+        let rows = vec![
+            ("users".to_string(), "InnoDB".to_string()),
+            ("legacy_cache".to_string(), "MyISAM".to_string()),
+        ];
+
+        assert_eq!(
+            non_transactional_mysql_tables(&rows),
+            vec!["legacy_cache (MyISAM)".to_string()]
+        );
     }
 
     #[test]

--- a/migration_core/src/dump_format.rs
+++ b/migration_core/src/dump_format.rs
@@ -417,72 +417,256 @@ pub(crate) fn dump_import_ddl_error(operation: &str, table: &str, err: &str) -> 
     )
 }
 
-/// import set 밖의 타겟 테이블이 import set 안의 테이블을 참조하는 살아있는 FK를 가려낸다.
-///
-/// replace/recreate 모드는 대상 테이블을 통째로 재생성하는데, 덤프에 포함되지 않은
-/// 타겟 테이블이 대상 테이블을 참조하는 FK를 갖고 있으면, 부모를 재생성하는 시점에
-/// 그 살아있는 자식 FK가 새 부모 정의와 (특히 charset/collation) 호환되지 않아
-/// MySQL ERROR 3780이 발생할 수 있다. 이런 경우 import를 차단해야 한다.
-///
-/// `rows`는 `(referencing_table, constraint_name, referenced_table)` 튜플 목록이다.
-/// 반환값은 `"<referencing_table>.<constraint_name> -> <referenced_table>"` 형식의
-/// 정렬·중복제거된 위반 목록이다.
-fn surviving_fk_offenders(
-    rows: &[(String, String, String)],
-    import_set: &BTreeSet<String>,
-) -> Vec<String> {
-    let mut offenders: Vec<String> = rows
+/// 덤프 밖에 남는 MySQL FK 한 컬럼과 현재 부모 정의를 표현한다. 새 부모 정의가 이
+/// 계약을 그대로 재현할 수 있는지 확인해서, 호환되는 target-only 테이블은 보존한다.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SurvivingFkColumn {
+    referencing_table: String,
+    constraint_name: String,
+    referenced_table: String,
+    ordinal_position: u64,
+    referenced_column: String,
+    existing_parent_column_type: String,
+    existing_parent_character_set: Option<String>,
+    existing_parent_collation: Option<String>,
+}
+
+fn mysql_base_column_type(type_name: &str) -> String {
+    let lower = type_name.trim().to_ascii_lowercase();
+    [" character set ", " charset ", " collate "]
         .iter()
-        .filter(|(table, _constraint, referenced)| {
-            import_set.contains(referenced) && !import_set.contains(table)
+        .filter_map(|marker| lower.find(marker))
+        .min()
+        .map(|index| lower[..index].trim().to_string())
+        .unwrap_or(lower)
+}
+
+fn mysql_charset_from_collation(collation: &str) -> Option<String> {
+    collation.split_once('_').map(|(charset, _)| charset.to_string())
+}
+
+fn imported_mysql_column_fidelity(
+    table: &NormalizedTable,
+    column: &NormalizedColumn,
+) -> MysqlCharacterFidelity {
+    let mut fidelity = mysql_character_fidelity(&column.type_name);
+    if fidelity.collation.is_none() {
+        fidelity.collation = table.table_collation.clone();
+    }
+    if fidelity.character_set.is_none() {
+        fidelity.character_set = fidelity
+            .collation
+            .as_deref()
+            .and_then(mysql_charset_from_collation);
+    }
+    fidelity
+}
+
+fn imported_table_has_referenced_index(table: &NormalizedTable, columns: &[String]) -> bool {
+    let primary_columns = table
+        .columns
+        .iter()
+        .filter(|column| column.primary_key)
+        .map(|column| column.name.as_str())
+        .collect::<Vec<_>>();
+    let requested = columns.iter().map(String::as_str).collect::<Vec<_>>();
+    primary_columns.starts_with(&requested)
+        || table.indexes.iter().any(|index| {
+            index
+                .columns
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .starts_with(&requested)
         })
-        .map(|(table, constraint, referenced)| format!("{table}.{constraint} -> {referenced}"))
-        .collect();
+        || (columns.len() == 1
+            && table.columns.iter().any(|column| {
+                column.name == columns[0] && (column.primary_key || column.unique)
+            }))
+}
+
+fn incompatible_surviving_fk_offenders(
+    rows: &[SurvivingFkColumn],
+    import_schema: &NormalizedSchema,
+) -> Vec<String> {
+    let import_set = import_schema
+        .tables
+        .iter()
+        .map(|table| table.name.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut offenders = Vec::new();
+
+    for row in rows {
+        if import_set.contains(row.referencing_table.as_str())
+            || !import_set.contains(row.referenced_table.as_str())
+        {
+            continue;
+        }
+        let Some(table) = import_schema
+            .tables
+            .iter()
+            .find(|table| table.name == row.referenced_table)
+        else {
+            continue;
+        };
+        let Some(column) = table
+            .columns
+            .iter()
+            .find(|column| column.name == row.referenced_column)
+        else {
+            offenders.push(format!(
+                "{}.{} -> {} (referenced column {} is absent from dump)",
+                row.referencing_table,
+                row.constraint_name,
+                row.referenced_table,
+                row.referenced_column
+            ));
+            continue;
+        };
+        let existing_type = mysql_base_column_type(&row.existing_parent_column_type);
+        let imported_type = mysql_base_column_type(&column.type_name);
+        if existing_type != imported_type {
+            offenders.push(format!(
+                "{}.{} -> {} (column {} type changes from {} to {})",
+                row.referencing_table,
+                row.constraint_name,
+                row.referenced_table,
+                row.referenced_column,
+                existing_type,
+                imported_type
+            ));
+            continue;
+        }
+        let imported_fidelity = imported_mysql_column_fidelity(table, column);
+        for (property, existing, imported) in [
+            (
+                "character set",
+                row.existing_parent_character_set.as_deref(),
+                imported_fidelity.character_set.as_deref(),
+            ),
+            (
+                "collation",
+                row.existing_parent_collation.as_deref(),
+                imported_fidelity.collation.as_deref(),
+            ),
+        ] {
+            if let (Some(existing), Some(imported)) = (existing, imported) {
+                if !existing.eq_ignore_ascii_case(imported) {
+                    offenders.push(format!(
+                        "{}.{} -> {} (column {} {} changes from {} to {})",
+                        row.referencing_table,
+                        row.constraint_name,
+                        row.referenced_table,
+                        row.referenced_column,
+                        property,
+                        existing,
+                        imported
+                    ));
+                    break;
+                }
+            }
+        }
+    }
+
+    let mut fk_columns = BTreeMap::<(String, String, String), Vec<(u64, String)>>::new();
+    for row in rows {
+        if import_set.contains(row.referencing_table.as_str())
+            || !import_set.contains(row.referenced_table.as_str())
+        {
+            continue;
+        }
+        fk_columns
+            .entry((
+                row.referencing_table.clone(),
+                row.constraint_name.clone(),
+                row.referenced_table.clone(),
+            ))
+            .or_default()
+            .push((row.ordinal_position, row.referenced_column.clone()));
+    }
+    for ((referencing_table, constraint_name, referenced_table), mut columns) in fk_columns {
+        columns.sort_by_key(|(ordinal, _)| *ordinal);
+        let columns = columns
+            .into_iter()
+            .map(|(_, column)| column)
+            .collect::<Vec<_>>();
+        let Some(table) = import_schema
+            .tables
+            .iter()
+            .find(|table| table.name == referenced_table)
+        else {
+            continue;
+        };
+        if !imported_table_has_referenced_index(table, &columns) {
+            offenders.push(format!(
+                "{referencing_table}.{constraint_name} -> {referenced_table} (dump does not recreate a referenced index beginning with {})",
+                columns.join(", ")
+            ));
+        }
+    }
     offenders.sort();
     offenders.dedup();
     offenders
 }
 
-/// 타겟 DB에서 import set 밖의 살아있는 referencing FK를 조회해, 있으면 import를 abort한다.
+/// 타겟 DB에서 import set 밖의 살아있는 referencing FK를 조회한다. 덤프가 재생성할
+/// 부모 정의와 구조적으로 호환되면 MySQL dump 복원처럼 그대로 보존하고 진행한다.
 ///
 /// MySQL 전용. 비-MySQL 어댑터는 그대로 통과시킨다(ERROR 3780은 MySQL 고유 증상이며,
 /// PostgreSQL은 `information_schema.KEY_COLUMN_USAGE`에 `REFERENCED_TABLE_NAME`을
 /// 노출하지 않아 별도 쿼리가 필요하다 — 후속 과제).
 ///
-/// 타겟을 수정하지 않고 오직 조회만 한다. 위반이 있으면 어떤 테이블의 어떤 FK가
-/// 충돌하는지 명시한 `preflight_surviving_fk` 에러를 반환한다.
+/// 타겟을 수정하지 않고 오직 조회만 한다. 구조가 달라지는 FK만 어떤 테이블의 어떤
+/// 제약이 충돌하는지 명시한 `preflight_surviving_fk` 에러를 반환한다.
 pub(crate) fn preflight_surviving_referencing_fks(
     adapter: &mut LiveAdapter,
-    schema: &str,
-    import_set: &BTreeSet<String>,
+    target_schema: &str,
+    import_schema: &NormalizedSchema,
 ) -> Result<(), String> {
     let conn = match adapter {
         LiveAdapter::MySql(conn) => conn,
         _ => return Ok(()),
     };
-    let rows: Vec<(String, String, String)> = conn
+    let rows: Vec<SurvivingFkColumn> = conn
         .exec_map(
-            "SELECT TABLE_NAME, CONSTRAINT_NAME, REFERENCED_TABLE_NAME \
-             FROM information_schema.KEY_COLUMN_USAGE \
-             WHERE TABLE_SCHEMA = ? AND REFERENCED_TABLE_NAME IS NOT NULL \
-             GROUP BY TABLE_NAME, CONSTRAINT_NAME, REFERENCED_TABLE_NAME \
-             ORDER BY TABLE_NAME, CONSTRAINT_NAME, REFERENCED_TABLE_NAME",
-            (schema,),
-            |(table, constraint, referenced): (String, String, String)| {
-                (table, constraint, referenced)
+            "SELECT k.TABLE_NAME, k.CONSTRAINT_NAME, k.REFERENCED_TABLE_NAME, \
+                    k.ORDINAL_POSITION, k.REFERENCED_COLUMN_NAME, c.COLUMN_TYPE, \
+                    c.CHARACTER_SET_NAME, c.COLLATION_NAME \
+             FROM information_schema.KEY_COLUMN_USAGE k \
+             JOIN information_schema.COLUMNS c \
+               ON c.TABLE_SCHEMA = k.REFERENCED_TABLE_SCHEMA \
+              AND c.TABLE_NAME = k.REFERENCED_TABLE_NAME \
+              AND c.COLUMN_NAME = k.REFERENCED_COLUMN_NAME \
+             WHERE k.TABLE_SCHEMA = ? AND k.REFERENCED_TABLE_NAME IS NOT NULL \
+             ORDER BY k.TABLE_NAME, k.CONSTRAINT_NAME, k.ORDINAL_POSITION",
+            (target_schema,),
+            |(referencing_table, constraint_name, referenced_table, ordinal_position,
+              referenced_column, existing_parent_column_type,
+              existing_parent_character_set, existing_parent_collation):
+             (String, String, String, u64, String, String, Option<String>, Option<String>)| {
+                SurvivingFkColumn {
+                    referencing_table,
+                    constraint_name,
+                    referenced_table,
+                    ordinal_position,
+                    referenced_column,
+                    existing_parent_column_type,
+                    existing_parent_character_set,
+                    existing_parent_collation,
+                }
             },
         )
         .map_err(|err| format!("mysql surviving-FK preflight inspect error: {err}"))?;
 
-    let offenders = surviving_fk_offenders(&rows, import_set);
+    let offenders = incompatible_surviving_fk_offenders(&rows, import_schema);
     if offenders.is_empty() {
         Ok(())
     } else {
         Err(classified_import_error(
             "preflight_surviving_fk",
             &format!(
-                "target tables outside the import set still reference tables being recreated; \
-                 drop or detach these foreign keys on the target before re-importing: {}",
+                "target-only foreign keys are incompatible with tables being recreated; \
+                 align or detach only these constraints before re-importing: {}",
                 offenders.join(", ")
             ),
             None,
@@ -972,7 +1156,7 @@ mod tests {
     
     
     use serde_json::{json, Value};
-    use std::collections::{BTreeMap, BTreeSet};
+    use std::collections::BTreeMap;
     use std::fs::{self};
     
     use std::path::Path;
@@ -1802,50 +1986,105 @@ mod tests {
     }
 
     #[test]
-    fn surviving_fk_offenders_flags_only_external_references() {
-        let import_set: BTreeSet<String> = ["audit_category", "df_evaluation_results"]
-            .into_iter()
-            .map(String::from)
-            .collect();
+    fn compatible_surviving_fk_is_preserved_for_mysql_like_import() {
+        let schema = NormalizedSchema {
+            tables: vec![NormalizedTable {
+                name: "supplement_review_item".to_string(),
+                columns: vec![NormalizedColumn {
+                    name: "id".to_string(),
+                    type_name: "bigint unsigned".to_string(),
+                    default_value: None,
+                    nullable: false,
+                    primary_key: true,
+                    unique: true,
+                }],
+                indexes: Vec::new(),
+                foreign_keys: Vec::new(),
+                table_collation: None,
+            }],
+        };
+        let rows = vec![SurvivingFkColumn {
+            referencing_table: "supplement_review_api_call".to_string(),
+            constraint_name: "fk_srac_item".to_string(),
+            referenced_table: "supplement_review_item".to_string(),
+            ordinal_position: 1,
+            referenced_column: "id".to_string(),
+            existing_parent_column_type: "bigint unsigned".to_string(),
+            existing_parent_character_set: None,
+            existing_parent_collation: None,
+        }];
 
-        let rows = vec![
-            // import set 밖의 테이블이 import set 안의 부모를 참조 → 위반
-            (
-                "legacy_audit_log".to_string(),
-                "fk_legacy_audit".to_string(),
-                "audit_category".to_string(),
-            ),
-            // import set 내부끼리의 FK → 위반 아님 (자식부터 drop되므로 안전)
-            (
-                "df_evaluation_results".to_string(),
-                "df_evaluation_results_ibfk_3".to_string(),
-                "audit_category".to_string(),
-            ),
-            // import set 밖의 테이블을 참조 → 위반 아님 (재생성 대상 아님)
-            (
-                "df_evaluation_results".to_string(),
-                "fk_eval_other".to_string(),
-                "some_external_table".to_string(),
-            ),
-        ];
+        assert!(incompatible_surviving_fk_offenders(&rows, &schema).is_empty());
+    }
 
-        let offenders = surviving_fk_offenders(&rows, &import_set);
+    #[test]
+    fn incompatible_surviving_fk_is_rejected_before_parent_recreate() {
+        let schema = NormalizedSchema {
+            tables: vec![NormalizedTable {
+                name: "supplement_review_item".to_string(),
+                columns: vec![NormalizedColumn {
+                    name: "id".to_string(),
+                    type_name: "bigint unsigned".to_string(),
+                    default_value: None,
+                    nullable: false,
+                    primary_key: true,
+                    unique: true,
+                }],
+                indexes: Vec::new(),
+                foreign_keys: Vec::new(),
+                table_collation: None,
+            }],
+        };
+        let rows = vec![SurvivingFkColumn {
+            referencing_table: "supplement_review_api_call".to_string(),
+            constraint_name: "fk_srac_item".to_string(),
+            referenced_table: "supplement_review_item".to_string(),
+            ordinal_position: 1,
+            referenced_column: "id".to_string(),
+            existing_parent_column_type: "int unsigned".to_string(),
+            existing_parent_character_set: None,
+            existing_parent_collation: None,
+        }];
+
         assert_eq!(
-            offenders,
-            vec!["legacy_audit_log.fk_legacy_audit -> audit_category".to_string()]
+            incompatible_surviving_fk_offenders(&rows, &schema),
+            vec!["supplement_review_api_call.fk_srac_item -> supplement_review_item (column id type changes from int unsigned to bigint unsigned)".to_string()]
         );
     }
 
     #[test]
-    fn surviving_fk_offenders_empty_when_no_external_references() {
-        let import_set: BTreeSet<String> =
-            ["audit_category"].into_iter().map(String::from).collect();
-        let rows = vec![(
-            "audit_category".to_string(),
-            "fk_self".to_string(),
-            "audit_category".to_string(),
-        )];
-        assert!(surviving_fk_offenders(&rows, &import_set).is_empty());
+    fn surviving_fk_requires_dump_to_recreate_referenced_index() {
+        let schema = NormalizedSchema {
+            tables: vec![NormalizedTable {
+                name: "parent".to_string(),
+                columns: vec![NormalizedColumn {
+                    name: "external_id".to_string(),
+                    type_name: "bigint unsigned".to_string(),
+                    default_value: None,
+                    nullable: false,
+                    primary_key: false,
+                    unique: false,
+                }],
+                indexes: Vec::new(),
+                foreign_keys: Vec::new(),
+                table_collation: None,
+            }],
+        };
+        let rows = vec![SurvivingFkColumn {
+            referencing_table: "target_only_child".to_string(),
+            constraint_name: "fk_child_parent".to_string(),
+            referenced_table: "parent".to_string(),
+            ordinal_position: 1,
+            referenced_column: "external_id".to_string(),
+            existing_parent_column_type: "bigint unsigned".to_string(),
+            existing_parent_character_set: None,
+            existing_parent_collation: None,
+        }];
+
+        assert_eq!(
+            incompatible_surviving_fk_offenders(&rows, &schema),
+            vec!["target_only_child.fk_child_parent -> parent (dump does not recreate a referenced index beginning with external_id)".to_string()]
+        );
     }
 
     #[test]

--- a/migration_core/src/import.rs
+++ b/migration_core/src/import.rs
@@ -125,7 +125,26 @@ fn dump_import<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value,
     set_mysql_import_session_tuning(&mut adapter, false)?;
 
     let target_schema = endpoint_schema(&endpoint);
-    prepare_import_target(mode, &tables, &mut adapter, &target_schema)?;
+    let selected_table_names = tables
+        .iter()
+        .map(|table| table.name.as_str())
+        .collect::<BTreeSet<_>>();
+    let import_schema = NormalizedSchema {
+        tables: manifest
+            .schema
+            .tables
+            .iter()
+            .filter(|table| selected_table_names.contains(table.name.as_str()))
+            .cloned()
+            .collect(),
+    };
+    prepare_import_target(
+        mode,
+        &tables,
+        &import_schema,
+        &mut adapter,
+        &target_schema,
+    )?;
 
     let import_result = (|| -> Result<(), String> {
         for (index, table_manifest) in tables.iter().enumerate() {
@@ -210,10 +229,9 @@ fn dump_import<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value,
 
 /// replace/recreate 모드일 때 import 전에 대상 테이블을 재생성 가능한 상태로 만든다.
 ///
-/// (1) Surviving-FK preflight (MySQL 전용, abort): import set 밖의 타겟 테이블이
-///     대상 테이블을 참조하는 FK를 갖고 있으면, 부모 재생성 시 그 살아있는 자식 FK가
-///     새 부모와 (charset/collation) 호환되지 않아 ERROR 3780이 난다. 타겟을 손대지
-///     않고 명확한 에러로 차단한다.
+/// (1) Surviving-FK preflight (MySQL 전용): import set 밖의 타겟 테이블과 그 FK는
+///     그대로 둔다. 새 부모 정의의 타입/charset/collation/index가 기존 FK 계약과
+///     달라지는 경우만 타겟을 손대기 전에 명확한 에러로 차단한다.
 ///
 /// (2) Drop-all-then-create-all 순서: import set 내부의 모든 대상 테이블을 자식 우선
 ///     (역의존성) 순서로 먼저 DROP한 뒤 루프에서 생성한다. 이렇게 하지 않고 테이블별로
@@ -224,14 +242,14 @@ fn dump_import<F: FnMut(Value)>(request: &Request, mut emit: F) -> Result<Value,
 fn prepare_import_target(
     mode: &str,
     tables: &[DumpTableManifest],
+    import_schema: &NormalizedSchema,
     adapter: &mut LiveAdapter,
     target_schema: &str,
 ) -> Result<(), String> {
     if !matches!(mode, "replace" | "recreate") {
         return Ok(());
     }
-    let import_set: BTreeSet<String> = tables.iter().map(|table| table.name.clone()).collect();
-    preflight_surviving_referencing_fks(adapter, target_schema, &import_set)?;
+    preflight_surviving_referencing_fks(adapter, target_schema, import_schema)?;
 
     // tables는 parent-first(dependency order)이므로 rev()는 child-first가 된다.
     // foreign_key_checks=0이 이미 켜져 있어 역순 DROP은 안전하다.

--- a/migration_core/tests/live_roundtrip.rs
+++ b/migration_core/tests/live_roundtrip.rs
@@ -2,6 +2,13 @@ use migration_core::{handle_request, Endpoint, Request};
 use mysql::prelude::Queryable;
 use serde_json::{json, Value};
 use std::env;
+use std::sync::{Mutex, MutexGuard};
+
+static LIVE_DB_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn live_db_test_guard() -> MutexGuard<'static, ()> {
+    LIVE_DB_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner())
+}
 
 fn endpoint(prefix: &str, default_port: u16, engine: &str) -> Option<Endpoint> {
     let host = env::var(format!("{prefix}_HOST")).ok()?;
@@ -128,6 +135,98 @@ fn mysql_table_charset_collation(
     .unwrap()
 }
 
+#[test]
+fn mysql_dump_import_preserves_compatible_target_only_fk_table_when_env_is_configured() {
+    let _guard = live_db_test_guard();
+    let Some(mysql_endpoint) = endpoint("TF_MYSQL", 3306, "mysql") else {
+        eprintln!("skipping MySQL dump/import FK preservation: TF_MYSQL_* is not configured");
+        return;
+    };
+    let parent = unique_table("tf_dump_parent");
+    let child = unique_table("tf_target_only_child");
+    let dump_dir = std::env::temp_dir().join(unique_table("tf_mysql_dump"));
+    let mut mysql = mysql_conn(&mysql_endpoint);
+    mysql
+        .query_drop(format!(
+            "CREATE TABLE `{parent}` (`id` BIGINT UNSIGNED NOT NULL PRIMARY KEY, `value` VARCHAR(32) NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+        ))
+        .unwrap();
+    mysql
+        .query_drop(format!("INSERT INTO `{parent}` VALUES (1, 'from_dump')"))
+        .unwrap();
+
+    let export = result_payload(handle_request(Request {
+        command: "dump.run".to_string(),
+        request_id: None,
+        payload: json!({
+            "source": endpoint_json(&mysql_endpoint),
+            "output_dir": dump_dir.to_string_lossy(),
+            "threads": 8,
+            "chunk_size": 1000,
+            "data_format": "tsv",
+            "compression": "none",
+            "tables": [parent]
+        }),
+    }));
+    assert_eq!(export["success"], true);
+    assert_eq!(export["snapshot_policy"], "mysql_shared_consistent_snapshot");
+    assert_eq!(export["strict_export"], true);
+
+    mysql
+        .query_drop(format!(
+            "CREATE TABLE `{child}` (`id` BIGINT UNSIGNED NOT NULL PRIMARY KEY, `parent_id` BIGINT UNSIGNED NOT NULL, CONSTRAINT `fk_target_only_parent` FOREIGN KEY (`parent_id`) REFERENCES `{parent}` (`id`)) ENGINE=InnoDB"
+        ))
+        .unwrap();
+    mysql
+        .query_drop(format!("INSERT INTO `{child}` VALUES (1, 1)"))
+        .unwrap();
+    mysql
+        .query_drop(format!("UPDATE `{parent}` SET `value`='changed' WHERE `id`=1"))
+        .unwrap();
+
+    let import = result_payload(handle_request(Request {
+        command: "dump.import".to_string(),
+        request_id: None,
+        payload: json!({
+            "target": endpoint_json(&mysql_endpoint),
+            "input_dir": dump_dir.to_string_lossy(),
+            "mode": "replace",
+            "threads": 8,
+            "strict_manifest": true
+        }),
+    }));
+    assert_eq!(import["success"], true);
+    assert_eq!(
+        mysql
+            .query_first::<String, _>(format!("SELECT `value` FROM `{parent}` WHERE `id`=1"))
+            .unwrap()
+            .as_deref(),
+        Some("from_dump")
+    );
+    assert_eq!(
+        mysql
+            .query_first::<u64, _>(format!("SELECT COUNT(*) FROM `{child}`"))
+            .unwrap(),
+        Some(1)
+    );
+    assert_eq!(
+        mysql
+            .exec_first::<u64, _, _>(
+                "SELECT COUNT(*) FROM information_schema.REFERENTIAL_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = ? AND TABLE_NAME = ? AND CONSTRAINT_NAME = 'fk_target_only_parent'",
+                (&mysql_endpoint.database, &child),
+            )
+            .unwrap(),
+        Some(1)
+    );
+
+    mysql.query_drop("SET SESSION foreign_key_checks=0").unwrap();
+    mysql
+        .query_drop(format!("DROP TABLE IF EXISTS `{child}`, `{parent}`"))
+        .unwrap();
+    mysql.query_drop("SET SESSION foreign_key_checks=1").unwrap();
+    std::fs::remove_dir_all(&dump_dir).unwrap();
+}
+
 fn unsupported_objects_from_inspect(endpoint: &Endpoint) -> Vec<String> {
     let inspect = result_payload(handle_request(Request {
         command: "inspect".to_string(),
@@ -145,6 +244,7 @@ fn unsupported_objects_from_inspect(endpoint: &Endpoint) -> Vec<String> {
 
 #[test]
 fn live_inspect_reports_views_as_unsupported_when_env_is_configured() {
+    let _guard = live_db_test_guard();
     let Some((mysql_endpoint, postgres_endpoint)) = test_endpoints() else {
         eprintln!("skipping live inspect: TF_MYSQL_* and TF_POSTGRES_* are not configured");
         return;
@@ -209,6 +309,7 @@ fn live_inspect_reports_views_as_unsupported_when_env_is_configured() {
 
 #[test]
 fn live_preflight_blocks_non_empty_target_when_env_is_configured() {
+    let _guard = live_db_test_guard();
     let Some((_mysql_endpoint, postgres_endpoint)) = test_endpoints() else {
         eprintln!("skipping live preflight: TF_MYSQL_* and TF_POSTGRES_* are not configured");
         return;
@@ -255,6 +356,7 @@ fn live_preflight_blocks_non_empty_target_when_env_is_configured() {
 
 #[test]
 fn live_readiness_reports_each_direction_when_env_is_configured() {
+    let _guard = live_db_test_guard();
     let Some((mysql_endpoint, postgres_endpoint)) = test_endpoints() else {
         eprintln!("skipping live readiness: TF_MYSQL_* and TF_POSTGRES_* are not configured");
         return;
@@ -315,6 +417,7 @@ fn live_readiness_reports_each_direction_when_env_is_configured() {
 
 #[test]
 fn oneclick_run_live_engine_innodb_when_env_is_configured() {
+    let _guard = live_db_test_guard();
     let Some(mysql_endpoint) = endpoint("TF_MYSQL", 3306, "mysql") else {
         eprintln!("skipping oneclick live apply: TF_MYSQL_* is not configured");
         return;
@@ -359,6 +462,7 @@ fn oneclick_run_live_engine_innodb_when_env_is_configured() {
 
 #[test]
 fn oneclick_run_live_charset_contract_when_env_is_configured() {
+    let _guard = live_db_test_guard();
     let Some(base_endpoint) = endpoint("TF_MYSQL", 3306, "mysql") else {
         eprintln!("skipping oneclick charset live apply: TF_MYSQL_* is not configured");
         return;
@@ -447,6 +551,7 @@ fn oneclick_run_live_charset_contract_when_env_is_configured() {
 
 #[test]
 fn oneclick_derive_charset_contracts_live_facts_when_env_is_configured() {
+    let _guard = live_db_test_guard();
     let Some(base_endpoint) = endpoint("TF_MYSQL", 3306, "mysql") else {
         eprintln!("skipping oneclick charset live derivation: TF_MYSQL_* is not configured");
         return;
@@ -514,6 +619,7 @@ fn oneclick_derive_charset_contracts_live_facts_when_env_is_configured() {
 
 #[test]
 fn live_guide_includes_row_values_and_sql_when_env_is_configured() {
+    let _guard = live_db_test_guard();
     let Some((mysql_endpoint, postgres_endpoint)) = test_endpoints() else {
         eprintln!("skipping live guide: TF_MYSQL_* and TF_POSTGRES_* are not configured");
         return;
@@ -571,6 +677,7 @@ fn live_guide_includes_row_values_and_sql_when_env_is_configured() {
 
 #[test]
 fn mysql_to_postgresql_live_roundtrip_when_env_is_configured() {
+    let _guard = live_db_test_guard();
     let Some((mysql_endpoint, postgres_endpoint)) = test_endpoints() else {
         eprintln!("skipping live roundtrip: TF_MYSQL_* and TF_POSTGRES_* are not configured");
         return;
@@ -684,6 +791,7 @@ fn mysql_to_postgresql_live_roundtrip_when_env_is_configured() {
 
 #[test]
 fn postgresql_to_mysql_live_roundtrip_when_env_is_configured() {
+    let _guard = live_db_test_guard();
     let Some((mysql_endpoint, postgres_endpoint)) = test_endpoints() else {
         eprintln!("skipping live roundtrip: TF_MYSQL_* and TF_POSTGRES_* are not configured");
         return;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tunnelforge"
-version = "2.4.0"
+version = "2.4.1"
 description = "SSH Tunnel and Rust DB Core Manager"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/core/i18n/legacy_translate.py
+++ b/src/core/i18n/legacy_translate.py
@@ -17,6 +17,7 @@ _HANGUL_CHAR_CLASS = f"[{_HANGUL_SYLLABLES_START}-{_HANGUL_SYLLABLES_END}]"
 
 
 _EN_TEXT_TRANSLATIONS = {
+    "MySQL은 모든 워커가 같은 일관 스냅샷을 사용합니다. 시작 시 쓰기 잠금을 최대 2초 안에 잠깐 획득해 즉시 해제하고, Export 중 일반 조회/입력/수정은 계속 가능하며 DDL만 제한됩니다.": "All MySQL workers use the same consistent snapshot. Export briefly acquires a write-blocking lock within a 2-second limit and releases it immediately; normal reads and writes remain available while only DDL is restricted until export completes.",
     "(백업 없음)": "(No backups)",
     "(미설정)": "(Not set)",
     "(복사)": "(Copy)",

--- a/src/exporters/rust_dump_exporter.py
+++ b/src/exporters/rust_dump_exporter.py
@@ -254,6 +254,8 @@ class RustDumpExporter(_RustDumpClientBase):
         message = f"Rust DB Core export 완료: {table_count}개 테이블, {rows:,} rows"
         if view_count:
             message += f", View {view_count}개"
+        if result.get("snapshot_policy") == "mysql_shared_consistent_snapshot":
+            message += f" (MySQL 공유 일관 스냅샷, {max(1, int(threads))}개 워커)"
         return True, message
 
     def export_full_schema(
@@ -334,7 +336,7 @@ class RustDumpExporter(_RustDumpClientBase):
             )
             if success:
                 self._write_metadata(output_dir, schema, "partial", final_tables, added_tables)
-                return True, f"{len(final_tables)}개 테이블 Export 완료", final_tables
+                return True, message, final_tables
             return False, message, []
         except DbCoreServiceError as exc:
             return False, f"Rust DB Core export 오류: {exc}", []
@@ -377,6 +379,10 @@ def _mark_non_done_import_results_error(
         import_results[table] = {"status": "error", "message": message}
         if table_status_callback:
             table_status_callback(table, "error", message)
+
+
+def _is_operation_scoped_import_error(message: str) -> bool:
+    return message.lstrip().startswith("preflight_surviving_fk:")
 
 
 class RustDumpImporter(_RustDumpClientBase):
@@ -515,7 +521,8 @@ class RustDumpImporter(_RustDumpClientBase):
                 message += f" (크로스 엔진 View {len(views_skipped)}개 건너뜀)"
             return True, message, import_results
         except DbCoreServiceError as exc:
-            _mark_non_done_import_results_error(import_results, str(exc), table_status_callback)
+            if not _is_operation_scoped_import_error(str(exc)):
+                _mark_non_done_import_results_error(import_results, str(exc), table_status_callback)
             return False, f"Rust DB Core import 오류: {exc}", import_results
         except Exception as exc:
             _mark_non_done_import_results_error(import_results, str(exc), table_status_callback)

--- a/src/ui/dialogs/db_export_dialog.py
+++ b/src/ui/dialogs/db_export_dialog.py
@@ -496,6 +496,11 @@ class RustDumpExportDialog(CollapsibleConfigDialog, ErrorReportingMixin, QDialog
         self.spin_threads = QSpinBox()
         self.spin_threads.setRange(1, 16)
         self.spin_threads.setValue(8)
+        self.spin_threads.setToolTip(
+            "MySQL은 모든 워커가 같은 일관 스냅샷을 사용합니다. "
+            "시작 시 쓰기 잠금을 최대 2초 안에 잠깐 획득해 즉시 해제하고, "
+            "Export 중 일반 조회/입력/수정은 계속 가능하며 DDL만 제한됩니다."
+        )
         option_layout.addRow("병렬 스레드:", self.spin_threads)
 
         self.combo_compression = QComboBox()

--- a/src/version.py
+++ b/src/version.py
@@ -4,7 +4,7 @@
 모든 버전 참조는 이 파일을 사용해야 합니다.
 """
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 __app_name__ = "TunnelForge"
 
 # GitHub 저장소 정보 (업데이트 확인용)

--- a/tests/test_current_status_docs.py
+++ b/tests/test_current_status_docs.py
@@ -959,10 +959,10 @@ def test_current_status_records_published_240_release():
     order = " ".join(_section(doc, "Recommended Execution Order").split())
     sessions = " ".join(_section(doc, "Session Log").split())
 
-    assert source_version == "2.4.0"
+    assert source_version == "2.4.1"
     assert "The latest stable release is now `v2.4.0`" in summary
     assert "anonymous error reporting" in summary
-    assert "Version references are aligned at `2.4.0`" in baseline
+    assert "Version references are aligned at `2.4.1`" in baseline
     assert "TF-STATUS-093 is `closed`" in summary
     assert "TF-STATUS-093 | High | closed" in tracker
     assert "`2.4.0` release-candidate preparation" in verification
@@ -984,6 +984,24 @@ def test_current_status_records_published_240_release():
     assert "Prepared the `2.4.0` release candidate" in sessions
     assert "Published `v2.4.0` as the stable/latest release" in sessions
     assert "https://github.com/sanghyun-io/tunnelforge/releases/tag/v2.4.0" in verification
+
+
+def test_current_status_tracks_241_mysql_dump_import_patch_candidate():
+    doc = (PROJECT_ROOT / "docs" / "current_status.md").read_text(encoding="utf-8")
+    summary = " ".join(_section(doc, "Summary").split())
+    tracker = " ".join(_section(doc, "Issue Tracker").split())
+    verification = " ".join(_section(doc, "Verification Log").split())
+    order = " ".join(_section(doc, "Recommended Execution Order").split())
+    sessions = " ".join(_section(doc, "Session Log").split())
+
+    assert "`2.4.1` patch release candidate" in summary
+    assert "TF-STATUS-094 | High | fixed_pending_full_verify" in tracker
+    assert "TF-STATUS-095 | High | fixed_pending_full_verify" in tracker
+    assert "mysql_shared_consistent_snapshot" in doc
+    assert "two-second bounded initial global read lock" in verification
+    assert "target-only FK live roundtrip passed" in verification
+    assert "Complete TF-STATUS-094/095" in order
+    assert "DML stays available" in sessions
 
 
 def test_current_status_closes_final_review_update_boundary_after_fresh_verification():
@@ -1188,7 +1206,7 @@ def test_current_status_records_anonymous_error_reporting_design():
     order = " ".join(_section(doc, "Recommended Execution Order").split())
     sessions = " ".join(_section(doc, "Session Log").split())
 
-    assert "Last reviewed: 2026-07-15" in doc
+    assert "Last reviewed: 2026-07-21" in doc
     assert "dedicated reporter GitHub App" in summary
     assert "Cloudflare Worker" in summary
     assert "TF-STATUS-092 | High | closed" in tracker

--- a/tests/test_rust_dump_exporter.py
+++ b/tests/test_rust_dump_exporter.py
@@ -815,6 +815,51 @@ class TestRustDumpImporter:
         assert ("orders", "error") in error_events
         assert ("products", "error") in error_events
 
+    def test_import_dump_keeps_tables_pending_for_operation_preflight_error(self, tmp_path):
+        """대상 전체 사전검사 실패를 덤프의 모든 테이블 실패로 부풀리지 않는다."""
+        from src.core.db_core_service import DbCoreServiceError
+        from src.exporters.rust_dump_exporter import RustDumpConfig, RustDumpImporter
+
+        dump_dir = tmp_path / 'dump'
+        dump_dir.mkdir(parents=True)
+        (dump_dir / '_tunnelforge_dump.json').write_text(
+            json.dumps(
+                {
+                    "format": "tunnelforge-dump",
+                    "format_version": 2,
+                    "database": "app",
+                    "tables": [
+                        {"name": "users", "path": "0001_users", "rows": 1, "chunks": 1},
+                        {"name": "orders", "path": "0002_orders", "rows": 1, "chunks": 1},
+                    ],
+                }
+            ),
+            encoding='utf-8',
+        )
+
+        class FakeFacade:
+            def import_dump(self, payload, on_event=None):
+                raise DbCoreServiceError(
+                    "preflight_surviving_fk: target-only foreign key is incompatible"
+                )
+
+        importer = RustDumpImporter(
+            RustDumpConfig('localhost', 3306, 'root', 'password'),
+            facade=FakeFacade(),
+        )
+        status_events = []
+
+        success, message, results = importer.import_dump(
+            str(dump_dir),
+            table_status_callback=lambda *event: status_events.append(event),
+        )
+
+        assert success is False
+        assert results["users"]["status"] == "pending"
+        assert results["orders"]["status"] == "pending"
+        assert not [event for event in status_events if event[1] == "error"]
+        assert "preflight_surviving_fk" in message
+
     def test_import_dump_reports_view_results_in_message(self, tmp_path):
         """import 결과의 views_imported/failed/skipped 가 메시지에 반영됨"""
         from src.exporters.rust_dump_exporter import RustDumpConfig, RustDumpImporter


### PR DESCRIPTION
## What changed
- make MySQL replace/recreate import operate on dump-contained tables while preserving structurally compatible target-only foreign-key tables
- use fixed MySQL worker sessions on one shared InnoDB consistent snapshot for 1-16 export threads
- bound the initial global read-lock acquisition to 2 seconds, release it before data scanning, and retain only the DDL-blocking backup lock
- report operation-level preflight failures once instead of marking every dump table failed
- bump the patch release candidate to 2.4.1 and update UX/status documentation

## Root cause
v2.4.0 treated every target-only FK into the import set as a fatal schema-wide conflict. Its parallel export workers also opened independent connections without a proven shared snapshot.

## User impact
MySQL-like restore scope is restored: tables absent from the dump stay intact when their FK contract remains compatible. Eight-worker exports are transactionally consistent for InnoDB while normal DML continues; DDL is restricted until export completion.

## Validation
- `cargo test --manifest-path migration_core\\Cargo.toml` with disposable MySQL 8.4: 221 lib, 2 CLI, 10 live, 2 stress passed / 1 ignored
- live target-only FK export/import roundtrip passed with 8 workers
- focused Export/Import/UI/i18n Python suite: 144 passed plus i18n gate
- split broad Python groups passed; existing macOS packaging group blocks on this Windows host, so hosted CI is required
- release build and version-sync test passed
- `git diff --check` passed