### PR TITLE
ci(release): decouple version bump from status-doc evidence (bot-maintained version marker)

### DIFF
--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -426,15 +426,17 @@ jobs:
           set -euo pipefail
 
           git fetch --no-tags --depth=1 origin "$HEAD_SHA"
-          mkdir -p .version-bump-input/src .version-bump-input/installer
+          mkdir -p .version-bump-input/src .version-bump-input/installer .version-bump-input/docs
           cp src/version.py .version-bump-input/src/version.py
           cp pyproject.toml .version-bump-input/pyproject.toml
           cp installer/TunnelForge.iss .version-bump-input/installer/TunnelForge.iss
+          cp docs/current_status.md .version-bump-input/docs/current_status.md
           python scripts/bump_version.py \
             --bump-type "$BUMP_TYPE" \
             --version-file .version-bump-input/src/version.py \
             --pyproject-file .version-bump-input/pyproject.toml \
             --installer-file .version-bump-input/installer/TunnelForge.iss \
+            --status-doc .version-bump-input/docs/current_status.md \
             > /tmp/bump.txt
           EXPECTED=$(grep 'new_version=' /tmp/bump.txt | cut -d= -f2)
           CURRENT_PY=$(git show "$HEAD_SHA:src/version.py" | grep '__version__' | cut -d'"' -f2)
@@ -479,7 +481,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           export GIT_INDEX_FILE="$RUNNER_TEMP/version-bump-index"
           git read-tree "$HEAD_SHA"
-          for path in src/version.py pyproject.toml installer/TunnelForge.iss; do
+          for path in src/version.py pyproject.toml installer/TunnelForge.iss docs/current_status.md; do
             mode=$(git ls-tree "$HEAD_SHA" -- "$path" | awk '{print $1}')
             blob=$(git hash-object -w ".version-bump-input/$path")
             git update-index --add --cacheinfo "$mode,$blob,$path"

--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -430,7 +430,11 @@ jobs:
           cp src/version.py .version-bump-input/src/version.py
           cp pyproject.toml .version-bump-input/pyproject.toml
           cp installer/TunnelForge.iss .version-bump-input/installer/TunnelForge.iss
-          cp docs/current_status.md .version-bump-input/docs/current_status.md
+          # 3개 버전 파일은 봇 소유라 base 복사 후 전면 재기록해도 안전하지만,
+          # current_status.md 는 PR 이 손으로 편집하는 문서다. base 를 복사해
+          # 덮어쓰면 PR 의 문서 편집이 사라진다. HEAD 에서 가져와 마커 라인만
+          # 바꾼다(HEAD 객체는 위 fetch 로 확보됨).
+          git show "$HEAD_SHA:docs/current_status.md" > .version-bump-input/docs/current_status.md
           python scripts/bump_version.py \
             --bump-type "$BUMP_TYPE" \
             --version-file .version-bump-input/src/version.py \
@@ -442,7 +446,12 @@ jobs:
           CURRENT_PY=$(git show "$HEAD_SHA:src/version.py" | grep '__version__' | cut -d'"' -f2)
           CURRENT_PROJECT=$(git show "$HEAD_SHA:pyproject.toml" | sed -n 's/^version = "\([^"]*\)"/\1/p' | head -1)
           CURRENT_INSTALLER=$(git show "$HEAD_SHA:installer/TunnelForge.iss" | sed -n 's/^#define MyAppVersion "\([^"]*\)"/\1/p' | head -1)
-          echo "expected=$EXPECTED python=$CURRENT_PY project=$CURRENT_PROJECT installer=$CURRENT_INSTALLER"
+          # current_status.md 의 'Current shipping version' 마커(있으면). '.v' 의
+          # '.' 로 백틱을 매칭해 셸에서 백틱 커맨드치환을 피한다. 마커는 fail-soft
+          # 대상이라 비어 있어도 아래 -z 가드에 넣지 않는다(비면 skip=false 로
+          # 떨어져 bump 가 돌며 마커를 동기화 -> 자가치유).
+          CURRENT_MARKER=$(git show "$HEAD_SHA:docs/current_status.md" | sed -n 's/.*Current shipping version:[[:space:]]*.v\([0-9.]*\).*/\1/p' | head -1)
+          echo "expected=$EXPECTED python=$CURRENT_PY project=$CURRENT_PROJECT installer=$CURRENT_INSTALLER marker=$CURRENT_MARKER"
 
           if [ -z "$EXPECTED" ] || [ -z "$CURRENT_PY" ] || \
              [ -z "$CURRENT_PROJECT" ] || [ -z "$CURRENT_INSTALLER" ]; then
@@ -452,8 +461,9 @@ jobs:
 
           if [ "$CURRENT_PY" = "$EXPECTED" ] && \
              [ "$CURRENT_PROJECT" = "$EXPECTED" ] && \
-             [ "$CURRENT_INSTALLER" = "$EXPECTED" ]; then
-            echo "All PR version files match the trusted expected version. Skipping."
+             [ "$CURRENT_INSTALLER" = "$EXPECTED" ] && \
+             [ "$CURRENT_MARKER" = "$EXPECTED" ]; then
+            echo "All PR version files and the status marker match the trusted expected version. Skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/docs/current_status.md
+++ b/docs/current_status.md
@@ -2,6 +2,8 @@
 
 Last reviewed: 2026-07-29
 
+Current shipping version: `v2.4.2` <!-- managed by scripts/bump_version.py (versioning.sync_status_marker); do not edit by hand -->
+
 This document is the current repository status index. It separates verified
 state from planning documents and lists the next actionable issues.
 
@@ -47,6 +49,18 @@ Required update fields:
 - Add command evidence in `Verification Log` when commands are run.
 - Add a short entry in `Session Log`.
 - Keep `Recommended Execution Order` aligned with open issue priority.
+
+Release bookkeeping (automated — do not hand-edit):
+
+- The `Current shipping version` marker near the top is maintained by the
+  `version-bump` bot (`scripts/bump_version.py` -> `versioning.sync_status_marker`),
+  which updates it together with the three version files. `test_current_status_docs.py`
+  enforces `marker == src/version.py`; do not edit the marker by hand.
+- After publishing a release, add its `Verification Log` publication row with
+  `python scripts/record_release.py` instead of hand-writing literals.
+  `test_current_status_docs.py` validates publication rows by *format* (PR ref,
+  run IDs, 40-hex merge commit, asset/digest evidence), so no per-release
+  hardcoded test is needed.
 
 Do not mark an issue `closed` without fresh verification evidence in the same
 session. If only focused tests passed, use `fixed_pending_full_verify`.

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -105,6 +105,14 @@ def main() -> int:
         default='installer/TunnelForge.iss',
         help='Inno Setup 스크립트 경로 (기본값: installer/TunnelForge.iss)'
     )
+    parser.add_argument(
+        '--status-doc',
+        default='docs/current_status.md',
+        help=(
+            "current_status.md 경로 ('Current shipping version' 마커 동기화 대상; "
+            '기본값: docs/current_status.md). 마커/파일이 없으면 경고 후 건너뛴다.'
+        )
+    )
 
     args = parser.parse_args()
 
@@ -115,6 +123,7 @@ def main() -> int:
     version_file = project_root / args.version_file
     pyproject_file = project_root / args.pyproject_file
     installer_file = project_root / args.installer_file
+    status_doc = project_root / args.status_doc
 
     # versioning 모듈 임포트 (scripts/ 디렉토리를 sys.path에 추가)
     sys.path.insert(0, str(script_dir))
@@ -124,6 +133,7 @@ def main() -> int:
             write_version,
             sync_pyproject,
             sync_installer,
+            sync_status_marker,
             bump_version,
         )
     except ImportError as e:
@@ -169,6 +179,18 @@ def main() -> int:
         rc = _apply_sync(sync_installer, installer_file, new_version, 'installer .iss', required=False)
         if rc is not None:
             return rc
+
+        # current_status.md 'Current shipping version' 마커 동기화.
+        # fail-soft: 파일/마커가 없어도 릴리스를 막지 않는다. 마커의 존재/일치는
+        # test_current_status_docs.py 의 coupling 테스트가 별도로 강제한다.
+        if status_doc.exists():
+            try:
+                sync_status_marker(status_doc, new_version)
+                print(f"[OK] {status_doc} 마커 업데이트 완료", file=sys.stderr)
+            except ValueError as e:
+                print(f"[WARN] {status_doc} 마커 동기화 건너뜀: {e}", file=sys.stderr)
+        else:
+            print(f"[SKIP] {status_doc} 없음, 마커 동기화 건너뜁니다.", file=sys.stderr)
 
     # $GITHUB_OUTPUT 호환 형식으로 stdout 출력
     print(f"new_version={new_version}")

--- a/scripts/record_release.py
+++ b/scripts/record_release.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+TunnelForge - record_release CLI
+
+릴리스 발행 후 docs/current_status.md 의 Verification Log 에 well-formed 한
+발행(publication) 행을 한 번에 append 하는 헬퍼.
+
+배경:
+    예전에는 릴리스마다 run ID/다이제스트 리터럴을 손으로 옮겨 적고, 그 값을
+    하드코딩한 새 pytest 함수를 매번 작성해야 했다(순환 + 토일). 이제
+    test_current_status_docs.py 는 발행 행을 리터럴이 아니라 *형식*으로 검증하며
+    (test_current_status_release_publication_rows_are_well_formed), 이 스크립트가
+    그 형식에 맞는 행을 생성해 넣는다. 릴리스 후 명령 한 번이면 원장이 최신으로
+    유지된다.
+
+Usage:
+    python scripts/record_release.py \
+        --version 2.4.3 --pr 258 \
+        --pr-run 31000000001 --pr-run 31000000002 \
+        --tag-run 31000100001 --release-run 31000200001 \
+        --merge-commit 1d9305c826f11ebe6c808ec501953ed1339152d9 \
+        --date 2026-08-01 --tf-status TF-STATUS-098
+
+    # 미리보기 (파일 수정 없음)
+    python scripts/record_release.py ... --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+RUN_RE = re.compile(r"^\d{8,}$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+TF_STATUS_RE = re.compile(r"^TF-STATUS-\d+$")
+
+VERIFICATION_LOG_HEADING = "## Verification Log"
+SEPARATOR_RE = re.compile(r"^\|\s*-{2,}\s*(\|\s*-{2,}\s*)+\|\s*$")
+
+
+def _join_runs(pr_runs: list[str]) -> str:
+    """PR run ID 목록을 백틱으로 감싸 자연어로 잇는다."""
+    quoted = [f"`{r}`" for r in pr_runs]
+    if len(quoted) == 1:
+        return quoted[0]
+    if len(quoted) == 2:
+        return f"{quoted[0]} and {quoted[1]}"
+    return f"{', '.join(quoted[:-1])}, and {quoted[-1]}"
+
+
+def build_row(
+    *,
+    version: str,
+    pr: int,
+    pr_runs: list[str],
+    tag_run: str,
+    release_run: str,
+    merge_commit: str,
+    date: str,
+    tf_status: str | None = None,
+) -> str:
+    """test_current_status_release_publication_rows_are_well_formed 를 통과하는
+    Verification Log 행 문자열을 생성한다(끝에 개행 없음)."""
+    status_suffix = f" / {tf_status}" if tf_status else ""
+    status_closed = f" {tf_status} is closed." if tf_status else ""
+    scope = f"`v{version}` protected publication closure{status_suffix}"
+    command = (
+        f"PR #{pr} protected checks and merge; "
+        f"approved `create-release-tag.yml` run `{tag_run}`; "
+        f"approved `release.yml` run `{release_run}`; "
+        "annotated-tag object/peeled-commit inspection; "
+        "draft asset/digest and checksum-sidecar inspection; "
+        "stable/latest publication and live `UpdateChecker`"
+    )
+    result = (
+        f"PR runs {_join_runs(pr_runs)} passed the required Python, Rust Core, "
+        "version, support-tracking, and internal/external macOS arm64/x86_64 "
+        f"gates; merge commit `{merge_commit}`; tag peels to that exact commit; "
+        "release run built and verified Windows plus unsigned macOS "
+        "arm64/x86_64 artifacts; all 10 release assets have GitHub SHA-256 "
+        "digests and all four macOS sidecars match"
+    )
+    notes = (
+        f"`v{version}` is stable/latest at "
+        f"`https://github.com/sanghyun-io/tunnelforge/releases/tag/v{version}`."
+        f"{status_closed}"
+    )
+    return f"| {date} | {scope} | {command} | {result} | {notes} |"
+
+
+def insert_row(doc_text: str, row: str, version: str) -> str:
+    """Verification Log 표 구분선 바로 다음(최신 우선)에 row 를 삽입한 새 문서
+    텍스트를 반환한다.
+
+    Raises:
+        ValueError: Verification Log/구분선을 찾지 못했거나, 해당 버전의 발행
+            행이 이미 존재할 때.
+    """
+    lines = doc_text.splitlines(keepends=True)
+
+    # Verification Log 섹션 범위
+    start = next(
+        (i for i, ln in enumerate(lines) if ln.rstrip("\n") == VERIFICATION_LOG_HEADING),
+        None,
+    )
+    if start is None:
+        raise ValueError(f"'{VERIFICATION_LOG_HEADING}' 섹션을 찾을 수 없습니다")
+    end = next(
+        (i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")),
+        len(lines),
+    )
+
+    section = lines[start:end]
+    # 이미 같은 버전의 발행 행이 있으면 거부(멱등/오기입 방지)
+    version_backtick = f"`v{version}`"
+    for ln in section:
+        if ln.startswith("| ") and "publication" in ln and version_backtick in ln:
+            raise ValueError(
+                f"이미 `v{version}` 발행 행이 Verification Log 에 존재합니다"
+            )
+
+    sep_idx = next(
+        (
+            start + off
+            for off, ln in enumerate(section)
+            if SEPARATOR_RE.match(ln.rstrip("\n"))
+        ),
+        None,
+    )
+    if sep_idx is None:
+        raise ValueError("Verification Log 표의 구분선(| --- | ... |)을 찾을 수 없습니다")
+
+    new_line = row if row.endswith("\n") else row + "\n"
+    lines.insert(sep_idx + 1, new_line)
+    return "".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="릴리스 발행 행을 current_status.md Verification Log 에 추가",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--version", required=True, help="릴리스 버전 (X.Y.Z)")
+    parser.add_argument("--pr", required=True, type=int, help="릴리스 PR 번호")
+    parser.add_argument(
+        "--pr-run", dest="pr_runs", action="append", required=True,
+        help="PR 워크플로 run ID (반복 지정, 최소 1개)",
+    )
+    parser.add_argument("--tag-run", required=True, help="create-release-tag.yml run ID")
+    parser.add_argument("--release-run", required=True, help="release.yml run ID")
+    parser.add_argument(
+        "--merge-commit", required=True, help="40자 머지 커밋 SHA (소문자 hex)"
+    )
+    parser.add_argument("--date", required=True, help="발행 날짜 (YYYY-MM-DD)")
+    parser.add_argument(
+        "--tf-status", default=None, help="닫을 이슈 ID (예: TF-STATUS-098, 선택)"
+    )
+    parser.add_argument(
+        "--doc", default="docs/current_status.md", help="대상 문서 경로"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="파일 수정 없이 생성될 행만 출력"
+    )
+
+    args = parser.parse_args()
+
+    errors = []
+    if not VERSION_RE.match(args.version):
+        errors.append(f"--version 은 X.Y.Z 형식이어야 합니다: {args.version!r}")
+    if not COMMIT_RE.match(args.merge_commit):
+        errors.append(
+            f"--merge-commit 은 40자 소문자 hex 여야 합니다: {args.merge_commit!r}"
+        )
+    if not DATE_RE.match(args.date):
+        errors.append(f"--date 는 YYYY-MM-DD 형식이어야 합니다: {args.date!r}")
+    for label, value in [
+        ("--tag-run", args.tag_run),
+        ("--release-run", args.release_run),
+    ]:
+        if not RUN_RE.match(value):
+            errors.append(f"{label} 은 8자리 이상 숫자여야 합니다: {value!r}")
+    for value in args.pr_runs:
+        if not RUN_RE.match(value):
+            errors.append(f"--pr-run 은 8자리 이상 숫자여야 합니다: {value!r}")
+    if args.tf_status is not None and not TF_STATUS_RE.match(args.tf_status):
+        errors.append(
+            f"--tf-status 는 TF-STATUS-### 형식이어야 합니다: {args.tf_status!r}"
+        )
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    row = build_row(
+        version=args.version,
+        pr=args.pr,
+        pr_runs=args.pr_runs,
+        tag_run=args.tag_run,
+        release_run=args.release_run,
+        merge_commit=args.merge_commit,
+        date=args.date,
+        tf_status=args.tf_status,
+    )
+
+    if args.dry_run:
+        print(row)
+        return 0
+
+    script_dir = Path(__file__).resolve().parent
+    project_root = script_dir.parent
+    doc_path = project_root / args.doc if not Path(args.doc).is_absolute() else Path(args.doc)
+    if not doc_path.exists():
+        print(f"ERROR: 문서를 찾을 수 없습니다: {doc_path}", file=sys.stderr)
+        return 1
+
+    try:
+        new_text = insert_row(doc_path.read_text(encoding="utf-8"), row, args.version)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    doc_path.write_text(new_text, encoding="utf-8")
+    print(f"[OK] `v{args.version}` 발행 행을 {doc_path} 에 추가했습니다", file=sys.stderr)
+    print(row)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/versioning.py
+++ b/scripts/versioning.py
@@ -119,6 +119,58 @@ def sync_installer(installer_file: Path, new_version: str) -> None:
     installer_file.write_text(new_content, encoding='utf-8')
 
 
+_STATUS_MARKER_RE = re.compile(r'(Current shipping version:\s*`v)(\d+\.\d+\.\d+)(`)')
+
+
+def read_status_marker(status_doc: Path) -> str:
+    """current_status.md의 'Current shipping version' 마커에서 버전을 읽는다.
+
+    Args:
+        status_doc: docs/current_status.md 경로
+
+    Returns:
+        버전 문자열 (예: "2.4.2")
+
+    Raises:
+        FileNotFoundError: 파일이 존재하지 않을 때
+        ValueError: 마커를 찾을 수 없을 때
+    """
+    content = status_doc.read_text(encoding='utf-8')
+    match = _STATUS_MARKER_RE.search(content)
+    if not match:
+        raise ValueError(
+            f"'Current shipping version' 마커를 찾을 수 없습니다: {status_doc}"
+        )
+    return match.group(2)
+
+
+def sync_status_marker(status_doc: Path, new_version: str) -> None:
+    """current_status.md의 'Current shipping version' 마커를 new_version으로 교체한다.
+
+    이 마커는 봇(version-gate.yml의 version-bump 잡)이 3개 버전 파일과 함께
+    갱신하며, test_current_status_docs.py가 마커 == src/version.py 를 강제한다.
+    사람이 손으로 맞출 필요는 없다.
+
+    Args:
+        status_doc: docs/current_status.md 경로
+        new_version: 새 버전 문자열 (예: "2.4.3")
+
+    Raises:
+        FileNotFoundError: 파일이 존재하지 않을 때
+        ValueError: 마커 라인을 찾을 수 없을 때
+    """
+    content = status_doc.read_text(encoding='utf-8')
+    new_content, count = _STATUS_MARKER_RE.subn(
+        rf'\g<1>{new_version}\g<3>',
+        content,
+    )
+    if count == 0:
+        raise ValueError(
+            f"'Current shipping version' 마커를 찾을 수 없습니다: {status_doc}"
+        )
+    status_doc.write_text(new_content, encoding='utf-8')
+
+
 def bump_version(version: str, bump_type: str) -> str:
     """시맨틱 버전을 bump_type에 따라 증가시킨다.
 

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -23,9 +23,11 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 from versioning import (
     bump_version,
     compare_versions,
+    read_status_marker,
     read_version,
     sync_installer,
     sync_pyproject,
+    sync_status_marker,
     write_version,
 )
 
@@ -258,6 +260,59 @@ class TestSyncInstaller:
 
 
 # ─────────────────────────────────────────────
+# sync_status_marker / read_status_marker 테스트
+# ─────────────────────────────────────────────
+
+class TestStatusMarker:
+    @pytest.fixture
+    def status_doc(self, tmp_path):
+        f = tmp_path / "current_status.md"
+        f.write_text(
+            "# TunnelForge Current Status\n\n"
+            "Last reviewed: 2026-07-29\n\n"
+            "Current shipping version: `v2.4.2` <!-- managed by bot -->\n\n"
+            "## Summary\n\nbody\n",
+            encoding='utf-8',
+        )
+        return f
+
+    def test_read_marker(self, status_doc):
+        assert read_status_marker(status_doc) == "2.4.2"
+
+    def test_sync_updates_marker(self, status_doc):
+        sync_status_marker(status_doc, "2.4.3")
+        assert "Current shipping version: `v2.4.3`" in status_doc.read_text(encoding='utf-8')
+
+    def test_sync_preserves_annotation_and_body(self, status_doc):
+        sync_status_marker(status_doc, "2.5.0")
+        content = status_doc.read_text(encoding='utf-8')
+        assert "<!-- managed by bot -->" in content
+        assert "Last reviewed: 2026-07-29" in content
+        assert "## Summary" in content
+
+    def test_read_after_sync(self, status_doc):
+        sync_status_marker(status_doc, "3.0.0")
+        assert read_status_marker(status_doc) == "3.0.0"
+
+    def test_sync_does_not_duplicate(self, status_doc):
+        sync_status_marker(status_doc, "2.4.3")
+        content = status_doc.read_text(encoding='utf-8')
+        assert content.count("Current shipping version:") == 1
+
+    def test_missing_marker_raises(self, tmp_path):
+        f = tmp_path / "no_marker.md"
+        f.write_text("# Status\n\nno marker\n", encoding='utf-8')
+        with pytest.raises(ValueError, match="Current shipping version"):
+            sync_status_marker(f, "1.0.0")
+        with pytest.raises(ValueError, match="Current shipping version"):
+            read_status_marker(f)
+
+    def test_file_not_found_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            sync_status_marker(tmp_path / "nonexistent.md", "1.0.0")
+
+
+# ─────────────────────────────────────────────
 # compare_versions 테스트
 # ─────────────────────────────────────────────
 
@@ -336,10 +391,13 @@ class TestBumpVersionCLI:
         code, _, _ = self.run_cli("--bump-type", "invalid")
         assert code != 0
 
-    def test_real_bump_syncs_all_three_files(self, tmp_path):
-        """실제 bump 시 version.py / pyproject.toml / .iss 세 파일이 모두 동기화되어야 한다.
+    def test_real_bump_syncs_all_four_files(self, tmp_path):
+        """실제 bump 시 version.py / pyproject.toml / .iss / current_status.md 마커가
+        모두 동기화되어야 한다.
 
-        워크트리 실제 파일을 건드리지 않도록 임시 경로를 인자로 전달한다.
+        워크트리 실제 파일(특히 docs/current_status.md)을 건드리지 않도록 모든
+        대상 경로를 임시 파일로 전달한다. --status-doc 을 명시하지 않으면
+        기본값(docs/current_status.md)이 잡히므로 반드시 임시 경로를 넘긴다.
         """
         vf = tmp_path / "version.py"
         vf.write_text('__version__ = "2.1.0"\n', encoding='utf-8')
@@ -347,18 +405,48 @@ class TestBumpVersionCLI:
         pf.write_text('[project]\nname = "x"\nversion = "2.1.0"\n', encoding='utf-8')
         isf = tmp_path / "TunnelForge.iss"
         isf.write_text('#define MyAppVersion "2.1.0"\n', encoding='utf-8')
+        doc = tmp_path / "current_status.md"
+        doc.write_text(
+            "# Status\n\nCurrent shipping version: `v2.1.0`\n\n## Summary\n",
+            encoding='utf-8',
+        )
 
         code, stdout, stderr = self.run_cli(
             "--bump-type", "patch",
             "--version-file", str(vf),
             "--pyproject-file", str(pf),
             "--installer-file", str(isf),
+            "--status-doc", str(doc),
         )
         assert code == 0, stderr
         assert "new_version=2.1.1" in stdout
         assert '__version__ = "2.1.1"' in vf.read_text(encoding='utf-8')
         assert 'version = "2.1.1"' in pf.read_text(encoding='utf-8')
         assert '#define MyAppVersion "2.1.1"' in isf.read_text(encoding='utf-8')
+        assert "Current shipping version: `v2.1.1`" in doc.read_text(encoding='utf-8')
+
+    def test_real_bump_missing_status_marker_is_fail_soft(self, tmp_path):
+        """current_status.md 에 마커가 없어도 bump 는 실패하지 않는다(fail-soft).
+
+        마커 부재/불일치의 강제는 test_current_status_docs.py 의 coupling 테스트가
+        담당하고, bump 자체는 릴리스를 막지 않아야 한다.
+        """
+        vf = tmp_path / "version.py"
+        vf.write_text('__version__ = "3.0.0"\n', encoding='utf-8')
+        doc = tmp_path / "current_status.md"
+        doc.write_text("# Status\n\nno marker here\n", encoding='utf-8')
+
+        code, stdout, stderr = self.run_cli(
+            "--bump-type", "minor",
+            "--version-file", str(vf),
+            "--pyproject-file", str(tmp_path / "absent.toml"),
+            "--installer-file", str(tmp_path / "absent.iss"),
+            "--status-doc", str(doc),
+        )
+        assert code == 0, stderr
+        assert "new_version=3.1.0" in stdout
+        assert "건너뜀" in stderr  # WARN skip message
+        assert doc.read_text(encoding='utf-8') == "# Status\n\nno marker here\n"
 
     def test_help_exit_zero(self):
         code, _, _ = self.run_cli("--help")

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -189,6 +189,22 @@ def test_version_bump_requires_real_version_files_and_pins_token_action():
     ) in bump_text
 
 
+def test_version_bump_syncs_current_status_marker():
+    """version-bump 봇은 세 버전 파일과 함께 docs/current_status.md 의 'Current
+    shipping version' 마커도 트러스티드 트리 커밋에 포함해야 한다.
+
+    이렇게 해야 가벼운 커플링(문서가 배포 버전을 추적)이 개발자 손질/트랩 없이
+    유지된다. bump_version.py 는 --status-doc 로 마커 복사본을 갱신하고, 커밋
+    루프는 docs/current_status.md 를 PR head 트리 위에 덮어써 함께 푸시한다.
+    """
+    bump_text = version_gate_job_text("version-bump")
+
+    assert "cp docs/current_status.md .version-bump-input/docs/current_status.md" in bump_text
+    assert "--status-doc .version-bump-input/docs/current_status.md" in bump_text
+    # 커밋 루프가 마커 파일을 트러스티드 트리에 포함해야 한다
+    assert "installer/TunnelForge.iss docs/current_status.md" in bump_text
+
+
 def test_release_tag_creation_is_manual_approved_and_sha_bound():
     workflow_text = CREATE_RELEASE_TAG_PATH.read_text(encoding="utf-8")
     workflow = load_workflow(CREATE_RELEASE_TAG_PATH)

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -199,10 +199,19 @@ def test_version_bump_syncs_current_status_marker():
     """
     bump_text = version_gate_job_text("version-bump")
 
-    assert "cp docs/current_status.md .version-bump-input/docs/current_status.md" in bump_text
+    # current_status.md 는 PR 이 손으로 편집하므로 base 복사가 아니라 HEAD 에서
+    # 가져와 마커만 바꿔야 PR 문서 편집이 보존된다. base cp 로 회귀하면 안 된다.
+    assert (
+        'git show "$HEAD_SHA:docs/current_status.md" > '
+        ".version-bump-input/docs/current_status.md"
+    ) in bump_text
+    assert "cp docs/current_status.md" not in bump_text
     assert "--status-doc .version-bump-input/docs/current_status.md" in bump_text
     # 커밋 루프가 마커 파일을 트러스티드 트리에 포함해야 한다
     assert "installer/TunnelForge.iss docs/current_status.md" in bump_text
+    # skip-detection 이 마커도 검사해야 부분 수동 bump 시 자가치유된다
+    assert "CURRENT_MARKER=$(git show" in bump_text
+    assert '[ "$CURRENT_MARKER" = "$EXPECTED" ]' in bump_text
 
 
 def test_release_tag_creation_is_manual_approved_and_sha_bound():

--- a/tests/test_current_status_docs.py
+++ b/tests/test_current_status_docs.py
@@ -793,8 +793,6 @@ def test_current_status_tracks_post_v217_version_drift_issue():
     normalized_doc = " ".join(doc.split())
     summary = " ".join(_section(doc, "Summary").split())
     baseline = _section(doc, "Current Baseline Verification")
-    version_source = (PROJECT_ROOT / "src" / "version.py").read_text(encoding="utf-8")
-    current_version = re.search(r'__version__\s*=\s*"([^"]+)"', version_source).group(1)
 
     assert "TF-STATUS-049" in doc
     assert "GitHub #149" in doc
@@ -802,7 +800,15 @@ def test_current_status_tracks_post_v217_version_drift_issue():
     assert "v2.1.7" in doc
     assert "2.1.8" in doc
     assert "GitHub #149 is fixed" in summary
-    assert f"Version references are aligned at `{current_version}`" in baseline
+    # 예전에는 `f"...aligned at `{current_version}`"` 로 src/version.py 를 파싱해
+    # 보간했는데, version-bump 봇은 baseline 프로세를 안 건드리므로 bump 순간
+    # 어긋나 pytest -q 를 깨뜨리는 두 번째 순환 트랩이었다(line 962 와 동일 부류).
+    # 특정 버전이 아니라 "정합 문장이 구체 버전과 함께 존재"함을 형식으로만
+    # 검증한다(버전업/문서 갱신 양쪽에 안전). 현재 버전 커플링은
+    # test_current_status_marker_tracks_source_version 이 트랩 없이 담당한다.
+    assert re.search(
+        r"Version references are aligned at `\d+\.\d+\.\d+`", baseline
+    ), "baseline must record version alignment at a concrete version"
 
 
 def test_current_status_tracks_rust_db_cursor_executemany_issue():
@@ -1392,3 +1398,57 @@ def test_current_status_release_publication_rows_are_well_formed():
         assert "asset" in row and "digest" in row, (
             f"{context}: missing asset/digest evidence"
         )
+
+
+def test_no_membership_assert_couples_to_parsed_source_version():
+    """회귀 방지: 이 파일의 어떤 테스트도 src/version.py 에서 파싱한 버전을
+    f-string 으로 보간해 문서 내용에 대한 membership(`... in doc/baseline/summary/
+    ...`)으로 단정해서는 안 된다.
+
+    그 패턴은 version-bump 봇이 버전을 bump 하는 순간(봇은 3개 버전 파일 +
+    마커만 갱신하고 문서 프로세는 안 건드림) 문서와 어긋나 pytest -q 를 깨뜨리는
+    순환 트랩이다(과거 line 805/962 사고 2건). 현재 배포 버전과의 커플링은
+    test_current_status_marker_tracks_source_version(마커==version.py) 만 트랩 없이
+    담당한다. AST 로 해당 형태의 assert 를 정적 검출한다.
+    """
+    import ast
+
+    src = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    # src/version.py 의 __version__ 을 파싱해 담는 변수명 수집
+    version_vars = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+            call_src = ast.get_source_segment(src, node.value) or ""
+            if "__version__" in call_src:
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Name):
+                        version_vars.add(tgt.id)
+
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assert):
+            continue
+        test = node.test
+        if not (
+            isinstance(test, ast.Compare)
+            and any(isinstance(op, ast.In) for op in test.ops)
+            and isinstance(test.left, ast.JoinedStr)
+        ):
+            continue
+        for value in test.left.values:
+            if (
+                isinstance(value, ast.FormattedValue)
+                and isinstance(value.value, ast.Name)
+                and value.value.id in version_vars
+            ):
+                offenders.append(node.lineno)
+
+    assert not offenders, (
+        "membership assert interpolating a parsed src/version.py version found at "
+        f"lines {sorted(set(offenders))}; this recreates the version-bump CI trap. "
+        "Use test_current_status_marker_tracks_source_version or a format-only "
+        "regex check instead of interpolating the live-parsed version into an "
+        "`... in <doc section>` assertion."
+    )

--- a/tests/test_current_status_docs.py
+++ b/tests/test_current_status_docs.py
@@ -959,7 +959,12 @@ def test_current_status_records_published_240_release():
     order = " ".join(_section(doc, "Recommended Execution Order").split())
     sessions = " ".join(_section(doc, "Session Log").split())
 
-    assert source_version == "2.4.2"
+    # 이 역사 기록 테스트는 특정 버전 리터럴에 고정하지 않는다. 예전에는
+    # `source_version == "2.4.2"` 로 하드핀되어 있어, version-gate 봇이 버전을
+    # 자동 bump 하는 순간 pytest -q 가 깨지는 순환 차단점이었다. 현재 배포
+    # 버전과의 커플링은 test_current_status_marker_tracks_source_version 이
+    # 트랩 없이(봇 자동 마커) 담당한다.
+    assert re.fullmatch(r"\d+\.\d+\.\d+", source_version), source_version
     assert "The latest stable release is now `v2.4.0`" in summary
     assert "anonymous error reporting" in summary
     assert "Version references are aligned at `2.4.2`" in baseline
@@ -1319,3 +1324,71 @@ def test_current_status_tracks_242_mysql_export_fallback_release_closure():
     assert "UpdateChecker" in verification
     assert "Keep TF-STATUS-097 closed" in order
     assert "Published `v2.4.2` as stable/latest" in sessions
+
+
+def test_current_status_marker_tracks_source_version():
+    """current_status.md 상단의 'Current shipping version' 마커는 src/version.py
+    와 일치해야 한다.
+
+    이 마커는 version-gate.yml 의 version-bump 봇이 세 버전 파일과 함께 자동
+    갱신한다(scripts/bump_version.py -> versioning.sync_status_marker). 따라서
+    가벼운 커플링(문서가 현재 배포 버전을 추적)을 사람 손질 없이 유지하며,
+    봇이 마커를 빠뜨려 둘이 어긋나면 이 테스트가 잡아낸다. 예전의
+    `source_version == "2.4.2"` 하드핀과 달리 특정 버전에 고정하지 않으므로
+    버전업이 CI 를 깨뜨리지 않는다.
+    """
+    doc = (PROJECT_ROOT / "docs" / "current_status.md").read_text(encoding="utf-8")
+    version_source = (PROJECT_ROOT / "src" / "version.py").read_text(encoding="utf-8")
+    source_match = re.search(r'__version__\s*=\s*"([^"]+)"', version_source)
+    assert source_match is not None, "src/version.py must define __version__"
+    source_version = source_match.group(1)
+
+    marker = re.search(r"Current shipping version:\s*`v(\d+\.\d+\.\d+)`", doc)
+    assert marker is not None, (
+        "current_status.md must carry a 'Current shipping version: `vX.Y.Z`' "
+        "marker (bot-maintained by scripts/bump_version.py)"
+    )
+    assert marker.group(1) == source_version, (
+        f"status marker `v{marker.group(1)}` must match src/version.py "
+        f"`{source_version}`; run scripts/bump_version.py to resync the marker"
+    )
+
+
+def test_current_status_release_publication_rows_are_well_formed():
+    """Verification Log 의 릴리스 발행(publication) 행은 릴리스별로 리터럴을
+    하드코딩한 새 테스트를 작성하지 않아도 실제 증거의 형태를 갖추도록 강제한다.
+
+    각 발행 행(Scope 열이 `vX.Y.Z` 를 담고 'publication' 을 언급)은 다음을
+    포함해야 한다: PR 참조, 최소 1개의 워크플로 run ID, 40자 머지 커밋,
+    자산/다이제스트 신호. 새 릴리스는 scripts/record_release.py 로 이 형식의
+    행을 append 하면 되고, 별도의 프리즈된 테스트를 매번 작성할 필요가 없다.
+    """
+    doc = (PROJECT_ROOT / "docs" / "current_status.md").read_text(encoding="utf-8")
+    log = _section(doc, "Verification Log")
+
+    publication_rows = []
+    for line in log.splitlines():
+        if not line.startswith("| "):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < 5:
+            continue
+        scope = cells[1]  # Date=0, Scope=1, Command=2, Result=3, Notes=4
+        if "publication" in scope and re.search(r"`v\d+\.\d+\.\d+`", scope):
+            publication_rows.append((scope, line))
+
+    assert publication_rows, (
+        "Verification Log must contain at least one release-publication row"
+    )
+
+    for scope, row in publication_rows:
+        version = re.search(r"`v(\d+\.\d+\.\d+)`", scope).group(1)
+        context = f"`v{version}` publication row"
+        assert re.search(r"PR #\d+", row), f"{context}: missing PR reference"
+        assert re.search(r"\b\d{8,}\b", row), f"{context}: missing workflow run id"
+        assert re.search(r"\b[0-9a-f]{40}\b", row), (
+            f"{context}: missing 40-hex merge commit"
+        )
+        assert "asset" in row and "digest" in row, (
+            f"{context}: missing asset/digest evidence"
+        )

--- a/tests/test_record_release.py
+++ b/tests/test_record_release.py
@@ -1,0 +1,201 @@
+"""
+scripts/record_release.py 단위/통합 테스트.
+
+핵심 계약: record_release 가 생성하는 발행 행은 test_current_status_docs.py 의
+test_current_status_release_publication_rows_are_well_formed 와 동일한 형식
+검증을 통과해야 한다(두 축이 상호운용). 또한 Verification Log 표의 구분선
+바로 다음(최신 우선)에 삽입되고, 같은 버전 중복은 거부해야 한다.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from record_release import build_row, insert_row  # noqa: E402
+
+CLI = str(SCRIPTS_DIR / "record_release.py")
+
+SAMPLE_DOC = (
+    "# TunnelForge Current Status\n"
+    "\n"
+    "Current shipping version: `v2.4.3`\n"
+    "\n"
+    "## Verification Log\n"
+    "\n"
+    "| Date | Scope | Command | Result | Notes |\n"
+    "| --- | --- | --- | --- | --- |\n"
+    "| 2026-07-29 | `v2.4.2` protected publication closure / TF-STATUS-097 | "
+    "PR #253 merge; run `30419408852` | merge commit "
+    "`1d9305c826f11ebe6c808ec501953ed1339152d9`; 10/10 assets have GitHub "
+    "digests | `v2.4.2` is stable/latest. |\n"
+    "\n"
+    "## Existing Status And Planning Documents\n"
+    "\n"
+    "tail\n"
+)
+
+
+def _kwargs(**over):
+    base = dict(
+        version="2.4.3",
+        pr=258,
+        pr_runs=["31000000001", "31000000002"],
+        tag_run="31000100001",
+        release_run="31000200001",
+        merge_commit="a" * 40,
+        date="2026-08-01",
+        tf_status="TF-STATUS-098",
+    )
+    base.update(over)
+    return base
+
+
+def _assert_well_formed(row: str):
+    """test_current_status_release_publication_rows_are_well_formed 와 동일한 검증."""
+    cells = [c.strip() for c in row.strip().strip("|").split("|")]
+    assert len(cells) >= 5
+    scope = cells[1]
+    assert "publication" in scope
+    assert re.search(r"`v\d+\.\d+\.\d+`", scope)
+    assert re.search(r"PR #\d+", row)
+    assert re.search(r"\b\d{8,}\b", row)
+    assert re.search(r"\b[0-9a-f]{40}\b", row)
+    assert "asset" in row and "digest" in row
+
+
+class TestBuildRow:
+    def test_row_is_well_formed(self):
+        _assert_well_formed(build_row(**_kwargs()))
+
+    def test_row_well_formed_without_tf_status(self):
+        _assert_well_formed(build_row(**_kwargs(tf_status=None)))
+
+    def test_single_pr_run(self):
+        row = build_row(**_kwargs(pr_runs=["31000000009"]))
+        _assert_well_formed(row)
+        assert "`31000000009`" in row
+        assert " and " not in row.split("passed the required")[0].split("PR runs")[1]
+
+    def test_two_pr_runs_joined_with_and(self):
+        row = build_row(**_kwargs(pr_runs=["31000000001", "31000000002"]))
+        assert "`31000000001` and `31000000002`" in row
+
+    def test_scope_carries_version_and_status(self):
+        row = build_row(**_kwargs())
+        assert "`v2.4.3` protected publication closure / TF-STATUS-098" in row
+        assert "TF-STATUS-098 is closed." in row
+
+    def test_no_status_suffix_when_absent(self):
+        row = build_row(**_kwargs(tf_status=None))
+        assert "TF-STATUS" not in row
+
+
+class TestInsertRow:
+    def test_inserts_after_separator_newest_first(self):
+        row = build_row(**_kwargs())
+        out = insert_row(SAMPLE_DOC, row, "2.4.3")
+        lines = out.splitlines()
+        sep_idx = next(i for i, ln in enumerate(lines) if re.match(r"^\|\s*-{2,}", ln))
+        # 삽입 행이 구분선 바로 다음(가장 최신)이어야 한다
+        assert "`v2.4.3`" in lines[sep_idx + 1]
+        # 기존 v2.4.2 행은 그 아래에 남는다
+        v242_idx = next(i for i, ln in enumerate(lines) if "`v2.4.2`" in ln and ln.startswith("| 2026"))
+        assert sep_idx + 1 < v242_idx
+
+    def test_inserted_row_passes_format_guard(self):
+        row = build_row(**_kwargs())
+        out = insert_row(SAMPLE_DOC, row, "2.4.3")
+        # Verification Log 섹션에서 발행 행을 추려 well-formed 검증
+        section = out.split("## Verification Log", 1)[1].split("\n## ", 1)[0]
+        pub_rows = [
+            ln for ln in section.splitlines()
+            if ln.startswith("| ") and "publication" in ln
+            and re.search(r"`v\d+\.\d+\.\d+`", ln.split("|")[2])
+        ]
+        assert len(pub_rows) == 2
+        for r in pub_rows:
+            _assert_well_formed(r)
+
+    def test_duplicate_version_refused(self):
+        row = build_row(**_kwargs(version="2.4.2"))
+        with pytest.raises(ValueError, match="이미"):
+            insert_row(SAMPLE_DOC, row, "2.4.2")
+
+    def test_missing_verification_log_raises(self):
+        with pytest.raises(ValueError, match="Verification Log"):
+            insert_row("# Doc\n\nno log here\n", build_row(**_kwargs()), "2.4.3")
+
+    def test_preserves_tail_sections(self):
+        out = insert_row(SAMPLE_DOC, build_row(**_kwargs()), "2.4.3")
+        assert "## Existing Status And Planning Documents" in out
+        assert out.rstrip().endswith("tail")
+
+
+class TestCLI:
+    def run(self, *args, cwd=None):
+        result = subprocess.run(
+            [sys.executable, CLI, *args],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            cwd=cwd,
+        )
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+    def _valid_args(self, doc: Path):
+        return [
+            "--version", "2.4.3", "--pr", "258",
+            "--pr-run", "31000000001", "--pr-run", "31000000002",
+            "--tag-run", "31000100001", "--release-run", "31000200001",
+            "--merge-commit", "a" * 40, "--date", "2026-08-01",
+            "--tf-status", "TF-STATUS-098", "--doc", str(doc),
+        ]
+
+    def test_dry_run_outputs_row_no_write(self, tmp_path):
+        doc = tmp_path / "current_status.md"
+        doc.write_text(SAMPLE_DOC, encoding="utf-8")
+        code, stdout, _ = self.run(*self._valid_args(doc), "--dry-run")
+        assert code == 0
+        assert "`v2.4.3`" in stdout
+        assert doc.read_text(encoding="utf-8") == SAMPLE_DOC
+
+    def test_real_insert(self, tmp_path):
+        doc = tmp_path / "current_status.md"
+        doc.write_text(SAMPLE_DOC, encoding="utf-8")
+        code, _, stderr = self.run(*self._valid_args(doc))
+        assert code == 0, stderr
+        content = doc.read_text(encoding="utf-8")
+        assert content.count("publication closure") == 2
+        _assert_well_formed(
+            next(ln for ln in content.splitlines() if "`v2.4.3`" in ln and ln.startswith("| "))
+        )
+
+    def test_duplicate_exit_nonzero(self, tmp_path):
+        doc = tmp_path / "current_status.md"
+        doc.write_text(SAMPLE_DOC, encoding="utf-8")
+        args = self._valid_args(doc)
+        # version 을 기존 2.4.2 로 바꿔 중복 유발
+        args[args.index("2.4.3")] = "2.4.2"
+        code, _, stderr = self.run(*args)
+        assert code == 1
+        assert "이미" in stderr
+
+    @pytest.mark.parametrize("flag,bad", [
+        ("--version", "2.4"),
+        ("--merge-commit", "xyz"),
+        ("--tag-run", "abc"),
+        ("--date", "2026/08/01"),
+        ("--tf-status", "TF-98"),
+    ])
+    def test_validation_errors_exit_nonzero(self, tmp_path, flag, bad):
+        doc = tmp_path / "current_status.md"
+        doc.write_text(SAMPLE_DOC, encoding="utf-8")
+        args = self._valid_args(doc)
+        args[args.index(flag) + 1] = bad
+        code, _, stderr = self.run(*args)
+        assert code == 1
+        assert "ERROR" in stderr


### PR DESCRIPTION
## 배경 / 문제

`version-gate.yml`의 `version-bump` 잡은 `version:patch|minor|major` 라벨이 붙은 PR에서 **버전을 자동 커밋**한다. 그런데 `tests/test_current_status_docs.py`가 `assert source_version == "2.4.2"`로 버전을 **하드핀**하고 있어, 봇이 버전을 올리는 순간 필수 게이트인 `pytest -q`(python-regression)가 깨졌다 — 즉 버전 라벨 PR이 **자기 CI를 스스로 망가뜨렸다**. 또한 릴리스 증거(run ID·다이제스트)는 빌드 후에만 존재하는데 릴리스마다 그 리터럴을 하드코딩한 새 테스트를 손으로 써야 하는 순환이 있었다.

## 변경 (가벼운 강제 + 봇 자동 마커)

- **순환 핀 제거**: `source_version == "2.4.2"` → 형식 검증. 버전업이 더 이상 CI를 안 깨뜨린다.
- **봇 자동 마커**: `docs/current_status.md`에 `Current shipping version` 마커를 두고, `version-bump` 봇이 3개 버전 파일과 함께 자동 동기화(`versioning.sync_status_marker` + `bump_version --status-doc` + 트러스티드 커밋). 새 커플링 테스트가 `마커 == src/version.py`를 리터럴 고정 없이 강제 → 개발자 손질/트랩 0으로 문서가 배포 버전을 추적.
- **발행 행 형식 검증**: Verification Log의 릴리스 발행 행을 리터럴이 아니라 형식(PR#·run ID·40자 커밋·자산/다이제스트)으로 검증 → 릴리스마다 새 프리즈 테스트를 쓸 필요 없음.
- **`scripts/record_release.py`**: 릴리스 후 well-formed 발행 행을 명령 한 번으로 추가.

## 적대적 검증 (다각도 리뷰)

4개 렌즈(CI 신뢰 커밋 / 테스트 하네스 무결성 / 헬퍼 정확성 / 쓰기경로 보안)로 리뷰 후 각 발견을 반증 검증. 확정 결함 3건 모두 수정:

- **HIGH**: version-bump이 base의 `current_status.md`를 복사해 HEAD에 덮어써 **PR 문서 편집을 clobber**하던 버그 → HEAD에서 `git show`로 소싱, 마커 라인만 변경.
- **HIGH**: 두 번째 살아있는 버전 커플링(`test_current_status_docs.py:805`, 파싱값을 baseline에 보간) → 형식 검증으로 교체. 재발 방지 AST 가드 추가.
- **LOW**: skip-detection이 마커를 무시하던 갭 → skip 조건에 마커 포함(fail-soft 자가치유).

## 검증

- 영향 테스트 170개 통과(docs/ci/bump/record-release) + smart_release 8개.
- 이 PR은 **버전 라벨 없이** 머지해야 한다(부트스트랩: 개선된 봇 로직이 main에 먼저 있어야 이후 PR이 자연스럽게 버전 적용됨).

🤖 Generated with [Claude Code](https://claude.com/claude-code)